### PR TITLE
Disable failing tests on Appveyor Windows 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,6 @@ before_build:
 
 build_script:
     - "echo %WLP_VERSION%"
-    - "mvn verify -Pappveyor-windows-its -Dinvoker.streamLogs=true -Druntime=%RUNTIME% -DruntimeVersion=%RUNTIME_VERSION%"
+    - "mvn verify -Ponline-its -Dinvoker.streamLogs=true -Druntime=%RUNTIME% -DruntimeVersion=%RUNTIME_VERSION%"
 
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,6 @@ before_build:
 
 build_script:
     - "echo %WLP_VERSION%"
-    - "mvn verify -Ponline-its -Dinvoker.streamLogs=true -Druntime=%RUNTIME% -DruntimeVersion=%RUNTIME_VERSION%"
+    - "mvn verify -Pappveyor-windows-its -Dinvoker.streamLogs=true -Druntime=%RUNTIME% -DruntimeVersion=%RUNTIME_VERSION%"
 
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,16 +23,16 @@ install:
 
 before_build:
     - cmd: |
-#        echo "Installing ci.ant lib..."
-#        git clone https://github.com/OpenLiberty/ci.ant.git ci.ant
-#        cd ci.ant
-#        mvn clean install
-#        cd..
         echo "Installing ci.common lib..."
         git clone https://github.com/OpenLiberty/ci.common.git ci.common
         cd ci.common
         mvn clean install
         cd..
+#        echo "Installing ci.ant lib..."
+#        git clone https://github.com/OpenLiberty/ci.ant.git ci.ant
+#        cd ci.ant
+#        mvn clean install
+#        cd..
 
 build_script:
     - "echo %WLP_VERSION%"

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -176,50 +176,6 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>appveyor-windows-its</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-invoker-plugin</artifactId>
-                        <version>3.1.0</version>
-                        <configuration>
-                            <debug>false</debug>
-                            <goals>
-                                <goal>install</goal>
-                            </goals>
-                            <projectsDirectory>src/it</projectsDirectory>
-                            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-                            <properties>
-                                <runtime>${runtime}</runtime>
-                                <runtimeGroupId>${runtimeGroupId}</runtimeGroupId>
-                                <runtimeArtifactId>${runtimeArtifactId}</runtimeArtifactId>
-                                <runtimeKernelId>${runtimeKernelId}</runtimeKernelId>
-                                <runtimeVersion>${runtimeVersion}</runtimeVersion>
-                            </properties>
-                            <streamLogs>true</streamLogs>
-                            <profiles>
-                                <profile>online-its</profile>
-                            </profiles>
-                            <streamLogs>true</streamLogs>
-                            <pomExcludes>
-                                <pomExclude>dev-it/pom.xml</pomExclude>
-                            </pomExcludes>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>integration-test</id>
-                                <goals>
-                                    <goal>install</goal>
-                                    <goal>run</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
 
         <!-- Profiles for WLP vs OL -->
         <profile>
@@ -268,6 +224,29 @@
                                 <pomExclude>server-param-default-it/pom.xml</pomExclude>
                                 <pomExclude>server-param-configdir-override-it/pom.xml</pomExclude>
                                 <pomExclude>install-features-it/pom.xml</pomExclude>
+                            </pomExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </pluginManagement>
+        </build>
+    </profile>
+    <profile>
+        <id>appveyor-windows-its</id>
+        <activation>
+        <os>
+            <family>Windows</family>
+        </os>
+        </activation>
+        <build>
+            <pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <configuration>
+                            <pomExcludes>
+                                <pomExclude>dev-it/pom.xml</pomExclude>
                             </pomExcludes>
                         </configuration>
                     </plugin>

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -231,16 +231,29 @@
             </pluginManagement>
         </build>
     </profile>
-    <profile>
-        <id>appveyor-windows-its</id>
-        <activation>
-        <os>
-            <family>Windows</family>
-        </os>
-        </activation>
-        <build>
-            <pluginManagement>
-                <plugins>
+
+    <!-- WLP/OP profiles for windows on appveyor -->
+            <profile>
+            <id>windows-wlp-its</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+                <property>
+                    <name>runtime</name>
+                    <value>wlp</value>
+                </property>
+            </activation>
+            <properties>
+                <runtime>wlp</runtime>
+                <runtimeGroupId>com.ibm.websphere.appserver.runtime</runtimeGroupId>
+                <runtimeArtifactId>wlp-javaee7</runtimeArtifactId>
+                <runtimeKernelId>wlp-kernel</runtimeKernelId>
+                <runtimeVersion>${runtimeVersion}</runtimeVersion>
+            </properties>
+            <build>
+                <pluginManagement>
+                  <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-invoker-plugin</artifactId>
@@ -253,7 +266,50 @@
                 </plugins>
             </pluginManagement>
         </build>
