### PR TITLE
Add skip info msgs for skip config

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/InstallFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/InstallFeatureSupport.java
@@ -114,6 +114,7 @@ public class InstallFeatureSupport extends BasicSupport {
 
     protected boolean initialize() throws MojoExecutionException {
         if (skip) {
+            log.info("\nSkipping install-feature goal.\n");
             return false;
         }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/InstallFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/InstallFeatureSupport.java
@@ -114,7 +114,7 @@ public class InstallFeatureSupport extends BasicSupport {
 
     protected boolean initialize() throws MojoExecutionException {
         if (skip) {
-            log.info("\nSkipping install-feature goal.\n");
+            getLog().info("\nSkipping install-feature goal.\n");
             return false;
         }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojo.java
@@ -46,6 +46,7 @@ public class DeployMojo extends DeployMojoSupport {
 
     protected void doExecute() throws Exception {
         if (skip) {
+            log.info("\nSkipping deploy goal.\n");
             return;
         }
         checkServerHomeExists();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojo.java
@@ -46,7 +46,7 @@ public class DeployMojo extends DeployMojoSupport {
 
     protected void doExecute() throws Exception {
         if (skip) {
-            log.info("\nSkipping deploy goal.\n");
+            getLog().info("\nSkipping deploy goal.\n");
             return;
         }
         checkServerHomeExists();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/UndeployAppMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/UndeployAppMojo.java
@@ -51,7 +51,7 @@ public class UndeployAppMojo extends DeployMojoSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
-            log.info("\nSkipping undeploy goal.\n");
+            getLog().info("\nSkipping undeploy goal.\n");
             return;
         }
         

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/UndeployAppMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/UndeployAppMojo.java
@@ -51,6 +51,7 @@ public class UndeployAppMojo extends DeployMojoSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
+            log.info("\nSkipping undeploy goal.\n");
             return;
         }
         

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CheckStatusMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CheckStatusMojo.java
@@ -29,6 +29,7 @@ public class CheckStatusMojo extends StartDebugMojoSupport {
 
     protected void doExecute() throws Exception {
         if (skip) {
+            log.info("\nSkipping status goal.\n");
             return;
         }
         if (isInstall) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CheckStatusMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CheckStatusMojo.java
@@ -29,7 +29,7 @@ public class CheckStatusMojo extends StartDebugMojoSupport {
 
     protected void doExecute() throws Exception {
         if (skip) {
-            log.info("\nSkipping status goal.\n");
+            getLog().info("\nSkipping status goal.\n");
             return;
         }
         if (isInstall) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CleanServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CleanServerMojo.java
@@ -52,7 +52,7 @@ public class CleanServerMojo extends StartDebugMojoSupport {
 
     protected void doExecute() throws Exception {
         if (skip) {
-            log.info("\nSkipping clean goal.\n");
+            getLog().info("\nSkipping clean goal.\n");
             return;
         }
         

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CleanServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CleanServerMojo.java
@@ -52,6 +52,7 @@ public class CleanServerMojo extends StartDebugMojoSupport {
 
     protected void doExecute() throws Exception {
         if (skip) {
+            log.info("\nSkipping clean goal.\n");
             return;
         }
         

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CreateServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CreateServerMojo.java
@@ -53,6 +53,7 @@ public class CreateServerMojo extends PluginConfigSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
+            log.info("\nSkipping create goal.\n");
             return;
         }
         if (isInstall) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CreateServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CreateServerMojo.java
@@ -53,7 +53,7 @@ public class CreateServerMojo extends PluginConfigSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
-            log.info("\nSkipping create goal.\n");
+            getLog().info("\nSkipping create goal.\n");
             return;
         }
         if (isInstall) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DebugServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DebugServerMojo.java
@@ -38,7 +38,7 @@ public class DebugServerMojo extends StartDebugMojoSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
-            log.info("\nSkipping debug goal.\n");
+            getLog().info("\nSkipping debug goal.\n");
             return;
         }
         if (isInstall) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DebugServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DebugServerMojo.java
@@ -38,6 +38,7 @@ public class DebugServerMojo extends StartDebugMojoSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
+            log.info("\nSkipping debug goal.\n");
             return;
         }
         if (isInstall) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -688,7 +688,7 @@ public class DevMojo extends StartDebugMojoSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
-            log.info("\nSkipping dev goal.\n");
+            getLog().info("\nSkipping dev goal.\n");
             return;
         }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -688,6 +688,7 @@ public class DevMojo extends StartDebugMojoSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
+            log.info("\nSkipping dev goal.\n");
             return;
         }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DumpServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DumpServerMojo.java
@@ -56,6 +56,7 @@ public class DumpServerMojo extends StartDebugMojoSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
+            log.info("\nSkipping dump goal.\n");
             return;
         }
         if (isInstall) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DumpServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DumpServerMojo.java
@@ -56,7 +56,7 @@ public class DumpServerMojo extends StartDebugMojoSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
-            log.info("\nSkipping dump goal.\n");
+            getLog().info("\nSkipping dump goal.\n");
             return;
         }
         if (isInstall) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallServerMojo.java
@@ -27,7 +27,7 @@ public class InstallServerMojo extends PluginConfigSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
-            log.info("\nSkipping install-server goal.\n");
+            getLog().info("\nSkipping install-server goal.\n");
             return;
         }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallServerMojo.java
@@ -27,6 +27,7 @@ public class InstallServerMojo extends PluginConfigSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
+            log.info("\nSkipping install-server goal.\n");
             return;
         }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/JavaDumpServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/JavaDumpServerMojo.java
@@ -43,6 +43,7 @@ public class JavaDumpServerMojo extends StartDebugMojoSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
+            log.info("\nSkipping java-dump goal.\n");
             return;
         }
         if (isInstall) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/JavaDumpServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/JavaDumpServerMojo.java
@@ -43,7 +43,7 @@ public class JavaDumpServerMojo extends StartDebugMojoSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
-            log.info("\nSkipping java-dump goal.\n");
+            getLog().info("\nSkipping java-dump goal.\n");
             return;
         }
         if (isInstall) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
@@ -132,7 +132,7 @@ public class PackageServerMojo extends StartDebugMojoSupport {
         }
 
         if (skip || skipLibertyPackage) {
-            log.info("\nSkipping package goal.\n");
+            getLog().info("\nSkipping package goal.\n");
             return;
         }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
@@ -132,8 +132,10 @@ public class PackageServerMojo extends StartDebugMojoSupport {
         }
 
         if (skip || skipLibertyPackage) {
+            log.info("\nSkipping package goal.\n");
             return;
         }
+
         if (isInstall) {
             installServerAssembly();
         } else {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -42,7 +42,7 @@ public class RunServerMojo extends PluginConfigSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
-            log.info("\nSkipping run goal.\n");
+            getLog().info("\nSkipping run goal.\n");
             return;
         }
         

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -42,6 +42,7 @@ public class RunServerMojo extends PluginConfigSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
+            log.info("\nSkipping run goal.\n");
             return;
         }
         

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartServerMojo.java
@@ -63,7 +63,7 @@ public class StartServerMojo extends StartDebugMojoSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
-            log.info("\nSkipping start goal.\n");
+            getLog().info("\nSkipping start goal.\n");
             return;
         }
         if (isInstall) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartServerMojo.java
