### PR TITLE
dev support for changes in groupId, version, scope and type in dependencies

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
@@ -81,7 +81,7 @@ public class DevTest extends BaseDevTest {
 
          // make an unhandled change to the pom.xml
          replaceString("dev-sample-proj", "dev-sample-project", pom);
-         assertFalse(checkLogMessage(100000, "Unhandled change detected in pom.xml"));
+         assertFalse(checkLogMessage(200000, "Unhandled change detected in pom.xml"));
       }
    }
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
@@ -81,7 +81,7 @@ public class DevTest extends BaseDevTest {
 
          // make an unhandled change to the pom.xml
          replaceString("dev-sample-proj", "dev-sample-project", pom);
-         assertFalse(checkLogMessage(200000, "Unhandled change detected in pom.xml"));
+         assertFalse(checkLogMessage(100000, "Unhandled change detected in pom.xml"));
       }
    }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -598,9 +598,10 @@ public class DevMojo extends StartDebugMojoSupport {
                 // resolve new artifact
                 Artifact artifact = getArtifact(dep.getGroupId(), dep.getArtifactId(), dep.getType(), dep.getVersion());
 
-                // match dependencies based on artifactId, groupId
+                // match dependencies based on artifactId, groupId, version and type
                 for (Dependency existingDep : existingDependencies) {
                     if (Objects.equals(artifact.getArtifactId(), existingDep.getArtifactId())
+                            && Objects.equals(artifact.getGroupId(), existingDep.getGroupId())
                             && Objects.equals(artifact.getVersion(), existingDep.getVersion())
                             && Objects.equals(artifact.getType(), existingDep.getType())) {
                         newDependency = false;
@@ -614,7 +615,7 @@ public class DevMojo extends StartDebugMojoSupport {
             } catch (MojoExecutionException e) {
                 log.warn(e.getMessage());
             } catch (IllegalArgumentException e) {
-                log.warn("Illegal argument on " + dep.toString() + " " + e.getMessage());
+                log.warn(dep.toString() + " is not valid: " + e.getMessage());
             }
         }
         return updatedArtifacts;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -309,13 +309,18 @@ public class DevMojo extends StartDebugMojoSupport {
                     if (difference.getControlNodeDetail().getNode() != null && !dependencyChange(difference.getControlNodeDetail().getNode())) {
                         unhandledChange = true;
                     }
-                }
+                }                
                 if (!allDifferences.isEmpty()) {
                     log.info("Pom has been modified");
                     if (isUsingBoost()) {
                         log.info("Running boost:package");
                         runBoostMojo("package", true);
                     }
+                    else if (unhandledChange) {
+                        log.warn(
+                                "Unhandled change detected in pom.xml. Restart liberty:dev mode for it to take effect.");
+                    }
+                    
                     MavenProject updatedProject = loadProject(buildFile);
                     List<Dependency> dependencies = updatedProject.getDependencies();
                     log.debug("Dependencies size: " + dependencies.size());
@@ -377,14 +382,9 @@ public class DevMojo extends StartDebugMojoSupport {
                         this.existingPom = modifiedPom;
 
                         return true;
-                    } else {
-                        if (isUsingBoost()) {
-                            this.existingPom = modifiedPom;
-                            return true;
-                        } else if (unhandledChange) {
-                            log.warn(
-                                "Unhandled change detected in pom.xml. Restart liberty:dev mode for it to take effect.");
-                        }
+                    } else if (isUsingBoost()) {
+                        this.existingPom = modifiedPom;
+                        return true;
                     }
                 }
             } catch (Exception e) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -606,7 +606,6 @@ public class DevMojo extends StartDebugMojoSupport {
                         newDependency = false;
                         break;
                     }
-
                 }
                 if (newDependency) {
                     log.debug("New dependency found: " + artifact.toString());
@@ -617,7 +616,6 @@ public class DevMojo extends StartDebugMojoSupport {
             } catch (IllegalArgumentException e) {
                 log.warn("Illegal argument on " + dep.toString() + " " + e.getMessage());
             }
-
         }
         return updatedArtifacts;
     }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -601,14 +601,12 @@ public class DevMojo extends StartDebugMojoSupport {
                 // match dependencies based on artifactId, groupId
                 for (Dependency existingDep : existingDependencies) {
                     if (Objects.equals(artifact.getArtifactId(), existingDep.getArtifactId())
-                            && Objects.equals(artifact.getGroupId(), existingDep.getGroupId())) {
-                        if (Objects.equals(artifact.getVersion(), existingDep.getVersion())) {
-                            if (Objects.equals(artifact.getType(), existingDep.getType())) {
-                                newDependency = false;
-                                break;
-                            }
-                        }
+                            && Objects.equals(artifact.getVersion(), existingDep.getVersion())
+                            && Objects.equals(artifact.getType(), existingDep.getType())) {
+                        newDependency = false;
+                        break;
                     }
+
                 }
                 if (newDependency) {
                     log.debug("New dependency found: " + artifact.toString());


### PR DESCRIPTION
Determine if there is a new dependency added to the `pom.xml` by comparing initial `existingDependencies` list to new `dependencies` list.

Dev mode considers a dependency "new" or "altered" if:
- artifactId has changed
- groupId has changed
- version has changed (as long as version is not null in existing dependency or new dependency). This does not resolve dependency versions against the `dependencyManagement` section in the pom.xml. 
- type has changed or both existing and new type are null
- scope has changed or both existing and new scope are null

Fixes #599 