### PR TITLE
add test for missing config files

### DIFF
--- a/liberty-maven-plugin/src/it/appsdirectory-include-configured-it/src/test/resources/testConfig/server.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-include-configured-it/src/test/resources/testConfig/server.xml
@@ -3,4 +3,6 @@
         <feature>jsp-2.3</feature>
     </featureManager>
     <include optional="true" location="./testDir/server.xml"/>
+    <include optional="true" location="./testDir/missing.xml"/>
+    <include optional="true" location="/testDir/missing.xml"/>
 </server>


### PR DESCRIPTION
The fix was in ci.common https://github.com/OpenLiberty/ci.common/pull/96. This PR adds a test case with missing config files.