### PR TITLE
Process multiple resource elements and check for a targetPath element…

### DIFF
--- a/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/pom.xml
+++ b/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/pom.xml
@@ -57,17 +57,13 @@
                     <webResources>
                         <resource>
                             <!-- this is relative to the pom.xml directory -->
-                            <directory>target/jekyll-webapp</directory>
+                            <directory>target/generated-test-sources</directory>
+                        </resource>
+                        <resource>
+                            <directory>target/generated-sources</directory>
+                            <targetPath>generated</targetPath>
                         </resource>
                     </webResources>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>3.1.0</version>
-                <configuration>
-                    <outputDirectory>target</outputDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/src/main/resources/jekyll-webapp/version.txt
+++ b/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/src/main/resources/jekyll-webapp/version.txt
@@ -1,1 +1,0 @@
-key=value

--- a/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/src/test/java/net/wasdev/wlp/test/servlet/it/LooseConfigTest.java
+++ b/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/src/test/java/net/wasdev/wlp/test/servlet/it/LooseConfigTest.java
@@ -55,7 +55,7 @@ public class LooseConfigTest {
         XPath xPath = XPathFactory.newInstance().newXPath();
         String expression = "/archive/dir";
         NodeList nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
-        Assert.assertEquals("Number of <dir> element ==>", 3, nodes.getLength());
+        Assert.assertEquals("Number of <dir> element ==>", 4, nodes.getLength());
         
         expression = "/archive/file";
         nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.Validate;
@@ -113,11 +114,11 @@ public class DeployMojoSupport extends PluginConfigSupport {
                 "/WEB-INF/classes");
 
         // retrieve the directories defined as resources in the maven war plugin
-        String webResources[] = MavenProjectUtil.getPluginConfiguration(proj, "org.apache.maven.plugins",
-            "maven-war-plugin", "webResources", "resource", "directory");
+        Map<String,String> webResources = MavenProjectUtil.getWebResourcesConfiguration(proj);
         if (webResources != null) {
-            for (int i = 0; i < webResources.length; i++) {
-                looseWar.addOutputDir(looseWar.getDocumentRoot(), new File(proj.getBasedir().getAbsolutePath(), webResources[i]), "/");
+            for (String directory : webResources.keySet()) {
+                String targetPath = webResources.get(directory)==null ? "/" : "/"+webResources.get(directory);
+                looseWar.addOutputDir(looseWar.getDocumentRoot(), new File(proj.getBasedir().getAbsolutePath(), directory), targetPath);
             }
         }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/MavenProjectUtil.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/MavenProjectUtil.java
@@ -18,6 +18,7 @@ package io.openliberty.tools.maven.utils;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.model.Plugin;
@@ -65,6 +66,9 @@ public class MavenProjectUtil {
      * Get directory and targetPath configuration values from the Maven WAR plugin
      * @param proj the Maven project
      * @return a Map of source and target directories corresponding to the configuration keys
+     * or null if the war plugin or its webResources or resource elements are not used. 
+     * The map will be empty if the directory element is not used. The value field of the 
+     * map is null when the targetPath element is not used.
      */
     public static Map<String,String> getWebResourcesConfiguration(MavenProject proj) {
         Xpp3Dom dom = proj.getGoalConfiguration("org.apache.maven.plugins", "maven-war-plugin", null, null);


### PR DESCRIPTION
… to rename the directory in the loose application xml. Since the processing of the configuration is so specific to the Maven War plugin, make a method dedicated to this. Update and streamline the test case to check for the extra entry and remove the unnecessary test directory and Maven resource plugin.