### PR TITLE
linkXRef set to false and check for summaryFile value

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -555,7 +555,7 @@ public class DevMojo extends StartDebugMojoSupport {
             // clean up previous summary file
             File summaryFile = null;
             Xpp3Dom summaryFileElement = config.getChild("summaryFile");
-            if (summaryFileElement != null) {
+            if (summaryFileElement != null && summaryFileElement.getValue() != null) {
                 summaryFile = new File(summaryFileElement.getValue());
             } else {
                 summaryFile = new File(project.getBuild().getDirectory() + "/failsafe-reports/failsafe-summary.xml");
@@ -574,6 +574,7 @@ public class DevMojo extends StartDebugMojoSupport {
         } else if (phase.equals("failsafe-report-only")) {
             Plugin failsafePlugin = getPlugin("org.apache.maven.plugins", "maven-failsafe-plugin");
             Xpp3Dom failsafeConfig = getPluginConfig(failsafePlugin, "integration-test");
+            Xpp3Dom linkXRef  = new Xpp3Dom("linkXRef");
             if (failsafeConfig != null) {
                 Xpp3Dom reportsDirectoryElement = failsafeConfig.getChild("reportsDirectory");
                 if (reportsDirectoryElement != null) {
@@ -581,16 +582,17 @@ public class DevMojo extends StartDebugMojoSupport {
                     reportDirectories.addChild(reportsDirectoryElement);
                     config.addChild(reportDirectories);
                 }
-                Xpp3Dom linkXRef = failsafeConfig.getChild("linkXRef");
+                linkXRef = failsafeConfig.getChild("linkXRef");
                 if (linkXRef == null) {
                     linkXRef = new Xpp3Dom("linkXRef");
                 }
-                linkXRef.setValue("false");
-                config.addChild(linkXRef);
-            }
+            } 
+            linkXRef.setValue("false");
+            config.addChild(linkXRef);
         } else if (phase.equals("report-only")) {
             Plugin surefirePlugin = getPlugin("org.apache.maven.plugins", "maven-surefire-plugin");
             Xpp3Dom surefireConfig = getPluginConfig(surefirePlugin, "test");
+            Xpp3Dom linkXRef  = new Xpp3Dom("linkXRef");
             if (surefireConfig != null) {
                 Xpp3Dom reportsDirectoryElement = surefireConfig.getChild("reportsDirectory");
                 if (reportsDirectoryElement != null) {
@@ -598,13 +600,13 @@ public class DevMojo extends StartDebugMojoSupport {
                     reportDirectories.addChild(reportsDirectoryElement);
                     config.addChild(reportDirectories);
                 }
-                Xpp3Dom linkXRef = surefireConfig.getChild("linkXRef");
+                linkXRef = surefireConfig.getChild("linkXRef");
                 if (linkXRef == null) {
                     linkXRef = new Xpp3Dom("linkXRef");
                 }
-                linkXRef.setValue("false");
-                config.addChild(linkXRef);
             }
+            linkXRef.setValue("false");
+            config.addChild(linkXRef);
         }
         log.debug(artifactId + " configuration for " + phase + " phase: " + config);
 


### PR DESCRIPTION
Fix for #514 and #520.

Error from #520 comes from https://github.com/OpenLiberty/ci.maven/pull/527/files#diff-4a8d574591d885ee76016350c6199ed9R559. The summaryFile value could not be read/was null in the following object:
```html
summaryFileElement: <?xml version="1.0" encoding="UTF-8"?>
<summaryFile default-value="${project.build.directory}/failsafe-reports/failsafe-summary.xml" implementation="java.io.File"/>
```
