### PR TITLE
Add polling option for dev mode

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -51,6 +51,8 @@ The following are the parameters supported by this goal in addition to the [comm
 | compileWait | Time in seconds to wait before processing Java changes. If you encounter compile errors while refactoring, increase this value to allow all files to be saved before compilation occurs. The default value is `0.5` seconds. | No |
 | serverStartTimeout | Maximum time to wait (in seconds) to verify that the server has started. The value must be an integer greater than or equal to 0. The default value is `30` seconds. | No |
 | verifyTimeout | Maximum time to wait (in seconds) to verify that the application has started or updated before running integration tests. The value must be an integer greater than or equal to 0. The default value is `30` seconds. | No |
+| polling | If set to `true`, poll for file changes instead of using file system notifications. The default value is `false`. | No |
+| pollingInterval | Polling interval in milliseconds. The default value is `100` milliseconds. This parameter is only used if `polling` is enabled. | No |
 
 ###### System Properties for Integration Tests
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/PollingDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/PollingDevTest.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2020.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import org.junit.BeforeClass;
+public class PollingDevTest extends DevTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      setUpBeforeClass("-Dpolling");
+   }
+
+}

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -141,6 +141,18 @@ public class DevMojo extends StartDebugMojoSupport {
     protected boolean clean;
 
     /**
+     * Poll for file changes instead of using file system notifications.
+     */
+    @Parameter(property = "polling", defaultValue = "false")
+    protected boolean polling;
+
+    /**
+     * Polling interval in milliseconds.
+     */
+    @Parameter(property = "pollingInterval", defaultValue = "100")
+    private long pollingInterval;
+
+    /**
      * The directory for source files.
      */
     @Parameter(readonly = true, required = true, defaultValue = " ${project.build.sourceDirectory}")
@@ -174,7 +186,7 @@ public class DevMojo extends StartDebugMojoSupport {
                 List<File> resourceDirs) throws IOException {
             super(serverDirectory, sourceDirectory, testSourceDirectory, configDirectory, resourceDirs, hotTests,
                     skipTests, skipUTs, skipITs, project.getArtifactId(), serverStartTimeout, verifyTimeout, verifyTimeout,
-                    ((long) (compileWait * 1000L)), libertyDebug, false, false);
+                    ((long) (compileWait * 1000L)), libertyDebug, false, false, polling, pollingInterval);
 
             ServerFeature servUtil = getServerFeatureUtil();
             this.existingFeatures = servUtil.getServerFeatures(serverDirectory);


### PR DESCRIPTION
Add a polling option for scenarios where file system notifications are not available, e.g. on mounted directories in Docker on Windows.

Fix is for OpenLiberty/ci.maven#617