### PR TITLE
Use ant snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ before_install:
     - echo "Deleting old .m2 artifacts..."
     - rm -rf $HOME/.m2/repository/net/wasdev
     - rm -rf $HOME/.m2/repository/io/openliberty
-    - echo 'Installing ci.ant lib...'
-    - git clone https://github.com/OpenLiberty/ci.ant.git ./ci.ant
-    - cd ./ci.ant
-    - mvn clean install
-    - cd ..
+#    - echo 'Installing ci.ant lib...'
+#    - git clone https://github.com/OpenLiberty/ci.ant.git ./ci.ant
+#    - cd ./ci.ant
+#    - mvn clean install
+#    - cd ..
     - echo 'Installing ci.common lib...'
     - git clone https://github.com/OpenLiberty/ci.common.git ./ci.common
     - cd ./ci.common

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,10 +24,10 @@ install:
 before_build:
     - cmd: |
         echo "Installing ci.ant lib..."
-        git clone https://github.com/OpenLiberty/ci.ant.git ci.ant
-        cd ci.ant
-        mvn clean install
-        cd..
+#        git clone https://github.com/OpenLiberty/ci.ant.git ci.ant
+#        cd ci.ant
+#        mvn clean install
+#        cd..
         echo "Installing ci.common lib..."
         git clone https://github.com/OpenLiberty/ci.common.git ci.common
         cd ci.common

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -14,6 +14,21 @@
     <name>liberty-maven-plugin</name>
     <description>Liberty Maven Plugin : Install, Start/Stop, Package, Create Server, Deploy/Undeploy applications</description>
 
+    <pluginRepositories>
+        <!-- Configure Sonatype OSS Maven snapshots repository -->
+        <pluginRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>io.openliberty.tools</groupId>


### PR DESCRIPTION
Update to use ant snapshot so I can release a 3.2.2-SNAPSHOT of liberty-maven-plugin.