### PR TITLE
Move copyDependencies to common parameters and all server goals

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -9,40 +9,11 @@ The following are the parameters supported by this goal in addition to the [comm
 | Parameter | Description | Required |
 | --------  | ----------- | -------  |
 | appsDirectory | The server's `apps` or `dropins` directory where the application files should be copied. The default value is set to `apps` if the application is defined in the server configuration, otherwise it is set to `dropins`.  | No |
-| copyDependencies | Copies the specified dependencies to the specified locations. Multiple `dependency` parameters and `dependencyGroup` parameters can be added to the `copyDependencies` configuration. The `location` parameter can be added to the `copyDependencies` or `dependencyGroup` configuration to override the default location, which is the `lib/global` folder of the target server. The `stripVersion` parameter can be added to the `copyDependencies` or `dependencyGroup` configuration to override the default `stripVersion` value, which is `false`. | No |
 | copyLibsDirectory | The optional directory to which loose application dependencies referenced by the loose application configuration file are copied. For example, if you want loose application dependencies to be contained within the build directory, you could set this parameter to `target`. The loose application configuration file will reference this directory for the loose application dependencies instead of the local repository cache. Only applicable when `looseApplication` is set to `true`. | No |
 | deployPackages | The Maven packages to copy to Liberty runtime's application directory. One of `dependencies`, `project` or `all`. The default is `project`.<br>For an ear type project, this parameter is ignored and only the project package is installed. | No |
 | looseApplication | Generate a loose application configuration file representing the Maven project package and copy it to the Liberty server's `apps` or `dropins` directory. The default value is `true`. This parameter is ignored if `deployPackages` is set to `dependencies` or if the project packaging type is neither `war` nor `liberty-assembly`. When using the packaging type `liberty-assembly`, using a combination of `deployPackages` set to `all` or `project` and `looseApplication` set to `true` results in the installation of application code provided in the project without the need of adding additional goals to your POM file. | No |
 | stripVersion | Strip artifact version when copying the application to Liberty runtime's application directory. The default value is `false`. | No |
 | timeout | Maximum time to wait (in seconds) to verify that the deployment has completed successfully. The default value is 40 seconds. | No |
-
-The `copyDependencies` parameter can contain the following parameters.
-
-| Parameter | Description | Required |
-| --------  | ----------- | -------  |
-| dependency | A collection of `dependency` parameters that specify the coordinate of the Maven dependency to copy. | Yes, only when `dependencyGroup` parameter is not set. |
-| dependencyGroup | A collection of `dependencyGroup` parameters that can contain a `location` parameter to override the default location, and multiple `dependency` parameters. | Yes, only when `dependency` parameter is not set. |
-| location | The optional directory to which the dependencies are copied. This can be an absolute path, or a relative path to the target server configuration directory. The default location is the `lib/global` folder of the target server.| No |
-| stripVersion | The optional boolean indicating whether to strip the artifact version when copying the dependency. The default value is `false`.| No |
-
-The `dependencyGroup` parameter within the `copyDependencies` can contain the following parameters.
-
-| Parameter | Description | Required |
-| --------  | ----------- | -------  |
-| dependency | A collection of `dependency` parameters that specify the coordinate of the Maven dependency to copy. | Yes |
-| location | The optional directory to which the dependencies are copied. This can be an absolute path, or a relative path to the target server configuration directory. If not specified, the `location` from the `copyDependencies` is used.| No |
-| stripVersion | The optional boolean indicating whether to strip the artifact version when copying the dependency. If not specified, the `stripVersion` from the `copyDependencies` is used.| No |
-
-The `dependency` parameter within the `copyDependencies` or `dependencyGroup` can contain the following parameters.
-
-| Parameter | Description | Required |
-| --------  | ----------- | -------  |
-| groupId | The groupId of the Maven dependency to be copied. The `artifactId` and `version` are optional. If only `groupId` is specified, all resolved dependencies with a matching `groupId` are copied to the specified or default location along with their transitive dependencies. | Yes |
-| artifactId | The artifactId of the Maven dependency to be copied. If an `artifactId` is specified, the resolved dependency with a matching `groupId` and `artifactId` is copied to the specified or default location along with its transitive dependencies. The `artifactId` may also end with a `*` to match all artifacts that have an `artifactId` that start with the specified string. | No |
-| type | The type of the Maven dependency to be copied. The default is `jar`. | No |
-| version | The version of the Maven dependency to be copied. You must specify the `version` for any dependency that is not configured in the Maven `dependencies` or Maven `dependencyManagement` section of the `pom.xml` file. | No |
-
-When determining which resolved dependencies to copy for the `copyDependencies` configuration, only scopes compile, runtime, system and provided are included. This ensures test scope dependencies are not copied. Please note that dependencies with scope compile, runtime, or system will still be packaged within the application unless configured otherwise. If you do not want the dependency within the application, then consider removing the dependency from the Maven `dependencies` or Maven `dependencyManagement` section of the pom.xml and specify the full coordinate with `version` within a `dependency` in `copyDependencies`. Alternatively, you could change the dependency scope to provided. A dependency that is configured in `copyDependencies` with a `version` will be treated as a 'provided'-scoped dependency in calculating transitive dependencies. The `type` is also defaulted to `jar`. If your scenario is more complex, consider using the `copy` or `copy-dependencies` goal in the `maven-dependency-plugin` instead.
 
 Example:
 Copy the Maven project dependencies.
@@ -116,79 +87,6 @@ Copy the Maven project package.
                             <stripVersion>true</stripVersion>
                             <deployPackages>project</deployPackages>
                             <looseApplication>true</looseApplication>
-                        </configuration>
-                    </execution>
-                    ...
-                </executions>
-                <configuration>
-                   <installDirectory>/opt/ibm/wlp</installDirectory>
-                   <serverName>test</serverName>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-    ...
-</project>
-```
-Copy the Maven project package plus dependencies configured with the `copyDependencies` parameter.
-```xml
-<project>
-    <groupId>wasdev</groupId>
-    <artifactId>SimpleServlet</artifactId>
-    <version>1.0</version>
-    <packaging>war</packaging>
-    ...
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
-            <version>10.15.2.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbyclient</artifactId>
-            <version>10.15.2.0</version>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
-    ...
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.openliberty.tools</groupId>
-                <artifactId>liberty-maven-plugin</artifactId>
-                <executions>
-                    ...
-                    <execution>
-                        <id>deploy</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>deploy</goal>
-                        </goals>
-                        <configuration>
-                            <appsDirectory>apps</appsDirectory>
-                            <stripVersion>true</stripVersion>
-                            <copyDependencies>
-                                <!-- copies the commons-logging:commons-logging:1.0.4 dependency plus transitive dependencies
-                                     to the default location lib/global folder of the target server and does not strip the version. -->
-                                <dependency>
-                                    <groupId>commons-logging</groupId>
-                                    <artifactId>commons-logging</artifactId>
-                                    <version>1.0.4</version>
-                                </dependency>
-                                <!-- copies the org.apache.derby:derby:10.15.2.0 and org.apache.derby:derbyclient:10.15.2.0 
-                                     dependencies plus transitive dependencies to the lib/global/derby folder of the target 
-                                     server and strips the version during the copy. -->
-                                <dependencyGroup>
-                                    <stripVersion>true</stripVersion>
-                                    <location>lib/global/derby</location>
-                                    <dependency>
-                                        <groupId>org.apache.derby</groupId>
-                                        <artifactId>derby*</artifactId>
-                                    </dependency>
-                                </dependencyGroup>
-                            </copyDependencies>
                         </configuration>
                     </execution>
                     ...

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojo.java
@@ -36,9 +36,10 @@ import io.openliberty.tools.common.plugins.config.LooseConfigData;
 import io.openliberty.tools.common.plugins.config.ServerConfigDocument;
 
 /**
- * Copy applications to the specified directory of the Liberty server. The ResolutionScope.COMPILE_PLUS_RUNTIME 
- * includes compile + system + provided + runtime dependencies. The copyDependencies functionality will
- * include dependencies with all those scopes, and transitive dependencies with scope compile + system + runtime. 
+ * Copy applications to the specified directory of the Liberty server. 
+ * The ResolutionScope.COMPILE_PLUS_RUNTIME includes compile + system + provided + runtime dependencies. 
+ * The copyDependencies functionality will include dependencies with all those scopes, and transitive 
+ * dependencies with scope compile + system + runtime. 
  * Provided scope transitive dependencies are not included by default (built-in maven behavior).
  */
 @Mojo(name = "deploy", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
@@ -58,7 +59,6 @@ public class DeployMojo extends DeployMojoSupport {
         // update target server configuration
         copyConfigFiles();
         exportParametersToXml();
-        copyDependencies();
         
         boolean installDependencies = false;
         boolean installProject = false;
@@ -92,118 +92,6 @@ public class DeployMojo extends DeployMojoSupport {
         if (applicationXml.hasChildElements()) {
             log.warn(messages.getString("warn.install.app.add.configuration"));
             applicationXml.writeApplicationXmlDocument(serverDirectory);
-        }
-    }
-
-    private void copyDependencies() throws Exception {
-        if (copyDependencies != null) {
-            List<Dependency> deps = copyDependencies.getDependencies();
-            boolean defaultStripVersion = copyDependencies.isStripVersion();
-            String defaultLocation = copyDependencies.getLocation();
-            File dftLocationFile = new File(defaultLocation);
-
-            if (!dftLocationFile.isAbsolute()) {
-                // relative path
-                dftLocationFile = new File(serverDirectory,defaultLocation);
-            }
-
-            if (!dftLocationFile.exists()) {
-                dftLocationFile.mkdirs();
-            } else if (!dftLocationFile.isDirectory()) {
-                // send config error
-                throw new MojoExecutionException("The copyDependencies location "+ dftLocationFile.getCanonicalPath() +" is not a directory.");
-            }
-
-            String dftLocationPath = dftLocationFile.getCanonicalPath();
-
-            if (!deps.isEmpty()) {      
-                log.debug("copyDependencies to location: "+dftLocationPath);
-            }
-
-            for (Dependency dep : deps) {
-                copyDependencies(dep, null, dftLocationPath, defaultStripVersion);                
-            }
-
-            List<DependencyGroup> depGroups = copyDependencies.getDependencyGroups();
-
-            for (DependencyGroup depGroup : depGroups) {
-                String overrideLocation = depGroup.getLocation();
-                if (overrideLocation != null) {
-                    log.debug("copyDependencies to location: "+ overrideLocation);
-                } else {
-                    log.debug("copyDependencies to location: "+dftLocationPath);
-                }
-                boolean stripVersion = defaultStripVersion;
-                Boolean overrideStripVersion = depGroup.getStripVersion();
-                if (overrideStripVersion != null) {
-                    stripVersion = overrideStripVersion.booleanValue();
-                }
-                List<Dependency> groupDeps = depGroup.getDependencies();
-                for (Dependency dep : groupDeps) {
-                    copyDependencies(dep, overrideLocation, dftLocationPath, stripVersion);                
-                }
-            }
-
-        }
-    }
-
-    private void copyDependencies(Dependency dep, String overrideLocation, String defaultLocation, boolean stripVersion) throws Exception {
-
-        String location = defaultLocation;
-
-        if (overrideLocation != null) {
-            File overrideLocationFile = new File(overrideLocation);
-            if (!overrideLocationFile.isAbsolute()) {
-                // relative path
-                overrideLocationFile = new File(serverDirectory, overrideLocation);
-            }
-
-            location = overrideLocationFile.getCanonicalPath();
-
-            if (!overrideLocationFile.exists()) {
-                overrideLocationFile.mkdirs();
-            } else if (!overrideLocationFile.isDirectory()) {
-                // send config error
-                log.warn("The specified dependency location "+ overrideLocationFile.getCanonicalPath() +" is not a directory. Using default copyDependencies location "+ defaultLocation +" instead.");
-                location = defaultLocation;
-            }
-        }
-
-        Set<Artifact> artifactsToCopy = getResolvedDependencyWithTransitiveDependencies(dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getType());
-
-        if (artifactsToCopy.isEmpty()) {
-            StringBuilder sb = new StringBuilder();
-            sb.append("copyDependencies failed for dependency with groupId "+ dep.getGroupId());
-            String artifactId = dep.getArtifactId();
-            if (artifactId != null) {
-                sb.append(", artifactId "+artifactId);
-            }
-            String version = dep.getVersion();
-            if (version != null) {
-                sb.append(", version "+ version);
-            }
-            sb.append(" and type "+dep.getType());
-            sb.append(". No matching resolved dependencies were found.");
-
-            log.warn(sb.toString());
-        } else {
-            for (Artifact nextArtifact : artifactsToCopy) {
-                File nextFile = nextArtifact.getFile();
-                String targetFileName = nextFile.getName();
-                if (stripVersion) {
-                    targetFileName = stripVersionFromName(targetFileName, nextArtifact.getVersion());
-                }
-           
-                File fileToCopyTo = new File(location, targetFileName);
-
-                Copy copy = (Copy) ant.createTask("copy");
-                copy.setFile(nextFile);
-                copy.setTofile(fileToCopyTo);
-                copy.setOverwrite(true);
-                copy.execute();
-
-                log.info("copyDependencies copied file "+nextFile.getName()+" to location "+location+"/"+targetFileName+".");
-            }
         }
     }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
@@ -61,12 +61,6 @@ public class DeployMojoSupport extends PluginConfigSupport {
     @Parameter(property = "copyLibsDirectory")
     protected File copyLibsDirectory;
 
-    /* 
-     * Define a set of dependencies to copy to the target Liberty server.
-     */
-    @Parameter
-    protected CopyDependencies copyDependencies;
-
     protected ApplicationXmlDocument applicationXml = new ApplicationXmlDocument();
 
     protected void installApp(Artifact artifact) throws Exception {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CopyDependencies.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CopyDependencies.java
@@ -13,16 +13,30 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.openliberty.tools.maven.applications;
+package io.openliberty.tools.maven.server;
 
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.maven.plugins.annotations.Parameter;
 
 /**
- * A collection of Dependency with an optional location.
+ * A class to store a set of CopyDependencies.
  */
-public class DependencyGroup {
+public class CopyDependencies {
+
+    /**
+     * The location to copy dependencies to. This can be a full path, or a path relative to
+     * ${server.config.dir}. The default is ${server.config.dir}/lib/global.
+     */
+    @Parameter
+    private String location = "lib/global";
+
+    /**
+     * Boolean to indicate whether to strip versions from the file names when copying.
+     * The default is false.
+     */
+    @Parameter(defaultValue="false")
+    private Boolean stripVersion;
 
     /**
      * A list of Dependency to copy.
@@ -30,13 +44,10 @@ public class DependencyGroup {
     private List<Dependency> copyDependencyList = new ArrayList<Dependency>();
     
     /**
-     * Optional location to copy the Dependency to. This can be a full path, or a path relative to
-     * ${server.config.dir}. The location in the containing CopyDependencies configuration will be 
-     * used if nothing is specified here.
+     * A list of DependencyGroup to copy.
      */
-    @Parameter
-    private String location = null;
-
+    private List<DependencyGroup> copyDependencyGroupList = new ArrayList<DependencyGroup>();
+    
     public String getLocation() {
         return location;
     }
@@ -45,13 +56,12 @@ public class DependencyGroup {
         this.location = location;
     }
     
-    /**
-     * Boolean to indicate whether to strip versions from the file names when copying.
-     * The stripVersion in the containing CopyDependencies configuration will be 
-     * used if nothing is specified here.
-     */
-    @Parameter
-    private Boolean stripVersion = null;
+    public boolean isStripVersion() {
+        if (this.stripVersion == null) {
+            return false;
+        }
+        return this.stripVersion.booleanValue();
+    }
 
     public Boolean getStripVersion() {
         return this.stripVersion;
@@ -60,6 +70,7 @@ public class DependencyGroup {
     public void setStripVersion(boolean strip) {
         this.stripVersion = new Boolean(strip);
     }
+    
     /**
      * Get all the current Dependency to copy.
      *
@@ -76,6 +87,24 @@ public class DependencyGroup {
      */
     public void addDependency(Dependency dependency) {
         copyDependencyList.add(dependency);
+    }
+
+    /**
+     * Get all the current DependencyGroups to copy.
+     *
+     * @return A list with the DependencyGroup to copy.
+     */
+    public List<DependencyGroup> getDependencyGroups() {
+        return copyDependencyGroupList;
+    }
+
+    /**
+     * Add a DependencyGroup into a list.
+     *
+     * @param DependencyGroup
+     */
+    public void addDependencyGroup(DependencyGroup dependencyGroup) {
+        copyDependencyGroupList.add(dependencyGroup);
     }
 
 }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CreateServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CreateServerMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2019.
+ * (C) Copyright IBM Corporation 2014, 2020.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.MessageFormat;
 
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -29,7 +30,7 @@ import io.openliberty.tools.ant.ServerTask;
 /**
  * Create a liberty server
   */
-@Mojo(name = "create")
+@Mojo(name = "create", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class CreateServerMojo extends PluginConfigSupport {
 
     /**

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DebugServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DebugServerMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2017, 2019.
+ * (C) Copyright IBM Corporation 2017, 2020.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,14 @@ import java.text.MessageFormat;
 
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import io.openliberty.tools.ant.ServerTask;
 
 /**
  * Start a liberty server in debug mode
  */
-@Mojo(name = "debug")
+@Mojo(name = "debug", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 
 public class DebugServerMojo extends StartDebugMojoSupport {
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/Dependency.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/Dependency.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.openliberty.tools.maven.applications;
+package io.openliberty.tools.maven.server;
 
 import org.apache.maven.plugins.annotations.Parameter;
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DependencyGroup.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DependencyGroup.java
@@ -13,30 +13,16 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.openliberty.tools.maven.applications;
+package io.openliberty.tools.maven.server;
 
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.maven.plugins.annotations.Parameter;
 
 /**
- * A class to store a set of CopyDependencies.
+ * A collection of Dependency with an optional location.
  */
-public class CopyDependencies {
-
-    /**
-     * The location to copy dependencies to. This can be a full path, or a path relative to
-     * ${server.config.dir}. The default is ${server.config.dir}/lib/global.
-     */
-    @Parameter
-    private String location = "lib/global";
-
-    /**
-     * Boolean to indicate whether to strip versions from the file names when copying.
-     * The default is false.
-     */
-    @Parameter(defaultValue="false")
-    private Boolean stripVersion;
+public class DependencyGroup {
 
     /**
      * A list of Dependency to copy.
@@ -44,10 +30,13 @@ public class CopyDependencies {
     private List<Dependency> copyDependencyList = new ArrayList<Dependency>();
     
     /**
-     * A list of DependencyGroup to copy.
+     * Optional location to copy the Dependency to. This can be a full path, or a path relative to
+     * ${server.config.dir}. The location in the containing CopyDependencies configuration will be 
+     * used if nothing is specified here.
      */
-    private List<DependencyGroup> copyDependencyGroupList = new ArrayList<DependencyGroup>();
-    
+    @Parameter
+    private String location = null;
+
     public String getLocation() {
         return location;
     }
@@ -56,12 +45,13 @@ public class CopyDependencies {
         this.location = location;
     }
     
-    public boolean isStripVersion() {
-        if (this.stripVersion == null) {
-            return false;
-        }
-        return this.stripVersion.booleanValue();
-    }
+    /**
+     * Boolean to indicate whether to strip versions from the file names when copying.
+     * The stripVersion in the containing CopyDependencies configuration will be 
+     * used if nothing is specified here.
+     */
+    @Parameter
+    private Boolean stripVersion = null;
 
     public Boolean getStripVersion() {
         return this.stripVersion;
@@ -70,7 +60,6 @@ public class CopyDependencies {
     public void setStripVersion(boolean strip) {
         this.stripVersion = new Boolean(strip);
     }
-    
     /**
      * Get all the current Dependency to copy.
      *
@@ -87,24 +76,6 @@ public class CopyDependencies {
      */
     public void addDependency(Dependency dependency) {
         copyDependencyList.add(dependency);
-    }
-
-    /**
-     * Get all the current DependencyGroups to copy.
-     *
-     * @return A list with the DependencyGroup to copy.
-     */
-    public List<DependencyGroup> getDependencyGroups() {
-        return copyDependencyGroupList;
-    }
-
-    /**
-     * Add a DependencyGroup into a list.
-     *
-     * @param DependencyGroup
-     */
-    public void addDependencyGroup(DependencyGroup dependencyGroup) {
-        copyDependencyGroupList.add(dependencyGroup);
     }
 
 }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DumpServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DumpServerMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2019.
+ * (C) Copyright IBM Corporation 2014, 2020.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,14 @@ import java.text.MessageFormat;
 
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import io.openliberty.tools.ant.ServerTask;
 
 /**
  * Dump diagnostic information from the server into an archive.
   */
-@Mojo(name = "dump")
+@Mojo(name = "dump", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class DumpServerMojo extends StartDebugMojoSupport {
 
     /**

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/JavaDumpServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/JavaDumpServerMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2019.
+ * (C) Copyright IBM Corporation 2014, 2020.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,14 @@ import java.text.MessageFormat;
 
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import io.openliberty.tools.ant.ServerTask;
 
 /**
  * Dump diagnostic information from the server JVM.
  */
-@Mojo(name = "java-dump")
+@Mojo(name = "java-dump", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class JavaDumpServerMojo extends StartDebugMojoSupport {
 
     /**

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2019. 
+ * (C) Copyright IBM Corporation 2014, 2020. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,13 +29,14 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import io.openliberty.tools.ant.ServerTask;
 
 /**
  * Package a liberty server
  */
-@Mojo(name = "package", defaultPhase = LifecyclePhase.PACKAGE)
+@Mojo(name = "package", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class PackageServerMojo extends StartDebugMojoSupport {
 
     private enum PackageFileType {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartServerMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2019.
+ * (C) Copyright IBM Corporation 2014, 2020.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,14 @@ import java.text.MessageFormat;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import io.openliberty.tools.ant.ServerTask;
 
 /**
  * Start a liberty server
  */
-@Mojo(name = "start")
+@Mojo(name = "start", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 
 public class StartServerMojo extends StartDebugMojoSupport {
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
@@ -147,8 +147,8 @@ public class ExecuteMojoUtil {
     ));
 
     private static final ArrayList<String> LIBERTY_COMMON_SERVER_PARAMS = new ArrayList<>(
-            Arrays.asList("serverXmlFile", "configDirectory", "bootstrapProperties", "bootstrapPropertiesFile",
-                    "jvmOptions", "jvmOptionsFile", "serverEnvFile", "mergeServerEnv"
+            Arrays.asList("serverXmlFile", "configDirectory", "copyDependencies", "bootstrapProperties", 
+            "bootstrapPropertiesFile", "jvmOptions", "jvmOptionsFile", "serverEnvFile", "mergeServerEnv"
             // executeMojo can not use alias parameters:
             // "configFile", "serverEnv"
             ));
@@ -166,7 +166,7 @@ public class ExecuteMojoUtil {
     static {
         DEPLOY_PARAMS = new ArrayList<>(Arrays.asList(
                 "appsDirectory", "stripVersion", "deployPackages", "timeout", "looseApplication",
-                "copyDependencies", "copyLibsDirectory"
+                "copyLibsDirectory"
                 // executeMojo can not use alias parameters:
                 // "installAppPackages"
                 ));


### PR DESCRIPTION
Related to issue #705 

@scottkurz has asked for the copyDependencies logic to move from the `deploy` goal to the `create` goal to enable scenarios such as this:

For a two-stage Docker build, stage 1 = compile+package WAR + gen Liberty config ,   stage 2 = copy the config & the app on top of the OL base image, we'd have no reason to do a "deploy" in stage 1.. we don't really want to do anything with the server.. we just want the maven props/config => Liberty config generated.

Two things I pointed out with this change are:

1. The copyDependencies logic will need to be called for every server related goal (just like copyConfigFiles is called on every server goal). Between one goal execution and the next, we do not know what may have changed.
2. If the copyDependencies configuration changes, the new dependencies will be copied over but any previously copied dependencies will remain. No clean up will be done (or can be done easily). The user would need to do a `mvn clean`.

I also needed to add `requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME` on many of the server related goals. That had been removed previously with issue #321 and modified again with issue #374.