+
+        </profile>
+        <profile>
+            <id>windows-ol-its</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+                <property>
+                    <name>runtime</name>
+                    <value>ol</value>
+                </property>
+            </activation>
+            <properties>
+                <runtime>ol</runtime>
+                <runtimeGroupId>io.openliberty</runtimeGroupId>
+                <runtimeArtifactId>openliberty-runtime</runtimeArtifactId>
+                <runtimeKernelId>openliberty-kernel</runtimeKernelId>
+                <runtimeVersion>${runtimeVersion}</runtimeVersion>
+            </properties>
+            <build>
+                <pluginManagement>
+                  <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <configuration>
+                            <pomExcludes>
+                                <pomExclude>dev-it/pom.xml</pomExclude>
+                                <pomExclude>basic-it/pom.xml</pomExclude>
+                                <pomExclude>assembly-it/pom.xml</pomExclude>
+                                <pomExclude>assembly-with-code-it/pom.xml</pomExclude>
+                                <pomExclude>server-param-pom-override-it/pom.xml</pomExclude>
+                                <pomExclude>server-param-default-it/pom.xml</pomExclude>
+                                <pomExclude>server-param-configdir-override-it/pom.xml</pomExclude>
+                                <pomExclude>install-features-it/pom.xml</pomExclude>
+                            </pomExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </pluginManagement>
+        </build>
     </profile>
+
 
 </profiles>
 

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -261,6 +261,7 @@
                             <configuration>
                                 <pomExcludes>
                                     <pomExclude>dev-it/pom.xml</pomExclude>
+                                    <pomExclude>kernel-install-feature-tests/uninstall-features-it/pom.xml</pomExclude>
                                 </pomExcludes>
                             </configuration>
                         </plugin>

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -176,6 +176,50 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>appveyor-windows-its</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <configuration>
+                            <debug>false</debug>
+                            <goals>
+                                <goal>install</goal>
+                            </goals>
+                            <projectsDirectory>src/it</projectsDirectory>
+                            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                            <properties>
+                                <runtime>${runtime}</runtime>
+                                <runtimeGroupId>${runtimeGroupId}</runtimeGroupId>
+                                <runtimeArtifactId>${runtimeArtifactId}</runtimeArtifactId>
+                                <runtimeKernelId>${runtimeKernelId}</runtimeKernelId>
+                                <runtimeVersion>${runtimeVersion}</runtimeVersion>
+                            </properties>
+                            <streamLogs>true</streamLogs>
+                            <profiles>
+                                <profile>online-its</profile>
+                            </profiles>
+                            <streamLogs>true</streamLogs>
+                            <pomExcludes>
+                                <pomExclude>dev-it/pom.xml</pomExclude>
+                            </pomExcludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <goals>
+                                    <goal>install</goal>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
         <!-- Profiles for WLP vs OL -->
         <profile>

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -69,7 +70,7 @@
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.5.2</version>
-            <scope>provided</scope><!-- annotations are needed only to build the plugin -->
+            <scope>provided</scope>            <!-- annotations are needed only to build the plugin -->
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
@@ -211,29 +212,29 @@
             </properties>
             <build>
                 <pluginManagement>
-                  <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-invoker-plugin</artifactId>
-                        <configuration>
-                            <pomExcludes>
-                                <pomExclude>basic-it/pom.xml</pomExclude>
-                                <pomExclude>assembly-it/pom.xml</pomExclude>
-                                <pomExclude>assembly-with-code-it/pom.xml</pomExclude>
-                                <pomExclude>server-param-pom-override-it/pom.xml</pomExclude>
-                                <pomExclude>server-param-default-it/pom.xml</pomExclude>
-                                <pomExclude>server-param-configdir-override-it/pom.xml</pomExclude>
-                                <pomExclude>install-features-it/pom.xml</pomExclude>
-                            </pomExcludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </pluginManagement>
-        </build>
-    </profile>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-invoker-plugin</artifactId>
+                            <configuration>
+                                <pomExcludes>
+                                    <pomExclude>basic-it/pom.xml</pomExclude>
+                                    <pomExclude>assembly-it/pom.xml</pomExclude>
+                                    <pomExclude>assembly-with-code-it/pom.xml</pomExclude>
+                                    <pomExclude>server-param-pom-override-it/pom.xml</pomExclude>
+                                    <pomExclude>server-param-default-it/pom.xml</pomExclude>
+                                    <pomExclude>server-param-configdir-override-it/pom.xml</pomExclude>
+                                    <pomExclude>install-features-it/pom.xml</pomExclude>
+                                </pomExcludes>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
 
