### PR TITLE
Handle empty server.xml

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -381,12 +381,14 @@ public class DevMojo extends StartDebugMojoSupport {
             try {
                 ServerFeature servUtil = getServerFeatureUtil();
                 Set<String> features = servUtil.getServerFeatures(serverDir);
-                features.removeAll(existingFeatures);
-                if (!features.isEmpty()) {
-                    List<String> configFeatures = new ArrayList<String>(features);
-                    log.info("Configuration features have been added");
-                    runLibertyMavenPlugin("install-feature", serverName, configFeatures);
-                    this.existingFeatures.addAll(features);
+                if (features != null) {
+                    features.removeAll(existingFeatures);
+                    if (!features.isEmpty()) {
+                        List<String> configFeatures = new ArrayList<String>(features);
+                        log.info("Configuration features have been added");
+                        runLibertyMavenPlugin("install-feature", serverName, configFeatures);
+                        this.existingFeatures.addAll(features);
+                    }
                 }
             } catch (MojoExecutionException e) {
                 log.error("Failed to install features from configuration file", e);


### PR DESCRIPTION
Part of https://github.com/OpenLiberty/ci.maven/issues/589

If server.xml is not found or doesn't exist, it returns null.  Avoid null pointer exception in this case, and treat it as if it has no features.