### PR TITLE
Combine verify app start and update timeouts

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -50,7 +50,7 @@ The following are the parameters supported by this goal in addition to the [comm
 | debugPort | The debug port that you can attach a debugger to. The default value is `7777`. | No |
 | compileWait | Time in seconds to wait before processing Java changes. If you encounter compile errors while refactoring, increase this value to allow all files to be saved before compilation occurs. The default value is `0.5` seconds. | No |
 | serverStartTimeout | Maximum time to wait (in seconds) to verify that the server has started. The default value is `30` seconds. | No |
-| verifyTimeout | Maximum time to wait (in seconds) to verify that the application has started before running integration tests. The default value is `30` seconds. | No |
+| verifyTimeout | Maximum time to wait (in seconds) to verify that the application has started or updated before running integration tests. The default value is `30` seconds. | No |
 
 ###### System Properties for Integration Tests
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -117,16 +117,10 @@ public class DevMojo extends StartDebugMojoSupport {
     protected ProjectBuilder mavenProjectBuilder;
 
     /**
-     * Time in seconds to wait while verifying that the application has started.
+     * Time in seconds to wait while verifying that the application has started or updated.
      */
     @Parameter(property = "verifyTimeout", defaultValue = "30")
     private int verifyTimeout;
-
-    /**
-     * Time in seconds to wait while verifying that the application has updated.
-     */
-    @Parameter(property = "appUpdateTimeout", defaultValue = "5")
-    private int appUpdateTimeout;
 
     /**
      * Time in seconds to wait while verifying that the server has started.
@@ -179,7 +173,7 @@ public class DevMojo extends StartDebugMojoSupport {
         public DevMojoUtil(File serverDirectory, File sourceDirectory, File testSourceDirectory, File configDirectory,
                 List<File> resourceDirs) throws IOException {
             super(serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, resourceDirs, hotTests,
-                    skipTests, skipUTs, skipITs, project.getArtifactId(), serverStartTimeout, verifyTimeout, appUpdateTimeout,
+                    skipTests, skipUTs, skipITs, project.getArtifactId(), serverStartTimeout, verifyTimeout, verifyTimeout,
                     ((long) (compileWait * 1000L)), libertyDebug);
 
             ServerFeature servUtil = getServerFeatureUtil();


### PR DESCRIPTION
DevUtil supports separate parameters for app startup and app update timeouts (but the update timeout was not documented).  To simplify things for users, we should combine them in the Maven plugin to use just the app startup timeout for both.