### PR TITLE
Incorporate feedback from the design review

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
@@ -113,6 +113,8 @@ public class DeployMojoSupport extends PluginConfigSupport {
             // Set up the config to replace the absolute path names with ${variable}/target type references
             config.setProjectRoot(proj.getBasedir().getAbsolutePath());
             config.setSourceOnDiskName("${"+PROJECT_ROOT_NAME+"}");
+            // Set the property to include the variable definition in liberty-plugin-variable-config.xml
+            proj.getProperties().setProperty("liberty.var."+PROJECT_ROOT_NAME, proj.getBasedir().getAbsolutePath());
         }
 
         LooseWarApplication looseWar = new LooseWarApplication(proj, config);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -72,7 +72,7 @@ public class StartDebugMojoSupport extends BasicSupport {
     private static final Pattern pattern = Pattern.compile(LIBERTY_CONFIG_MAVEN_PROPS); 
 
     protected final String PLUGIN_VARIABLE_CONFIG_XML = "configDropins/overrides/liberty-plugin-variable-config.xml";
-    protected final String PROJECT_ROOT_NAME = "io.openliberty.projectRoot";
+    protected final String PROJECT_ROOT_NAME = "io.openliberty.tools.projectRoot";
 
     protected Map<String,String> bootstrapMavenProps = new HashMap<String,String>();  
     protected Map<String,String> envMavenProps = new HashMap<String,String>();  
@@ -327,14 +327,6 @@ public class StartDebugMojoSupport extends BasicSupport {
             bootStrapPropertiesPath = bootstrapPropertiesFile.getCanonicalPath();
         }
 
-        if (project.getProperties().containsKey("container") ||
-            (System.getProperty("container") != null)) {
-            // Define the variable used in the loose app. configuration file.
-            if (serverDirectory.exists()) {
-                appendToBootstrap(bootstrapFile, PROJECT_ROOT_NAME+" = "+project.getBasedir().getAbsolutePath());
-            }
-        }
-
         // copy server.env to server directory if end-user explicitly set it
         File envFile = new File(serverDirectory, "server.env");
         if (!envMavenProps.isEmpty()) {
@@ -442,22 +434,6 @@ public class StartDebugMojoSupport extends BasicSupport {
                     log.warn("The value of the bootstrap property " + key + " is null. Verify if the needed POM properties are set correctly.");
                 }
             }
-        } finally {
-            if (writer != null) {
-                writer.close();
-            }
-        }
-    }
-
-    protected void appendToBootstrap(File bootstrapFile, String line) throws IOException {
-        log.debug("AppendToBootstrap file="+bootstrapFile.getAbsolutePath()+" line="+line);
-        PrintWriter writer = null;
-        try {
-            FileWriter fwriter = new FileWriter(bootstrapFile, true);
-            writer = new PrintWriter(fwriter);
-            writer.println();
-            writer.println(HEADER);
-            writer.println(line);
         } finally {
             if (writer != null) {
                 writer.close();


### PR DESCRIPTION
In the Maven case when we set up the loose app. we can also set a project property to define the variable value in liberty-plugin-variable-config.xml. This is good for locality of code. 

In the Gradle case each task works independently so we do it differently. We must configure the loose app. in the deploy task and configure the variable value in the AbstractServerTask definition. 

If you think the implementations should match better I can change the Maven code to look more like the Gradle code.