### PR TITLE
Added support for <outputFileNameMapping>. 

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -40,6 +40,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-mapping</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>3.5.0</version>

--- a/liberty-maven-plugin/src/it/ear-project-it/SampleEAR/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/SampleEAR/pom.xml
@@ -52,6 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
+                <version>3.0.2</version>
                 <configuration>
                     <!-- Tell Maven we are using Java EE 7 -->
                     <version>7</version>
@@ -59,7 +60,7 @@
                         libraries are in easy way to package any libraries needed in the ear, and 
                         automatically have any modules (EJB-JARs and WARs) use them -->
                     <defaultLibBundleDir>lib</defaultLibBundleDir>
-                    <fileNameMapping>no-version</fileNameMapping>
+                    <outputFileNameMapping>@{artifactId}@.@{extension}@</outputFileNameMapping>
                     <modules>
                         <webModule>
                             <groupId>io.openliberty.tools.it</groupId>

--- a/liberty-maven-plugin/src/it/ear-project-it/helloworld-ear/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/helloworld-ear/pom.xml
@@ -34,11 +34,11 @@
         <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
+                <version>3.0.2</version>
                 <configuration>
                     <version>7</version>
-                    <fileNameMapping>no-version</fileNameMapping>
+                    <outputFileNameMapping>@{artifactId}@.@{extension}@</outputFileNameMapping>
                     <defaultLibBundleDir>lib</defaultLibBundleDir>
                 </configuration>
             </plugin>

--- a/liberty-maven-plugin/src/it/ear-project-it/skinnywar-ear/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/skinnywar-ear/pom.xml
@@ -50,6 +50,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
+                <version>2.10.1</version>
                 <configuration>
                     <version>7</version>
                     <fileNameMapping>no-version</fileNameMapping>

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/LooseEarApplication.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/LooseEarApplication.java
@@ -1,3 +1,18 @@
+/**
+ * (C) Copyright IBM Corporation 2017, 2020.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.openliberty.tools.maven.applications;
 
 import java.io.File;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/LooseEarApplication.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/LooseEarApplication.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.shared.mapping.MappingUtils;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.w3c.dom.Element;
@@ -104,18 +105,15 @@ public class LooseEarApplication extends LooseApplication {
         }
     }
 
-    public String getModuleUri(Artifact artifact) throws Exception {
-        return getModuleUri(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion(), artifact.getType());
-    }
-
     public String getModuleUri(MavenProject proj) throws Exception {
-        return getModuleUri(proj.getGroupId(), proj.getArtifactId(), proj.getVersion(), proj.getPackaging());
+        return getModuleUri(proj.getArtifact());
     }
 
-    public String getModuleUri(String groupId, String artifactId, String version, String type) throws Exception {
-        String defaultUri = "/" + getModuleName(groupId, artifactId, version, type);
+    public String getModuleUri(Artifact artifact) throws Exception {
+        String defaultUri = "/" + getModuleName(artifact);
         // both "jar" and "bundle" packaging type project are "jar" type dependencies
         // that will be packaged in the ear lib directory
+        String type = artifact.getType();
         if (("jar".equals(type) || "bundle".equals(type)) && getEarDefaultLibBundleDir() != null) {
             defaultUri = "/" + getEarDefaultLibBundleDir() + defaultUri;
         }
@@ -126,8 +124,8 @@ public class LooseEarApplication extends LooseApplication {
                 Xpp3Dom[] modules = val.getChildren();
                 if (modules != null) {
                     for (int i = 0; i < modules.length; i++) {
-                        if (groupId.equals(getConfigValue(modules[i].getChild("groupId")))
-                                && artifactId.equals(getConfigValue(modules[i].getChild("artifactId")))) {
+                        if (artifact.getGroupId().equals(getConfigValue(modules[i].getChild("groupId")))
+                                && artifact.getArtifactId().equals(getConfigValue(modules[i].getChild("artifactId")))) {
                             String uri = getConfigValue(modules[i].getChild("uri"));
                             if (uri != null) {
                                 return uri;
@@ -159,7 +157,7 @@ public class LooseEarApplication extends LooseApplication {
                                 if (bundleFileName != null) {
                                     return bundleDir + "/" + bundleFileName;
                                 } else {
-                                    return bundleDir + "/" + getModuleName(groupId, artifactId, version, type);
+                                    return bundleDir + "/" + getModuleName(artifact);
                                 }
                             }
                         }
@@ -182,7 +180,15 @@ public class LooseEarApplication extends LooseApplication {
         config.addFile(artifact.getFile(), artifactName);
     }
 
-    public String getModuleName(String groupId, String artifactId, String version, String packaging) {
+    public String getModuleName(Artifact artifact) throws Exception {
+        int earPluginVersion = MavenProjectUtil.getMajorPluginVersion(project, "org.apache.maven.plugins:maven-ear-plugin");
+        if (earPluginVersion < 3) {
+            return getEarFileNameMappingHelper(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion(), artifact.getType());
+        }
+        return getEarOutputFileNameMapping(artifact);
+    }
+
+    public String getEarFileNameMappingHelper(String groupId, String artifactId, String version, String packaging) {
         String moduleName;
 
         String fileExtension = packaging;
@@ -211,7 +217,21 @@ public class LooseEarApplication extends LooseApplication {
         }
         return moduleName;
     }
+    
+    // Valid for maven-ear-plugin version 3 and greater
+    public String getEarOutputFileNameMapping(Artifact artifact) throws Exception {
+        String outputFileNameMapping = MavenProjectUtil.getPluginConfiguration(project, "org.apache.maven.plugins",
+            "maven-ear-plugin", "outputFileNameMapping");
+        String fileNameMapping = MappingUtils.evaluateFileNameMapping( outputFileNameMapping, artifact );
+        if (fileNameMapping == null || fileNameMapping.isEmpty()) {
+            // default format if none is specified
+            String defaultFormat = "@{groupId}@-@{artifactId}@-@{version}@@{dashClassifier?}@.@{extension}@";
+            fileNameMapping = MappingUtils.evaluateFileNameMapping( defaultFormat, artifact );
+        }
+        return fileNameMapping;
+    }
 
+    // Deprecated for maven-ear-plugin version 3 and greater
     public String getEarFileNameMapping() {
         // valid values are: standard, no-version, no-version-for-ejb, full
         String fileNameMapping = MavenProjectUtil.getPluginConfiguration(project, "org.apache.maven.plugins",

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/MavenProjectUtil.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/MavenProjectUtil.java
@@ -171,4 +171,16 @@ public class MavenProjectUtil {
         return null;
     }
 
+     /**
+     * Get major plugin version
+     * @param project
+     * @param pluginKey
+     * @return the major plugin version
+     * @throws PluginScenarioException
+     */
+    public static int getMajorPluginVersion(MavenProject project, String pluginKey) throws PluginScenarioException {
+        Plugin plugin = project.getPlugin(pluginKey);
+        return Character.getNumericValue(plugin.getVersion().charAt(0));
+    }
+
 }


### PR DESCRIPTION
Version 3.0 of the maven-ear-plugin deprecated fileNameMapping.

- Added support for the new outputFileNameMapping while still supporting fileNameMapping. 

Fixes #781