### PR TITLE
Examine war plugin webResources for directories to add to loose app

### DIFF
--- a/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/pom.xml
+++ b/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/pom.xml
@@ -54,6 +54,20 @@
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <packagingExcludes>pom.xml</packagingExcludes>
+                    <webResources>
+                        <resource>
+                            <!-- this is relative to the pom.xml directory -->
+                            <directory>target/jekyll-webapp</directory>
+                        </resource>
+                    </webResources>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <outputDirectory>target</outputDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/src/main/resources/jekyll-webapp/version.txt
+++ b/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/src/main/resources/jekyll-webapp/version.txt
@@ -1,0 +1,1 @@
+key=value

--- a/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/src/test/java/net/wasdev/wlp/test/servlet/it/LooseConfigTest.java
+++ b/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/src/test/java/net/wasdev/wlp/test/servlet/it/LooseConfigTest.java
@@ -55,7 +55,7 @@ public class LooseConfigTest {
         XPath xPath = XPathFactory.newInstance().newXPath();
         String expression = "/archive/dir";
         NodeList nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
-        Assert.assertEquals("Number of <dir> element ==>", 2, nodes.getLength());
+        Assert.assertEquals("Number of <dir> element ==>", 3, nodes.getLength());
         
         expression = "/archive/file";
         nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
@@ -115,8 +115,10 @@ public class DeployMojoSupport extends PluginConfigSupport {
         // retrieve the directories defined as resources in the maven war plugin
         String webResources[] = MavenProjectUtil.getPluginConfiguration(proj, "org.apache.maven.plugins",
             "maven-war-plugin", "webResources", "resource", "directory");
-        for (int i = 0; i < webResources.length; i++) {
-            looseWar.addOutputDir(looseWar.getDocumentRoot(), new File(proj.getBasedir().getAbsolutePath(), webResources[i]), "/");
+        if (webResources != null) {
+            for (int i = 0; i < webResources.length; i++) {
+                looseWar.addOutputDir(looseWar.getDocumentRoot(), new File(proj.getBasedir().getAbsolutePath(), webResources[i]), "/");
+            }
         }
 
         // retrieves dependent library jar files

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
@@ -112,6 +112,13 @@ public class DeployMojoSupport extends PluginConfigSupport {
         looseWar.addOutputDir(looseWar.getDocumentRoot(), new File(proj.getBuild().getOutputDirectory()),
                 "/WEB-INF/classes");
 
+        // retrieve the directories defined as resources in the maven war plugin
+        String webResources[] = MavenProjectUtil.getPluginConfiguration(proj, "org.apache.maven.plugins",
+            "maven-war-plugin", "webResources", "resource", "directory");
+        for (int i = 0; i < webResources.length; i++) {
+            looseWar.addOutputDir(looseWar.getDocumentRoot(), new File(proj.getBasedir().getAbsolutePath(), webResources[i]), "/");
+        }
+
         // retrieves dependent library jar files
         addEmbeddedLib(looseWar.getDocumentRoot(), proj, looseWar, "/WEB-INF/lib/");
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/MavenProjectUtil.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/MavenProjectUtil.java
@@ -83,10 +83,11 @@ public class MavenProjectUtil {
                 }
                 if (val2 != null) {
                     Xpp3Dom[] children = null;
-                    if (childName == null)
+                    if (childName == null) {
                         children = val2.getChildren();
-                    else
+                    } else {
                         children = val2.getChildren(childName);
+                    }
                     if (children != null) {
                         String[] result = new String[children.length];
                         for (int i = 0; i < children.length; i++) {


### PR DESCRIPTION
Add the directories specified in the war plugin webResources elements to the loose application .war.xml file that this plugin generates in dev mode. For issue #767 .