### PR TITLE
do not display error in dev when liberty:stop is called

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -557,7 +557,7 @@ public class DevMojo extends StartDebugMojoSupport {
         try {
             util.watchFiles(pom, outputDirectory, testOutputDirectory, executor, artifactPaths, serverXmlFile);
         } catch (PluginScenarioException e) { // this exception is caught when the server has been stopped by another process
-            log.info(e.toString()); 
+            log.info(e.getMessage()); 
             return; // enter shutdown hook 
         }
     }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -557,8 +557,8 @@ public class DevMojo extends StartDebugMojoSupport {
         try {
             util.watchFiles(pom, outputDirectory, testOutputDirectory, executor, artifactPaths, serverXmlFile);
         } catch (PluginScenarioException e) { // this exception is caught when the server has been stopped by another process
-            log.info(e); 
-            System.exit(0); // enter shutdown hook 
+            log.info(e.toString()); 
+            return; // enter shutdown hook 
         }
     }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -554,7 +554,12 @@ public class DevMojo extends StartDebugMojoSupport {
         // all files in the configDirectory,
         // which is where the server.xml is located if a specific serverXmlFile
         // configuration parameter is not specified.
-        util.watchFiles(pom, outputDirectory, testOutputDirectory, executor, artifactPaths, serverXmlFile);
+        try {
+            util.watchFiles(pom, outputDirectory, testOutputDirectory, executor, artifactPaths, serverXmlFile);
+        } catch (PluginScenarioException e) { // this exception is caught when the server has been stopped by another process
+            log.info(e); 
+            System.exit(0); // enter shutdown hook 
+        }
     }
 
     private void addArtifacts(org.eclipse.aether.graph.DependencyNode root, List<File> artifacts) {


### PR DESCRIPTION
fix for #572 

Only the case where liberty:stop is called throws a PluginScenarioException, so we can catch that in ci.maven and log the error without causing the maven build failure error.