### PR TITLE
display server stop message when stopServer is called before server starts

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -24,6 +24,7 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.name;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -232,8 +233,7 @@ public class DevMojo extends StartDebugMojoSupport {
                 serverTask.setOperation("stop");
                 serverTask.execute();
             } catch (Exception e) {
-                // ignore
-                log.debug("Error stopping server", e);
+                log.warn(MessageFormat.format(messages.getString("warn.server.stopped"), serverName));
             }
         }
 


### PR DESCRIPTION
Fixes #644 

Match the functionality in liberty:stop. If Ctl-C is pressed before the server starts, the following is displayed:

```
[INFO] Stopping server defaultServer.
[INFO] Server defaultServer stop failed. Check server logs for details.
[WARNING] CWWKM2133W: The command to stop server defaultServer failed. The server is probably already stopped.
```