### PR TITLE
Skip message on normal exit, use ci.common 1.8.2-SNAPSHOT

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>io.openliberty.tools</groupId>
             <artifactId>liberty-ant-tasks</artifactId>
-            <version>1.9.3-SNAPSHOT</version>
+            <version>1.9.3</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.mojo</groupId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>io.openliberty.tools</groupId>
             <artifactId>ci.common</artifactId>
-            <version>1.8-SNAPSHOT</version>
+            <version>1.8.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.twdata.maven</groupId>

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -735,8 +735,11 @@ public class DevMojo extends StartDebugMojoSupport {
         // configuration parameter is not specified.
         try {
             util.watchFiles(pom, outputDirectory, testOutputDirectory, executor, artifactPaths, serverXmlFile);
-        } catch (PluginScenarioException e) { // this exception is caught when the server has been stopped by another process
-            log.info(e.getMessage()); 
+        } catch (PluginScenarioException e) {
+            if (e.getMessage() != null) {
+                // a proper message is included in the exception if the server has been stopped by another process
+                log.info(e.getMessage());
+            }
             return; // enter shutdown hook 
         }
     }


### PR DESCRIPTION
Needed due to changes for https://github.com/OpenLiberty/ci.gradle/issues/378

- With OpenLiberty/ci.common#119, DevUtil will throw PluginScenarioException with empty message if dev mode exits normally by user input. Only print the exception message if it is not null.