### PR TITLE
Updates for release 3.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ jdk:
     - openjdk8
     - openjdk11
 env:
-    - RUNTIME=ol RUNTIME_VERSION=19.0.0.6
-    - RUNTIME=ol RUNTIME_VERSION=19.0.0.9
-    - RUNTIME=wlp RUNTIME_VERSION=19.0.0.6
-    - RUNTIME=wlp RUNTIME_VERSION=19.0.0.9
+    - RUNTIME=ol RUNTIME_VERSION=19.0.0.12
+    - RUNTIME=ol RUNTIME_VERSION=20.0.0.3
+    - RUNTIME=wlp RUNTIME_VERSION=19.0.0.12
+    - RUNTIME=wlp RUNTIME_VERSION=20.0.0.3
 cache:
     directories:
         - $HOME/.m2
@@ -21,10 +21,10 @@ before_install:
     - cd ./ci.ant
     - mvn clean install
     - cd ..
-#    - echo 'Installing ci.common lib...'
-#    - git clone https://github.com/OpenLiberty/ci.common.git ./ci.common
-#    - cd ./ci.common
-#    - mvn clean install
-#    - cd ..
+    - echo 'Installing ci.common lib...'
+    - git clone https://github.com/OpenLiberty/ci.common.git ./ci.common
+    - cd ./ci.common
+    - mvn clean install
+    - cd ..
 script:
     - travis_wait 40 mvn verify -Ponline-its -Dinvoker.streamLogs=true -Druntime=$RUNTIME -DruntimeVersion=$RUNTIME_VERSION

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To enable Liberty Maven Plugin in your project add the following to your `pom.xm
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>[3.0.1,)</version>
+                <version>[3.2.1,)</version>
                 <!-- Specify configuration, executions for liberty-maven-plugin -->
                 ...
             </plugin>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,16 @@
 environment:
     matrix:
         - jdk: "C:\\Program Files\\Java\\jdk1.8.0\\bin:"
-          RUNTIME_VERSION: 19.0.0.6
+          RUNTIME_VERSION: 19.0.0.12
           RUNTIME: ol
         - jdk: "C:\\Program Files\\Java\\jdk1.8.0\\bin:"
-          RUNTIME_VERSION: 19.0.0.9
+          RUNTIME_VERSION: 20.0.0.3
           RUNTIME: ol
         - jdk: "C:\\Program Files\\Java\\jdk1.8.0\\bin:"
-          RUNTIME_VERSION: 19.0.0.6
+          RUNTIME_VERSION: 19.0.0.12
           RUNTIME: wlp
         - jdk: "C:\\Program Files\\Java\\jdk1.8.0\\bin:"
-          RUNTIME_VERSION: 19.0.0.9
+          RUNTIME_VERSION: 20.0.0.3
           RUNTIME: wlp
 
 install:
@@ -28,11 +28,11 @@ before_build:
         cd ci.ant
         mvn clean install
         cd..
-#        echo "Installing ci.common lib..."
-#        git clone https://github.com/OpenLiberty/ci.common.git ci.common
-#        cd ci.common
-#        mvn clean install
-#        cd..
+        echo "Installing ci.common lib..."
+        git clone https://github.com/OpenLiberty/ci.common.git ci.common
+        cd ci.common
+        mvn clean install
+        cd..
 
 build_script:
     - "echo %WLP_VERSION%"

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -14,21 +14,6 @@
     <name>liberty-maven-plugin</name>
     <description>Liberty Maven Plugin : Install, Start/Stop, Package, Create Server, Deploy/Undeploy applications</description>
 
-    <pluginRepositories>
-        <!-- Configure Sonatype OSS Maven snapshots repository -->
-        <pluginRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </pluginRepository>
-    </pluginRepositories>
-
     <dependencies>
         <dependency>
             <groupId>io.openliberty.tools</groupId>
@@ -79,7 +64,7 @@
         <dependency>
             <groupId>io.openliberty.tools</groupId>
             <artifactId>ci.common</artifactId>
-            <version>1.8.4-SNAPSHOT</version>
+            <version>1.8.4</version>
         </dependency>
         <dependency>
             <groupId>org.twdata.maven</groupId>


### PR DESCRIPTION
Update to use ci.common release 1.8.4, update version in readme instructions, update to use two most recent quarterly runtimes.