### PR TITLE
Pass installDirectory parameter

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -732,6 +732,9 @@ public class DevMojo extends StartDebugMojoSupport {
             if (testServerName != null) {
                 elements.add(element(name("serverName"), testServerName));
                 elements.add(element(name("configDirectory"), configDirectory.getCanonicalPath()));
+                if (installDirectory != null && installDirectory.exists()) {
+                    elements.add(element(name("installDirectory"), installDirectory.getCanonicalPath()));
+                }
                 if (goal.equals("install-feature") && (dependencies != null)) {
                     Element[] featureElems = new Element[dependencies.size()];
                     for (int i = 0; i < featureElems.length; i++) {


### PR DESCRIPTION
Pass installDirectory parameter when calling Liberty goals from dev mode.
Fixes https://github.com/OpenLiberty/ci.maven/issues/556