### PR TITLE
Allow option to disable debug mode

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -20,7 +20,12 @@ $ mvn liberty:dev -DhotTests=true
 
 Start dev mode and listen on a specific port for attaching a debugger (default is 7777).
 ```
-$ mvn liberty:dev -Dliberty.debug.port=8787
+$ mvn liberty:dev -Ddebug.port=8787
+```
+
+Start dev mode without allowing to attach a debugger.
+```
+$ mvn liberty:dev -Ddebug=false
 ```
 
 ###### Additional Parameters
@@ -33,7 +38,8 @@ The following are the parameters supported by this goal in addition to the [comm
 | skipTests | If set to `true`, do not run any tests in dev mode. The default value is `false`. | No |
 | skipUTs | If set to `true`, skip unit tests. The default value is `false`. | No |
 | skipITs | If set to `true`, skip integration tests. The default value is `false`.  | No |
-| liberty.debug.port | The debug port that you can attach a debugger to. The default value is `7777`. | No |
+| debug | Whether to allow attaching a debugger to the running server. The default value is `true`. | No |
+| debug.port | The debug port that you can attach a debugger to. The default value is `7777`. | No |
 
 ###### System Properties for Integration Tests
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -99,7 +99,10 @@ public class DevMojo extends StartDebugMojoSupport {
     @Parameter(property = "skipITs", defaultValue = "false")
     private boolean skipITs;
 
-    @Parameter(property = "liberty.debug.port", defaultValue = "7777")
+    @Parameter(property = "debug", defaultValue = "true")
+    private boolean libertyDebug;
+
+    @Parameter(property = "debug.port", defaultValue = "7777")
     private int libertyDebugPort;
 
     private int runId = 0;
@@ -236,7 +239,7 @@ public class DevMojo extends StartDebugMojoSupport {
         }
 
         @Override
-        public ServerTask getDebugServerTask() throws IOException {
+        public ServerTask getServerTask() throws IOException {
             if (serverTask != null) {
                 return serverTask;
             } else {
@@ -244,7 +247,11 @@ public class DevMojo extends StartDebugMojoSupport {
                 serverTask = initializeJava();
                 copyConfigFiles();
                 serverTask.setClean(clean);
-                serverTask.setOperation("debug");
+                if (libertyDebug) {
+                    serverTask.setOperation("debug");
+                } else {
+                    serverTask.setOperation("run");
+                }
                 return serverTask;
             }
         }


### PR DESCRIPTION
- Support `debug` option to enable/disable debug mode.  Default is `true` e.g. debug mode is enabled.
- Rename `liberty.debug.port` to `debug.port`