### PR TITLE
Update package goal with new parameters for package type, dir, name.

### DIFF
--- a/docs/configure-arquillian.md
+++ b/docs/configure-arquillian.md
@@ -51,7 +51,8 @@ Specify the following `liberty-maven-plugin` configuration in `pom.xml`:
 		</assemblyArtifact>
 		<assemblyInstallDirectory>${project.build.directory}</assemblyInstallDirectory>
 		<serverXmlFile>src/main/liberty/config/server.xml</serverXmlFile>
-		<packageFile>${project.build.directory}/package.jar</packageFile>
+		<packageName>package</packageName>
+		<packageType>jar</packageType>
 		<bootstrapProperties>
 			<default.http.port>9080</default.http.port>
 			<default.https.port>9443</default.https.port>
@@ -60,7 +61,6 @@ Specify the following `liberty-maven-plugin` configuration in `pom.xml`:
 		<features>
 			<acceptLicense>true</acceptLicense>
 		</features>
-		<include>runnable</include>
 		<installAppPackages>all</installAppPackages>
 		<appsDirectory>apps</appsDirectory>
 		<stripVersion>true</stripVersion>

--- a/docs/package.md
+++ b/docs/package.md
@@ -31,7 +31,7 @@ Examples:
                 <goal>package</goal>
             </goals>
             <configuration>
-                <packageFile>${project.build.directory}/test.zip</packageFile>
+                <packageName>test</packageName>
             </configuration>
         </execution>
         ...
@@ -57,8 +57,8 @@ Examples:
                 <goal>package</goal>
             </goals>
             <configuration>
-                <packageFile>${project.build.directory}/test.jar</packageFile>
-                <include>runnable</include>
+                <packageName>test</packageName>
+                <packageType>jar</packageType>
             </configuration>
         </execution>
         ...

