### PR TITLE
Remove building war during dev

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -406,7 +406,6 @@ public class DevMojo extends StartDebugMojoSupport {
         @Override
         public void runIntegrationTests() throws PluginExecutionException, PluginScenarioException {
             try {
-                runMojo("org.apache.maven.plugins", "maven-war-plugin", "war", null, null);
                 runTestMojo("org.apache.maven.plugins", "maven-failsafe-plugin", "integration-test");
                 runTestMojo("org.apache.maven.plugins", "maven-surefire-report-plugin", "failsafe-report-only");
                 runTestMojo("org.apache.maven.plugins", "maven-failsafe-plugin", "verify");


### PR DESCRIPTION
Dev mode uses looseApplication mode so it does not need to build a war file.  Integration tests in dev mode can connect to the existing Liberty server. The user should run `mvn package` if they actually need the war file.