### PR TITLE
Don't issue warning message if configFile just redundant

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -285,7 +285,7 @@ public class StartDebugMojoSupport extends BasicSupport {
 
         // copy server.xml file to server directory if end-user explicitly set it.
         if (serverXmlFile != null && serverXmlFile.exists()) {
-            if (serverXMLPath != null) {
+            if (serverXMLPath != null && ! serverXmlFile.getCanonicalPath().equals(serverXMLPath)) {
                 log.warn("The " + serverXMLPath + " file is overwritten by the "+serverXmlFile.getCanonicalPath()+" file.");
             }
             Copy copy = (Copy) ant.createTask("copy");


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

It seems alarmist or maybe like something's wrong to get a warning:

> [WARNING] The C:\myapp\src\main\liberty\config\server.xml file is overwritten by the C:\myapp\src\main\liberty\config\server.xml file.

Maybe let's just turn this off if you have the unnecessary config? :

                    <configFile>src/main/liberty/config/server.xml</configFile>
