### PR TITLE
Update default Liberty version range from 18.0.0.1 when generating fr…

### DIFF
--- a/liberty-archetype-ear/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/liberty-archetype-ear/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -13,7 +13,7 @@
             <defaultValue>openliberty-runtime</defaultValue>
         </requiredProperty>
         <requiredProperty key="runtimeVersion">
-            <defaultValue>[18.0.0.1,)</defaultValue>
+            <defaultValue>[20.0.0.4,)</defaultValue>
         </requiredProperty>
         <requiredProperty key="libertyPluginVersion">
             <defaultValue>${project.version}</defaultValue>

--- a/liberty-archetype-ear/src/test/resources/projects/it/archetype.properties
+++ b/liberty-archetype-ear/src/test/resources/projects/it/archetype.properties
@@ -4,5 +4,5 @@ version=1.0-SNAPSHOT
 package=${groupId}
 runtimeGroupId=io.openliberty
 runtimeArtifactId=openliberty-runtime
-runtimeVersion=[18.0.0.1,)
+runtimeVersion=[20.0.0.4,)
 libertyPluginVersion=3.0.1

--- a/liberty-archetype-mp/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/liberty-archetype-mp/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -13,7 +13,7 @@
             <defaultValue>openliberty-runtime</defaultValue>
         </requiredProperty>
         <requiredProperty key="runtimeVersion">
-            <defaultValue>[18.0.0.1,)</defaultValue>
+            <defaultValue>[20.0.0.4,)</defaultValue>
         </requiredProperty>
         <requiredProperty key="libertyPluginVersion">
             <defaultValue>2.2</defaultValue>

--- a/liberty-archetype-mp/src/test/resources/projects/it/archetype.properties
+++ b/liberty-archetype-mp/src/test/resources/projects/it/archetype.properties
@@ -3,6 +3,6 @@ artifactId=MicroProfileSample
 version=0.1-SNAPSHOT
 runtimeGroupId=com.ibm.websphere.appserver.runtime
 runtimeArtifactId=wlp-microProfile1
-runtimeVersion=[18.0.0.1,)
+runtimeVersion=[20.0.0.4,)
 libertyPluginVersion=3.0.1
 package=${groupId}

--- a/liberty-archetype-webapp/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/liberty-archetype-webapp/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -13,7 +13,7 @@
             <defaultValue>openliberty-runtime</defaultValue>
         </requiredProperty>
         <requiredProperty key="runtimeVersion">
-            <defaultValue>[18.0.0.1,)</defaultValue>
+            <defaultValue>[20.0.0.4,)</defaultValue>
         </requiredProperty>
         <requiredProperty key="libertyPluginVersion">
             <defaultValue>${project.version}</defaultValue>

--- a/liberty-archetype-webapp/src/test/resources/projects/it/archetype.properties
+++ b/liberty-archetype-webapp/src/test/resources/projects/it/archetype.properties
@@ -4,5 +4,5 @@ version=0.1-SNAPSHOT
 package=${groupId}
 runtimeGroupId=io.openliberty
 runtimeArtifactId=openliberty-runtime
-runtimeVersion=[18.0.0.1,)
+runtimeVersion=[20.0.0.4,)
 libertyPluginVersion=3.0.1


### PR DESCRIPTION
…om archetype. I guess it doesn't matter if the user says yes to "[18.0.0.1,)" since it is open-ended and will pick up the most recent version, but I think it's just a bit confusing for a new user that doesn't know maven well. Alternatively, maybe consider not asking for a runtimeVersion in interactive mode.

```
$ mvn archetype:generate -DarchetypeGroupId=io.openliberty.tools -DarchetypeArtifactId=liberty-archetype-webapp -DarchetypeVersion=3.2.1 -DgroupId=com.example.liberty -DartifactId=myapp -Dversion=1.0-SNAPSHOT
[...]
runtimeArtifactId: openliberty-runtime
runtimeGroupId: io.openliberty
runtimeVersion: [18.0.0.1,)
 Y: :
```