### PR TITLE
When using a container generate a loose application relative to a certain root directory.

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
@@ -108,6 +108,11 @@ public class DeployMojoSupport extends PluginConfigSupport {
                     MessageFormat.format(messages.getString("error.project.not.compile"), proj.getId()));
         }
 
+        if (proj.getProperties().containsKey("container") ||
+            (System.getProperty("container") != null)) {
+            config.setProjectRoot(proj.getBasedir().getAbsolutePath());
+        }
+
         LooseWarApplication looseWar = new LooseWarApplication(proj, config);
         looseWar.addSourceDir(proj);
         looseWar.addOutputDir(looseWar.getDocumentRoot(), new File(proj.getBuild().getOutputDirectory()),


### PR DESCRIPTION
For now I've hard coded /devmode but perhaps there is a better name.