### PR TITLE
Pass debug environment variables to server startup task

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>io.openliberty.tools</groupId>
             <artifactId>liberty-ant-tasks</artifactId>
-            <version>1.9.1</version>
+            <version>1.9.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.mojo</groupId>

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -271,6 +271,7 @@ public class DevMojo extends StartDebugMojoSupport {
                 serverTask.setClean(clean);
                 if (libertyDebug) {
                     serverTask.setOperation("debug");
+                    serverTask.setEnvironmentVariables(getDebugEnvironmentVariables(libertyDebugPort));
                 } else {
                     serverTask.setOperation("run");
                 }


### PR DESCRIPTION
Pass debug environment variables to the server startup ant task.  This will cause the task to use those environment variables as the default, but values in server.env will override them (even though they should always be the same).

This is needed as part of OpenLiberty/ci.maven#580 so that dev mode (with debug mode) will work on Windows on previous Liberty releases even if the server.bat was not handling server.env properly.