@@ -63,6 +63,7 @@ public class StartServerMojo extends StartDebugMojoSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
+            log.info("\nSkipping start goal.\n");
             return;
         }
         if (isInstall) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StopServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StopServerMojo.java
@@ -37,7 +37,7 @@ public class StopServerMojo extends StartDebugMojoSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
-            log.info("\nSkipping stop goal.\n");
+            getLog().info("\nSkipping stop goal.\n");
             return;
         }
         

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StopServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StopServerMojo.java
@@ -37,6 +37,7 @@ public class StopServerMojo extends StartDebugMojoSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
+            log.info("\nSkipping stop goal.\n");
             return;
         }
         

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/TestStartServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/TestStartServerMojo.java
@@ -38,7 +38,7 @@ public class TestStartServerMojo extends StartServerMojo {
                 || (skipITs != null && skipITs.equalsIgnoreCase("true")) 
                 || (mavenSkipTest != null && mavenSkipTest.equalsIgnoreCase("true"))
                 || skipTestServer){
-            log.info("\nSkipping test-start goal.\n");
+            getLog().info("\nSkipping test-start goal.\n");
             return;
         }
         super.doExecute();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/TestStartServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/TestStartServerMojo.java
@@ -38,6 +38,7 @@ public class TestStartServerMojo extends StartServerMojo {
                 || (skipITs != null && skipITs.equalsIgnoreCase("true")) 
                 || (mavenSkipTest != null && mavenSkipTest.equalsIgnoreCase("true"))
                 || skipTestServer){
+            log.info("\nSkipping test-start goal.\n");
             return;
         }
         super.doExecute();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/TestStopServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/TestStopServerMojo.java
@@ -38,7 +38,7 @@ public class TestStopServerMojo extends StopServerMojo {
                 || (skipITs != null && skipITs.equalsIgnoreCase("true")) 
                 || (mavenSkipTest != null && mavenSkipTest.equalsIgnoreCase("true"))
                 || skipTestServer){
-            log.info("\nSkipping test-stop goal.\n");
+            getLog().info("\nSkipping test-stop goal.\n");
             return;
         }
         super.doExecute();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/TestStopServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/TestStopServerMojo.java
@@ -38,6 +38,7 @@ public class TestStopServerMojo extends StopServerMojo {
                 || (skipITs != null && skipITs.equalsIgnoreCase("true")) 
                 || (mavenSkipTest != null && mavenSkipTest.equalsIgnoreCase("true"))
                 || skipTestServer){
+            log.info("\nSkipping test-stop goal.\n");
             return;
         }
         super.doExecute();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/UninstallFeatureMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/UninstallFeatureMojo.java
@@ -52,7 +52,7 @@ public class UninstallFeatureMojo extends BasicSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
-            log.info("\nSkipping uninstall-feature goal.\n");
+            getLog().info("\nSkipping uninstall-feature goal.\n");
             return;
         }
         

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/UninstallFeatureMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/UninstallFeatureMojo.java
@@ -52,6 +52,7 @@ public class UninstallFeatureMojo extends BasicSupport {
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
+            log.info("\nSkipping uninstall-feature goal.\n");
             return;
         }
         


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Other goals like failsafe/surefire log feedback to the console when they are skipped because of special properties or config, e.g.:

> [INFO] --- maven-failsafe-plugin:2.19.1:verify (default-cli) @ batch-bonuspayout-application ---
> [INFO] Tests are skipped.

But liberty-maven-plugin has a couple mojos which go through a common init then just exit.
What do you think about a log message like this ?

Or would it have to be a translated message?

**NOTE:**  I didn't test this !    Wanted to start the discussion and see if it was OK without a translated message