### PR TITLE
Stage deprecation for `runnable` include parameter

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
@@ -151,7 +151,8 @@ public class PackageServerMojo extends StartDebugMojoSupport {
     }
     
     /**
-     * Returns file extension for specified package type
+     * Returns file extension for specified package type.
+     * Deprecating `runnable` include parameter. Will use jar type instead of defaulting to zip if `runnable` is specified, for now.
      * 
      * @return package file extension, or default to "zip"
      * @throws MojoFailureException
@@ -167,6 +168,16 @@ public class PackageServerMojo extends StartDebugMojoSupport {
             if (packageType != null && !packageType.equals("zip")) {
                 log.info(packageType + " not supported. Defaulting to 'zip'");
             }
+
+            // Check for `runnable` in `include` for deprecation before completely removing it in favor of `jar` `packageType`
+            if (include.contains("runnable")) {
+                if (packageType != null && packageType.equals("zip")) {
+                    throw new MojoFailureException("The `include` parameter `runnable` cannot be used with the `zip` packageType");
+                }
+                packageType = "jar";
+                return ".jar";
+            }
+
             packageType = "zip";
             return ".zip";
         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
@@ -174,6 +174,7 @@ public class PackageServerMojo extends StartDebugMojoSupport {
                 if (packageType != null && packageType.equals("zip")) {
                     throw new MojoFailureException("The `include` parameter `runnable` cannot be used with the `zip` packageType");
                 }
+                log.warn("The `runnable` value for the include parameter is deprecated. Use packageType `jar` instead.");
                 packageType = "jar";
                 return ".jar";
             }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
@@ -170,7 +170,7 @@ public class PackageServerMojo extends StartDebugMojoSupport {
             }
 
             // Check for `runnable` in `include` for deprecation before completely removing it in favor of `jar` `packageType`
-            if (include.contains("runnable")) {
+            if (include != null && include.contains("runnable")) {
                 if (packageType != null && packageType.equals("zip")) {
                     throw new MojoFailureException("The `include` parameter `runnable` cannot be used with the `zip` packageType");
                 }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
@@ -153,8 +153,6 @@ public class PackageServerMojo extends StartDebugMojoSupport {
     /**
      * Returns file extension for specified package type
      * 
-     * @param packageType "jar" or "zip"
-     * @param include parameter, for checking if "jar" is valid for the include type
      * @return package file extension, or default to "zip"
      * @throws MojoFailureException
      */
@@ -177,7 +175,6 @@ public class PackageServerMojo extends StartDebugMojoSupport {
     /**
      * Returns package name
      * 
-     * @param packageName
      * @return specified package name, or default ${project.build.finalName} if unspecified
      */
     private String getPackageName() {
@@ -191,7 +188,6 @@ public class PackageServerMojo extends StartDebugMojoSupport {
     /**
      * Returns canonical path to package directory
      * 
-     * @param packageDirectory
      * @return canonical path to specified package directory, or default ${project.build.directory} (target) if unspecified
      * @throws IOException
      */


### PR DESCRIPTION
Fixes #559

Allows `runnable` to still produce a jar, instead of defaulting to zip.

In the future, will fully remove the ability to use the `runnable` value in the include parameter in favor of using `jar` packageType.