--- a/docs/package.md
+++ b/docs/package.md
@@ -10,8 +10,10 @@ The following are the parameters supported by this goal in addition to the [comm
 
 | Parameter | Description | Required |
 | --------  | ----------- | -------  |
-| packageFile | Location of the target file or directory. If the target location is a file, the contents of the server instance will be compressed into the specified file. If the target location is a directory, the contents of the server instance will be compressed into `${packageFile}/${project.build.finalName}.zip`&#124;`jar` file. If the target location is not specified, it defaults to `${project.build.directory}/${project.build.finalName}.zip`&#124;`jar`. A jar file is created when the packaging type is `runnable`. A zip file is created for other packaging types.| No |
-| include | Packaging type. Can be used with values `all`, `usr`, `minify`, `wlp`, `runnable`, `all,runnable`, and `minify,runnable`. The default value is `all`. The `runnable` value is supported in Open Liberty and WebSphere Liberty versions since 8.5.5.9 and works with `jar` type archives only.  | Yes, only when the `os` option is set |
+| packageType | Type of package, `zip` or `jar`. Defaults to `zip`. | No
+| packageName | Name of the package. Defaults to `${project.build.finalName}` | No
+| packageDirectory | Directory of the packaged file. Defaults to `${project.build.directory}` | No
+| include | Packaging type. Can be used with values `all`, `usr`, `minify`, `wlp`. The default value is `all`. | Yes, only when the `os` option is set |
 | os | A comma-delimited list of operating systems that you want the packaged server to support. To specify that an operating system is not to be supported, prefix it with a minus sign ("-"). The 'include' attribute __must__ be set to `minify`. | No |
 | skipLibertyPackage | If true, the `package-server` goal is bypassed entirely. The default value is false. | No |
 

--- a/liberty-maven-plugin/src/it/arquillian-tests/pom.xml
+++ b/liberty-maven-plugin/src/it/arquillian-tests/pom.xml
@@ -171,7 +171,8 @@
                     </assemblyArtifact>
                     <assemblyInstallDirectory>${project.build.directory}</assemblyInstallDirectory>
                     <serverXmlFile>src/main/resources/server.xml</serverXmlFile>
-                    <packageFile>${project.build.directory}/WebsocketServerPackage.jar</packageFile>
+                    <packageName>WebsocketServerPackage</packageName>
+                    <packageType>jar</packageType>
                     <bootstrapProperties>
                         <default.http.port>9080</default.http.port>
                         <default.https.port>9443</default.https.port>
@@ -180,7 +181,6 @@
                     <features>
                         <acceptLicense>true</acceptLicense>
                     </features>
-                    <include>runnable</include>
                     <installAppPackages>all</installAppPackages>
                     <appsDirectory>apps</appsDirectory>
                     <stripVersion>true</stripVersion>

--- a/liberty-maven-plugin/src/it/basic-it/pom.xml
+++ b/liberty-maven-plugin/src/it/basic-it/pom.xml
@@ -174,7 +174,6 @@
                             <goal>package</goal>
                         </goals>
                         <configuration>
-                            <packageFile>${project.build.directory}</packageFile>
                             <include>minify</include>
                             <os>Windows7,Windows8</os>
                         </configuration>

--- a/liberty-maven-plugin/src/it/config-packagefile-runnable-it/pom.xml
+++ b/liberty-maven-plugin/src/it/config-packagefile-runnable-it/pom.xml
@@ -42,7 +42,8 @@
                         <type>zip</type>
                     </assemblyArtifact>
                     <serverName>test</serverName>
-                    <include>minify,runnable</include>
+                    <include>minify</include>
+                    <packageType>jar</packageType>
                 </configuration>
                 <executions>
                     <execution>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
@@ -23,7 +23,6 @@
     <testServerHttpPort>9080</testServerHttpPort>
     <testServerHttpsPort>9443</testServerHttpsPort>
     <!-- end::ports[] -->
-    <package.file>${project.build.directory}/${app.name}.zip</package.file>
     <packaging.type>usr</packaging.type>
   </properties>
 
@@ -172,7 +171,7 @@
             <version>RUNTIME_VERSION</version>
             <type>zip</type>
           </assemblyArtifact>
-          <packageFile>${package.file}</packageFile>
+          <packageName>${app.name}</packageName>
           <include>${packaging.type}</include>
           <bootstrapProperties>
             <default.http.port>${testServerHttpPort}</default.http.port>

--- a/liberty-maven-plugin/src/it/loose-config-it/pom.xml
+++ b/liberty-maven-plugin/src/it/loose-config-it/pom.xml
@@ -15,8 +15,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <package.file>${project.build.directory}/${project.artifactId}.jar</package.file>
-        <packaging.type>minify,runnable</packaging.type>
+        <package.type>jar</package.type>
+        <include>minify</include>
     </properties>
 
     <dependencies>
@@ -73,8 +73,9 @@
                     <installAppPackages>project</installAppPackages>
                     <looseApplication>true</looseApplication>
                     <stripVersion>true</stripVersion>
-                    <packageFile>${package.file}</packageFile>
-                    <include>${packaging.type}</include>
+                    <packageName>${project.artifactId}</packageName>
+                    <packageType>${package.type}</packageType>
+                    <include>${include}</include>
                 </configuration>
                 <executions>
                     <execution>

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
@@ -122,11 +122,16 @@ public class PackageServerMojo extends StartDebugMojoSupport {
     private void validateInclude() throws MojoFailureException {
         // if jar, validate include options, and add runnable
         if (packageType.equals("jar")) {
-            if (include.contains("usr") || include.contains("wlp")) {
-                throw new MojoFailureException("Package type jar cannot be used with `usr` or `wlp`.");
-            }
-            if (!include.contains("runnable")) {
-                include.concat(",runnable");
+            if (include == null) {
+                include = "runnable";
+            } else {
+                if (include.contains("usr") || include.contains("wlp")) {
+                    throw new MojoFailureException("Package type jar cannot be used with `usr` or `wlp`.");
+                }
+                
+                if (!include.contains("runnable")) {
+                    include.concat(",runnable");
+                }
             }
         }
     }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
@@ -144,30 +144,30 @@ public class PackageServerMojo extends StartDebugMojoSupport {
      * @throws IOException
      */
     private void setPackageFilePath() throws MojoFailureException, IOException {
-        String projectFileType = getPackageFileType(packageType, include);
-        String projectBuildDir = getPackageDirectory(packageDirectory);
-        String projectBuildName = getPackageName(packageName);
+        String projectFileType = getPackageFileType();
+        String projectBuildDir = getPackageDirectory();
+        String projectBuildName = getPackageName();
         packageFile = new File(projectBuildDir, projectBuildName + projectFileType);
     }
     
     /**
      * Returns file extension for specified package type
      * 
-     * @param pkgType "jar" or "zip"
+     * @param packageType "jar" or "zip"
      * @param include parameter, for checking if "jar" is valid for the include type
      * @return package file extension, or default to "zip"
      * @throws MojoFailureException
      */
-    private String getPackageFileType(String pkgType, String include) throws MojoFailureException {
-    	if (pkgType != null && pkgType.equals("jar")) {
+    private String getPackageFileType() throws MojoFailureException {
+    	if (packageType != null && packageType.equals("jar")) {
             if (include == null || include.equals("all") || include.equals("minify")) {
                 return ".jar";
             } else {
                 throw new MojoFailureException("The jar packageType requires `all` or `minify` in the `include` parameter");
             }
     	} else {
-            if (pkgType != null && !pkgType.equals("zip")) {
-                log.info(pkgType + " not supported. Defaulting to 'zip'");
+            if (packageType != null && !packageType.equals("zip")) {
+                log.info(packageType + " not supported. Defaulting to 'zip'");
             }
             packageType = "zip";
             return ".zip";
@@ -177,12 +177,12 @@ public class PackageServerMojo extends StartDebugMojoSupport {
     /**
      * Returns package name
      * 
-     * @param pkgName
+     * @param packageName
      * @return specified package name, or default ${project.build.finalName} if unspecified
      */
-    private String getPackageName(String pkgName) {
-        if (pkgName != null && !pkgName.isEmpty()) {
-            return pkgName;
+    private String getPackageName() {
+        if (packageName != null && !packageName.isEmpty()) {
+            return packageName;
         }
         packageName = project.getBuild().getFinalName();
         return packageName;
@@ -191,18 +191,18 @@ public class PackageServerMojo extends StartDebugMojoSupport {
     /**
      * Returns canonical path to package directory
      * 
-     * @param pkgDirectory
+     * @param packageDirectory
      * @return canonical path to specified package directory, or default ${project.build.directory} (target) if unspecified
      * @throws IOException
      */
-    private String getPackageDirectory(String pkgDirectory) throws IOException {
-        if (pkgDirectory != null && !pkgDirectory.isEmpty()) {
+    private String getPackageDirectory() throws IOException {
+        if (packageDirectory != null && !packageDirectory.isEmpty()) {
             // done: check if path is relative or absolute, convert to canonical
-            File dir = new File(pkgDirectory);
+            File dir = new File(packageDirectory);
             if (dir.isAbsolute()) {
                 return dir.getCanonicalPath();
             } else { //relative path
-                return new File(project.getBuild().getDirectory(), pkgDirectory).getCanonicalPath();
+                return new File(project.getBuild().getDirectory(), packageDirectory).getCanonicalPath();
             }
         } else {
             packageDirectory = project.getBuild().getDirectory();


### PR DESCRIPTION
Resolves #512 

- Removes `packageFile` parameter from package goal, replaced by `packageType`, `packageName`, and `packageDirectory`.
- Removes `runnable` from `include` parameter. Use `jar` package type instead.
- Add check for `attach` to make sure `packageType` matches project packaging type
- Updated tests and docs which used `packageFile`