### PR TITLE
Close Scanner resource in tests

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
@@ -179,12 +179,15 @@ public class BaseDevTest {
 
    private static boolean readFile(String str, File file) throws FileNotFoundException {
       Scanner scanner = new Scanner(file);
-
-      while (scanner.hasNextLine()) {
-         String line = scanner.nextLine();
-         if (line.contains(str)) {
-            return true;
+      try {
+         while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+            if (line.contains(str)) {
+               return true;
+            }
          }
+      } finally {
+         scanner.close();
       }
       return false;
    }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
@@ -60,12 +60,15 @@ public class DevTest extends BaseDevTest {
       assertFalse(checkLogMessage(60000, "CWWKZ0003I"));
       Thread.sleep(2000);
       Scanner scanner = new Scanner(targetServerXML);
-
-      while (scanner.hasNextLine()) {
-         String line = scanner.nextLine();
-         if (line.contains("<feature>mpHealth-1.0</feature>")) {
-            assertTrue(true);
+      try {
+         while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+            if (line.contains("<feature>mpHealth-1.0</feature>")) {
+               assertTrue(true);
+            }
          }
+      } finally {
+         scanner.close();
       }
    }
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
@@ -55,8 +55,8 @@ public class DevTest extends BaseDevTest {
 
       replaceString("</feature>", "</feature>\n" + "    <feature>mpHealth-1.0</feature>", srcServerXML);
 
-      // check for application updated message
-      assertFalse(checkLogMessage(60000, "CWWKZ0003I"));
+      // check for server configuration was successfully updated message
+      assertFalse(checkLogMessage(60000, "CWWKG0017I"));
       Thread.sleep(2000);
       Scanner scanner = new Scanner(targetServerXML);
       boolean foundUpdate = false;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
@@ -15,8 +15,7 @@
  *******************************************************************************/
 package net.wasdev.wlp.test.dev.it;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -60,16 +59,19 @@ public class DevTest extends BaseDevTest {
       assertFalse(checkLogMessage(60000, "CWWKZ0003I"));
       Thread.sleep(2000);
       Scanner scanner = new Scanner(targetServerXML);
+      boolean foundUpdate = false;
       try {
          while (scanner.hasNextLine()) {
             String line = scanner.nextLine();
             if (line.contains("<feature>mpHealth-1.0</feature>")) {
-               assertTrue(true);
+               foundUpdate = true;
+               break;
             }
          }
       } finally {
-         scanner.close();
+            scanner.close();
       }
+      assertTrue("Could not find the updated feature in the target server.xml file", foundUpdate);
    }
 
    @Test

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MPStarterTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MPStarterTest.java
@@ -22,7 +22,6 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.nio.file.Files;
-import java.util.Scanner;
 
 import org.apache.maven.shared.utils.io.FileUtils;
 import org.junit.AfterClass;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/RunTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/RunTest.java
@@ -23,7 +23,6 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.nio.file.Files;
-import java.util.Scanner;
 
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpStatus;


### PR DESCRIPTION
Close Scanner resource in tests.  Fixes the following failure in the current Appveyor tests:
`Failed tests: 
[INFO]   MPStarterTest.cleanUpAfterClass:54->BaseDevTest.cleanUpAfterClass:128->BaseDevTest.cleanUpAfterClass:139
`
Other Appveyor tests on Windows still fail though.