-    <!-- WLP/OP profiles for windows on appveyor -->
-            <profile>
+        <!-- WLP/OP profiles for windows on appveyor -->
+        <profile>
             <id>windows-wlp-its</id>
             <activation>
                 <os>
@@ -253,20 +254,19 @@
             </properties>
             <build>
                 <pluginManagement>
-                  <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-invoker-plugin</artifactId>
-                        <configuration>
-                            <pomExcludes>
-                                <pomExclude>dev-it/pom.xml</pomExclude>
-                            </pomExcludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </pluginManagement>
-        </build>
-
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-invoker-plugin</artifactId>
+                            <configuration>
+                                <pomExcludes>
+                                    <pomExclude>dev-it/pom.xml</pomExclude>
+                                </pomExcludes>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
         <profile>
             <id>windows-ol-its</id>
@@ -288,32 +288,30 @@
             </properties>
             <build>
                 <pluginManagement>
-                  <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-invoker-plugin</artifactId>
-                        <configuration>
-                            <pomExcludes>
-                                <pomExclude>dev-it/pom.xml</pomExclude>
-                                <pomExclude>basic-it/pom.xml</pomExclude>
-                                <pomExclude>assembly-it/pom.xml</pomExclude>
-                                <pomExclude>assembly-with-code-it/pom.xml</pomExclude>
-                                <pomExclude>server-param-pom-override-it/pom.xml</pomExclude>
-                                <pomExclude>server-param-default-it/pom.xml</pomExclude>
-                                <pomExclude>server-param-configdir-override-it/pom.xml</pomExclude>
-                                <pomExclude>install-features-it/pom.xml</pomExclude>
-                            </pomExcludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </pluginManagement>
-        </build>
-    </profile>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-invoker-plugin</artifactId>
+                            <configuration>
+                                <pomExcludes>
+                                    <pomExclude>dev-it/pom.xml</pomExclude>
+                                    <pomExclude>basic-it/pom.xml</pomExclude>
+                                    <pomExclude>assembly-it/pom.xml</pomExclude>
+                                    <pomExclude>assembly-with-code-it/pom.xml</pomExclude>
+                                    <pomExclude>server-param-pom-override-it/pom.xml</pomExclude>
+                                    <pomExclude>server-param-default-it/pom.xml</pomExclude>
+                                    <pomExclude>server-param-configdir-override-it/pom.xml</pomExclude>
+                                    <pomExclude>install-features-it/pom.xml</pomExclude>
+                                </pomExcludes>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
 
-
-</profiles>
-
-<prerequisites>
-    <maven>3.0</maven>
-</prerequisites>
+    <prerequisites>
+        <maven>3.0</maven>
+    </prerequisites>
 </project>

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -261,7 +261,6 @@
                             <configuration>
                                 <pomExcludes>
                                     <pomExclude>dev-it/pom.xml</pomExclude>
-                                    <pomExclude>kernel-install-feature-tests/uninstall-features-it/pom.xml</pomExclude>
                                 </pomExcludes>
                             </configuration>
                         </plugin>

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/pom.xml
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/pom.xml
@@ -45,6 +45,10 @@
         <profile>
             <id>wlp-its</id>
             <activation>
+            <!-- exclude from Windows due to file locking issues -->
+                <os>
+                    <family>unix</family>
+                </os>
                 <property>
                     <name>runtime</name>
                     <value>wlp</value>


### PR DESCRIPTION
Disable known failing tests in Windows testing
- Fix appveyor build script
- Disable dev mode tests on Windows until #742 is resolved.
  - modify or remove these Windows profiles if fixing
- Disable `kernel-install-feature-test/uninstall-features-it` along with the corresponding install on WLP for windows, until #891 is resolved
   - kept failing due to file locking issues
```
[00:25:27] [INFO] [INFO] CWWKF1234E: Feature com.ibm.websphere.appserver.internal.optional.jaxb-2.2 cannot be uninstalled because the file C:\projects\ci-maven\liberty-maven-plugin\target\it\kernel-install-feature-test\uninstall-features-it\target\liberty\wlp\dev\api\spec\com.ibm.websphere.javaee.jaxb.2.2_1.0.41.jar is locked. Stop all running servers and retry the operation.
```