### PR TITLE
handle invalid dependencies

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
@@ -76,6 +76,11 @@
         <type>esa</type>
         <scope>provided</scope>
     </dependency> -->
+    <!-- <dependency>
+        <groupId>io.openliberty.features</groupId>
+        <artifactId>abcd</artifactId>
+        <version>1.0</version>
+    </dependency> -->
     <!-- For tests -->
     <dependency>
       <groupId>junit</groupId>

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
@@ -161,6 +161,21 @@ public class DevTest extends BaseDevTest {
       assertFalse(checkLogMessage(2000,  "Integration tests finished."));
    }
    
+    @Test
+    public void invalidDependencyTest() throws Exception {
+        if (isWindows)
+            return;
+
+        // add invalid dependency to pom.xml
+        String invalidDepComment = "<!-- <dependency>\n" + "        <groupId>io.openliberty.features</groupId>\n"
+                + "        <artifactId>abcd</artifactId>\n" + "        <version>1.0</version>\n"
+                + "    </dependency> -->";
+        String invalidDep = "<dependency>\n" + "        <groupId>io.openliberty.features</groupId>\n"
+                + "        <artifactId>abcd</artifactId>\n" + "        <version>1.0</version>\n" + "    </dependency>";
+        replaceString(invalidDepComment, invalidDep, pom);
+        assertFalse(checkLogMessage(10000, "Unable to resolve artifact: io.openliberty.features:abcd:1.0"));
+    }
+   
    @Test
    public void resolveDependencyTest() throws Exception {
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -369,6 +369,7 @@ public class DevMojo extends StartDebugMojoSupport {
                             for (Dependency dependency : dependencies) {
                                 if (artifact.getArtifactId().equals(dependency.getArtifactId())) {
                                     this.existingDependencies.add(dependency);
+                                    break;
                                 }
                             }
                         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -324,7 +324,6 @@ public class DevMojo extends StartDebugMojoSupport {
                     List<Artifact> updatedArtifacts = getNewDependencies(dependencies, this.existingDependencies);
 
                     if (!updatedArtifacts.isEmpty()) {
-
                         for (Artifact artifact : updatedArtifacts) {
                             if (("esa").equals(artifact.getType())) {
                                 dependencyIds.add(artifact.getArtifactId());
@@ -362,11 +361,18 @@ public class DevMojo extends StartDebugMojoSupport {
 
                         if (!dependencyIds.isEmpty()) {
                             runLibertyMavenPlugin("install-feature", serverName, dependencyIds);
+                            // update dependencies
+                            for (String dependencyId : dependencyIds) {
+                                for (Dependency dependency : dependencies) {
+                                    if (dependencyId.equals(dependency.getArtifactId())) {
+                                        log.info("found match: " + dependencyId);
+                                        this.existingDependencies.add(dependency);
+                                    }
+                                }
+                            }
                             dependencyIds.clear();
                         }
 
-                        // update dependencies
-                        this.existingDependencies = dependencies;
                         this.existingPom = modifiedPom;
 
                         return true;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -361,16 +361,16 @@ public class DevMojo extends StartDebugMojoSupport {
 
                         if (!dependencyIds.isEmpty()) {
                             runLibertyMavenPlugin("install-feature", serverName, dependencyIds);
-                            // update dependencies
-                            for (String dependencyId : dependencyIds) {
-                                for (Dependency dependency : dependencies) {
-                                    if (dependencyId.equals(dependency.getArtifactId())) {
-                                        log.info("found match: " + dependencyId);
-                                        this.existingDependencies.add(dependency);
-                                    }
+                            dependencyIds.clear();
+                        }
+
+                        // update dependencies
+                        for (Artifact artifact : updatedArtifacts) {
+                            for (Dependency dependency : dependencies) {
+                                if (artifact.getArtifactId().equals(dependency.getArtifactId())) {
+                                    this.existingDependencies.add(dependency);
                                 }
                             }
-                            dependencyIds.clear();
                         }
 
                         this.existingPom = modifiedPom;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -375,7 +375,7 @@ public class DevMojo extends StartDebugMojoSupport {
                             this.existingPom = modifiedPom;
                             return true;
                         } else if (unhandledChange) {
-                            log.info(
+                            log.warn(
                                 "Unhandled change detected in pom.xml. Restart liberty:dev mode for it to take effect.");
                         }
                     }


### PR DESCRIPTION
fix for #595 

Adding a dependency that does not exist or cannot be downloaded from Maven Central or any configured repositories will trigger the following error: 
```
Unable to resolve artifact: io.openliberty.features:abcdefgh:1.0
```