### PR TITLE
Don't strip resource plugin 'resources' parm config

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
@@ -61,7 +61,7 @@ public class ExecuteMojoUtil {
 
     // https://maven.apache.org/plugins/maven-resources-plugin/resources-mojo.html
     private static final ArrayList<String> RESOURCES_PARAMS = new ArrayList<>(Arrays.asList(
-            "outputDirectory", "addDefaultExcludes", "delimiters", "encoding", "escapeString",
+            "outputDirectory", "resources", "addDefaultExcludes", "delimiters", "encoding", "escapeString",
             "escapeWindowsPaths", "fileNameFiltering", "filters", "includeEmptyDirs", 
             "mavenFilteringHints", "nonFilteredFileExtensions", "overwrite", "skip",
             "supportMultiLineFiltering", "useBuildFilters", "useDefaultDelimiters"


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

I think we missed this because:

1. We rely on the doc:
https://maven.apache.org/plugins/maven-resources-plugin/resources-mojo.html
https://maven.apache.org/plugins/maven-resources-plugin/testResources-mojo.html

2.  With the /build/resources plugin, this is a special case, the 'resources' parm is not "required" for the resources goal like it is for testResources... or at least it's a bug / confusion in the resources plugin doc.


Probably would be worth having a test...

Fixes #930 