### PR TITLE
verify message json format

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
@@ -193,6 +193,7 @@
           <bootstrapProperties>
             <default.http.port>${testServerHttpPort}</default.http.port>
             <default.https.port>${testServerHttpsPort}</default.https.port>
+            <com.ibm.ws.logging.message.format>json</com.ibm.ws.logging.message.format>
           </bootstrapProperties>
         </configuration>
       </plugin>

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
@@ -116,7 +116,7 @@ public class BaseDevTest {
       Thread.sleep(5000);
       assertFalse(checkLogMessage(120000, "CWWKF0011I"));
       if (isDevMode) {
-          assertFalse(checkLogMessage(60000, "Enter key to run tests on demand"));
+         assertFalse(checkLogMessage(60000, "Enter key to run tests on demand"));
       }
 
       // verify that the target directory was created

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
@@ -43,7 +43,8 @@ public class DevTest extends BaseDevTest {
    @Test
    /* simple double check. if failure, check parse in ci.common */
    public void verifyJsonHost() throws Exception {
-      checkLogMessage(2000, "CWWKT0016I"); 
+      checkLogMessage(2000, "CWWKT0016I");   // Verify web app code triggered
+      checkLogMessage(2000, "http:\\/\\/");  // Verify escape char seq passes
    }
 
    @Test

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
@@ -41,14 +41,14 @@ public class DevTest extends BaseDevTest {
    }
 
    @Test
-   public void basicTest() throws Exception {
-      testModifyJavaFile();
+   /* simple double check. if failure, check parse in ci.common */
+   public void verifyJsonHost() throws Exception {
+      checkLogMessage(2000, "CWWKT0016I"); 
    }
 
    @Test
-   public void verifyJsonHostName() throws Exception {
-      // simply verify escaped host exists in logs. parse occurs in ci.common
-      checkLogMessage(60, "CWWKT0016I: Web application available (default_host): http:\\/\\/");
+   public void basicTest() throws Exception {
+      testModifyJavaFile();
    }
 
    @Test

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
@@ -46,6 +46,12 @@ public class DevTest extends BaseDevTest {
    }
 
    @Test
+   public void verifyJsonHostName() throws Exception {
+      // simply verify escaped host exists in logs. parse occurs in ci.common
+      checkLogMessage(60, "CWWKT0016I: Web application available (default_host): http:\\/\\/");
+   }
+
+   @Test
    public void configChangeTest() throws Exception {
       // configuration file change
       File srcServerXML = new File(tempProj, "/src/main/liberty/config/server.xml");


### PR DESCRIPTION
Fix was implemented in ci.common

dev-it/basic-dev-project logging format changed to json from start
add to DevTest verify web app message appears, as parse fails on hostname esc chars in ci.common

