### PR TITLE
Move app startup verification to before ITs, decrease to 30 seconds

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -50,7 +50,7 @@ The following are the parameters supported by this goal in addition to the [comm
 | debugPort | The debug port that you can attach a debugger to. The default value is `7777`. | No |
 | compileWait | Time in seconds to wait before processing Java changes. If you encounter compile errors while refactoring, increase this value to allow all files to be saved before compilation occurs. The default value is `0.5` seconds. | No |
 | serverStartTimeout | Maximum time to wait (in seconds) to verify that the server has started. The default value is `30` seconds. | No |
-| verifyTimeout | Maximum time to wait (in seconds) to verify that the application has started after the server starts up. The default value is `60` seconds. | No |
+| verifyTimeout | Maximum time to wait (in seconds) to verify that the application has started before running integration tests. The default value is `30` seconds. | No |
 
 ###### System Properties for Integration Tests
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -133,22 +133,22 @@ public class DevMojo extends StartDebugMojoSupport {
     protected ProjectBuilder mavenProjectBuilder;
 
     /**
-     * Time in seconds to wait while verifying that the server has started.
+     * Time in seconds to wait while verifying that the application has started.
      */
-    @Parameter(property = "verifyTimeout", defaultValue = "60")
-    private int verifyTimeout = 60;
+    @Parameter(property = "verifyTimeout", defaultValue = "30")
+    private int verifyTimeout;
 
     /**
      * Time in seconds to wait while verifying that the application has updated.
      */
     @Parameter(property = "appUpdateTimeout", defaultValue = "5")
-    private int appUpdateTimeout = 5;
+    private int appUpdateTimeout;
 
     /**
      * Time in seconds to wait while verifying that the server has started.
      */
     @Parameter(property = "serverStartTimeout", defaultValue = "30")
-    private int serverStartTimeout = 30;
+    private int serverStartTimeout;
 
     /**
      * comma separated list of app names to wait for
@@ -197,7 +197,7 @@ public class DevMojo extends StartDebugMojoSupport {
         public DevMojoUtil(File serverDirectory, File sourceDirectory, File testSourceDirectory, File configDirectory,
                 List<File> resourceDirs) throws IOException {
             super(serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, resourceDirs, hotTests,
-                    skipTests, skipUTs, skipITs, project.getArtifactId(), appUpdateTimeout, ((long)(compileWait * 1000L)));
+                    skipTests, skipUTs, skipITs, project.getArtifactId(), verifyTimeout, appUpdateTimeout, ((long)(compileWait * 1000L)));
 
             this.existingDependencies = project.getDependencies();
             File pom = project.getFile();
@@ -546,7 +546,7 @@ public class DevMojo extends StartDebugMojoSupport {
         util = new DevMojoUtil(serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, resourceDirs);
         util.addShutdownHook(executor);
         util.enableServerDebug(libertyDebugPort);
-        util.startServer(serverStartTimeout, verifyTimeout);
+        util.startServer(serverStartTimeout);
 
         // collect artifacts canonical paths in order to build classpath
         List<String> artifactPaths = util.getArtifacts();


### PR DESCRIPTION
Move app startup verification to just before running ITs.  Once app startup has been verified, it will not need verification again (other than checking that the app is updated during hot deployment scenarios).

App startup verification was originally increased from 30 to 60 to allow time for slower environments to start up.  Now that we move the verification to before ITs, we can decrease it back to 30, otherwise the wait is too long.  If the app is still not started, the user can just run the tests again.

Fixes https://github.com/OpenLiberty/ci.maven/issues/629