### PR TITLE
Use snapshot for repositories instead of pluginRepositories

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -14,9 +14,9 @@
     <name>liberty-maven-plugin</name>
     <description>Liberty Maven Plugin : Install, Start/Stop, Package, Create Server, Deploy/Undeploy applications</description>
 
-    <pluginRepositories>
+    <repositories>
         <!-- Configure Sonatype OSS Maven snapshots repository -->
-        <pluginRepository>
+        <repository>
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -26,8 +26,8 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </pluginRepository>
-    </pluginRepositories>
+        </repository>
+    </repositories>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
liberty-maven-plugin's pom.xml has the Sonatype snapshots repo configured in its `<pluginRepositories>`.  I don't see any reason for this, since this pom is not using any snapshots for in its `<plugins>` section.  

However, before release, we do have a scenario where `ci.common` is on Sonatype snapshot repo, and it would be good to build `liberty-maven-plugin` using the ci.common snapshot so we don't have to build ci.common ourselves.

Therefore, it seems we should change `<pluginRepositories>` to `<repositories>`.  And since the `<releases><enabled>` flag is false for the snapshot repo, it would only be used for the ci.common snapshot (since that is the only dependency in this pom file that is referring to a SNAPSHOT version).