### PR TITLE
#755 Update parent and plugin version in archetypes to use the corres…

### DIFF
--- a/liberty-archetype-ear/pom.xml
+++ b/liberty-archetype-ear/pom.xml
@@ -19,6 +19,25 @@
     </description>
     
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>META-INF/maven/archetype-metadata.xml</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <includes>
+                    <include>archetype-resources/pom.xml</include>
+                    <include>archetype-resources/__rootArtifactId__-ear/pom.xml</include>
+                    <include>archetype-resources/__rootArtifactId__-ejb/pom.xml</include>
+                    <include>archetype-resources/__rootArtifactId__-war/pom.xml</include>
+                </includes>
+            </resource>
+        </resources>
         <extensions>
             <extension>
                 <groupId>org.apache.maven.archetype</groupId>

--- a/liberty-archetype-ear/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/liberty-archetype-ear/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -16,7 +16,7 @@
             <defaultValue>[18.0.0.1,)</defaultValue>
         </requiredProperty>
         <requiredProperty key="libertyPluginVersion">
-            <defaultValue>3.0-M2</defaultValue>
+            <defaultValue>${project.version}</defaultValue>
         </requiredProperty>
     </requiredProperties>
     <modules>

--- a/liberty-archetype-webapp/pom.xml
+++ b/liberty-archetype-webapp/pom.xml
@@ -15,6 +15,22 @@
     <name>Archetype - liberty-archetype-webapp</name>
     
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>META-INF/maven/archetype-metadata.xml</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <includes>
+                    <include>archetype-resources/pom.xml</include>
+                </includes>
+            </resource>
+        </resources>
         <extensions>
             <extension>
                 <groupId>org.apache.maven.archetype</groupId>

--- a/liberty-archetype-webapp/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/liberty-archetype-webapp/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -16,7 +16,7 @@
             <defaultValue>[18.0.0.1,)</defaultValue>
         </requiredProperty>
         <requiredProperty key="libertyPluginVersion">
-            <defaultValue>3.0-M2</defaultValue>
+            <defaultValue>${project.version}</defaultValue>
         </requiredProperty>
     </requiredProperties>
     <fileSets>


### PR DESCRIPTION
Uses project's version as the default value for the `libertyPluginVersion` in the `liberty-archetype-ear` and `liberty-archetype-webapp` archetypes. It does so by filtering the corresponding `archetype-metadata.xml` files.

This was requested in https://github.com/OpenLiberty/ci.maven/issues/755