### PR TITLE
handle pom.xml changes in dev mode

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
@@ -81,7 +81,7 @@ public class DevTest extends BaseDevTest {
 
          // make an unhandled change to the pom.xml
          replaceString("dev-sample-proj", "dev-sample-project", pom);
-         assertFalse(checkLogMessage(100000, "Unhandled change detected in pom.xml"));
+         assertFalse(checkLogMessage(100000, "An unexpected error occurred while processing changes in pom.xml"));
       }
    }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -352,7 +352,7 @@ public class DevMojo extends StartDebugMojoSupport {
 
         @Override
         public boolean recompileBuildFile(File buildFile, List<String> artifactPaths, ThreadPoolExecutor executor) {
-            // monitoring project pom.xml file changes for dev mode update:
+            // monitoring project pom.xml file changes in dev mode:
             // - liberty.* properites in project properties section
             // - changes in liberty plugin configuration in the build plugin section
             // - project dependencies changes
@@ -414,7 +414,7 @@ public class DevMojo extends StartDebugMojoSupport {
                     }
                 }
 
-                // Liberty plugin configuration change in the pom.xml
+                // monitoring Liberty plugin configuration changes in dev mode
                 if (!restartServer && !createServer) {
                     Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(libertyPlugin, "create", log);
                     Xpp3Dom currentConfig = ExecuteMojoUtil.getPluginGoalConfig(backupLibertyPlugin, "create", log);
@@ -526,7 +526,6 @@ public class DevMojo extends StartDebugMojoSupport {
                     session.setCurrentProject(backupProject);
                     return false;
                 }
-                //
             } catch (IOException | DependencyResolutionException | MojoExecutionException
                     | ProjectBuildingException e) {
                 log.error("Could not handle changes in pom.xml. " + e.getMessage());

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -487,8 +487,8 @@ public class DevMojo extends StartDebugMojoSupport {
                     // - install feature
                     // - deploy app
                     // - start server
-                    log.error("Changes for Liberty server bootstrap properties or environment variables or JVM options "
-                            + "in the pom.xml has been detected, Restart liberty:dev mode for it to take effect.");
+                    log.error("Changes for Liberty server bootstrap properties, environment variables or JVM options "
+                            + "in the pom.xml have been detected. Restart liberty:dev mode for the changes to take effect.");
                     project = backupProject;
                     session.setCurrentProject(backupProject);
                     return false;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -360,12 +360,10 @@ public class DevMojo extends StartDebugMojoSupport {
                     getPropertiesWithKeyPrefix(backupProjProp, LIBERTY_VAR_PROP))) {
                 return true;
             }
-
             if (!Objects.equals(getPropertiesWithKeyPrefix(projProp, LIBERTY_DEFAULT_VAR_PROP), 
                     getPropertiesWithKeyPrefix(backupProjProp, LIBERTY_DEFAULT_VAR_PROP))) {
                 return true;
             }
-
             return false;
         }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -483,7 +483,7 @@ public class DevMojo extends StartDebugMojoSupport {
                 if (restartServer) {
                     // TODO: restart server automatically
                     // - stop Server
-                    // - create server or runBootMojo
+                    // - create server or runBoostMojo
                     // - install feature
                     // - deploy app
                     // - start server
@@ -506,15 +506,14 @@ public class DevMojo extends StartDebugMojoSupport {
                     }
                 }
                 if (!(restartServer || createServer || redeployApp || installFeature || runBoostPackage)) {
-                    // pom.xml is changed but not affecting dev mode
+                    // pom.xml is changed but not affecting liberty:dev mode. return true with the updated 
+                    // project set in the session 
                     log.debug("changes in the pom.xml are not monitored by dev mode");
-                    project = backupProject;
-                    session.setCurrentProject(backupProject);
-                    return false;
+                    return true;
                 }
             } catch (IOException | DependencyResolutionException | MojoExecutionException
                     | ProjectBuildingException e) {
-                log.error("Unhandled change detected in pom.xml. " + e.getMessage());
+                log.error("An unexpected error occurred while processing changes in pom.xml. " + e.getMessage());
                 log.debug(e);
                 project = backupProject;
                 session.setCurrentProject(backupProject);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -288,20 +288,6 @@ public class DevMojo extends StartDebugMojoSupport {
             return artifactPaths;
         }
 
-        public boolean compareProperties(Properties p, Properties q) {
-            if (p.size() != q.size()) {
-                return false;
-            }
-            Enumeration<?> e = p.propertyNames();
-            while (e.hasMoreElements()) {
-                String key = (String) e.nextElement();
-                if (!(p.get(key).equals(q.get(key)))) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
         private Properties getPropertiesWithKeyPrefix(Properties p, String prefix) {
             Properties result = new Properties();
             if (p != null) {
@@ -314,17 +300,6 @@ public class DevMojo extends StartDebugMojoSupport {
                 }
             }
             return result;
-        }
-
-        private boolean compareConfigElement(Xpp3Dom source, Xpp3Dom target) {
-            if (source != null) {
-                if (source.equals(target)) {
-                    return true;
-                }
-            } else if (target == null) {
-                return true;
-            }
-            return false;
         }
 
         private List<Dependency> getEsaDependency(List<Dependency> dependencies) {
@@ -384,17 +359,17 @@ public class DevMojo extends StartDebugMojoSupport {
                 // Monitoring liberty properties in the pom.xml
                 Properties p = getPropertiesWithKeyPrefix(project.getProperties(), "liberty.bootstrap.");
                 Properties q = getPropertiesWithKeyPrefix(backupProject.getProperties(), "liberty.bootstrap.");
-                if (!compareProperties(p, q)) {
+                if (!Objects.equals(p, q)) {
                     restartServer = true;
                 } else {
                     p = getPropertiesWithKeyPrefix(project.getProperties(), "liberty.jvm.");
                     q = getPropertiesWithKeyPrefix(backupProject.getProperties(), "liberty.jvm.");
-                    if (!compareProperties(p, q)) {
+                    if (!Objects.equals(p, q)) {
                         restartServer = true;
                     } else {
                         p = getPropertiesWithKeyPrefix(project.getProperties(), "liberty.env.");
                         q = getPropertiesWithKeyPrefix(backupProject.getProperties(), "liberty.env.");
-                        if (!compareProperties(p, q)) {
+                        if (!Objects.equals(p, q)) {
                             restartServer = true;
                         }
                     }
@@ -403,12 +378,12 @@ public class DevMojo extends StartDebugMojoSupport {
                 if (!restartServer) {
                     p = getPropertiesWithKeyPrefix(project.getProperties(), "liberty.var.");
                     q = getPropertiesWithKeyPrefix(backupProject.getProperties(), "liberty.var.");
-                    if (!compareProperties(p, q)) {
+                    if (!Objects.equals(p, q)) {
                         createServer = true;
                     } else {
                         p = getPropertiesWithKeyPrefix(project.getProperties(), "liberty.defaultVar.");
                         q = getPropertiesWithKeyPrefix(backupProject.getProperties(), "liberty.defaultVar.");
-                        if (!compareProperties(p, q)) {
+                        if (!Objects.equals(p, q)) {
                             createServer = true;
                         }
                     }
@@ -419,22 +394,22 @@ public class DevMojo extends StartDebugMojoSupport {
                     Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(libertyPlugin, "create", log);
                     Xpp3Dom currentConfig = ExecuteMojoUtil.getPluginGoalConfig(backupLibertyPlugin, "create", log);
 
-                    if (!compareConfigElement(config.getChild("bootstrapProperties"),
+                    if (!Objects.equals(config.getChild("bootstrapProperties"),
                             currentConfig.getChild("bootstrapProperties"))) {
                         restartServer = true;
-                    } else if (!compareConfigElement(config.getChild("bootstrapPropertiesFile"),
+                    } else if (!Objects.equals(config.getChild("bootstrapPropertiesFile"),
                             currentConfig.getChild("bootstrapPropertiesFile"))) {
                         restartServer = true;
-                    } else if (!compareConfigElement(config.getChild("jvmOptions"),
+                    } else if (!Objects.equals(config.getChild("jvmOptions"),
                             currentConfig.getChild("jvmOptions"))) {
                         restartServer = true;
-                    } else if (!compareConfigElement(config.getChild("jvmOptionsFile"),
+                    } else if (!Objects.equals(config.getChild("jvmOptionsFile"),
                             currentConfig.getChild("jvmOptionsFile"))) {
                         restartServer = true;
-                    } else if (!compareConfigElement(config.getChild("serverEnvFile"),
+                    } else if (!Objects.equals(config.getChild("serverEnvFile"),
                             currentConfig.getChild("serverEnvFile"))) {
                         restartServer = true;
-                    } else if (!compareConfigElement(config.getChild("configDirectory"),
+                    } else if (!Objects.equals(config.getChild("configDirectory"),
                             currentConfig.getChild("configDirectory"))) {
                         restartServer = true;
                         // restart dev mode
@@ -443,7 +418,7 @@ public class DevMojo extends StartDebugMojoSupport {
                         config = ExecuteMojoUtil.getPluginGoalConfig(libertyPlugin, "install-feature", log);
                         currentConfig = ExecuteMojoUtil.getPluginGoalConfig(backupLibertyPlugin, "install-feature",
                                 log);
-                        if (!compareConfigElement(config.getChild("features"), currentConfig.getChild("features"))) {
+                        if (!Objects.equals(config.getChild("features"), currentConfig.getChild("features"))) {
                             installFeature = true;
                         }
                     }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -496,14 +496,14 @@ public class DevMojo extends StartDebugMojoSupport {
                 }
                 if (!(restartServer || createServer || redeployApp || installFeature || runBoostPackage)) {
                     // pom.xml is changed but not affecting dev mode
-                    log.debug("changes in the pom.xml is not required by dev mode");
+                    log.debug("changes in the pom.xml are not monitored by dev mode");
                     project = backupProject;
                     session.setCurrentProject(backupProject);
                     return false;
                 }
             } catch (IOException | DependencyResolutionException | MojoExecutionException
                     | ProjectBuildingException e) {
-                log.error("Could not handle changes in pom.xml. " + e.getMessage());
+                log.error("Unhandled change detected in pom.xml. " + e.getMessage());
                 log.debug(e);
                 project = backupProject;
                 session.setCurrentProject(backupProject);


### PR DESCRIPTION
Monitoring the following changes in project pom.xml while dev mode is running.:
- all `liberty.*` properties
- all `liberty-maven-plugin` configurations
- dependencies

Signed-off-by: Patrick Tiu <tiu@ca.ibm.com>