### PR TITLE
Try to get LMP from pluginManagement if not configured

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -25,41 +25,41 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
 
 import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.HashSet;
 import java.util.Set;
-import java.util.EnumSet;
-import java.util.regex.Pattern;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import javax.xml.transform.TransformerException;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
 
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginManagement;
+import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.tools.ant.taskdefs.Copy;
 import org.apache.tools.ant.types.FileSet;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.twdata.maven.mojoexecutor.MojoExecutor.Element;
 
 import io.openliberty.tools.ant.ServerTask;
+import io.openliberty.tools.common.plugins.config.ServerConfigDropinXmlDocument;
 import io.openliberty.tools.maven.BasicSupport;
 import io.openliberty.tools.maven.utils.ExecuteMojoUtil;
-import io.openliberty.tools.common.plugins.config.ServerConfigDropinXmlDocument;
-
-import org.apache.maven.model.Plugin;
-import org.apache.maven.plugin.BuildPluginManager;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Start/Debug server support.
@@ -189,9 +189,26 @@ public class StartDebugMojoSupport extends BasicSupport {
     protected Plugin getLibertyPlugin() {
         Plugin plugin = project.getPlugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID + ":" + LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
         if (plugin == null) {
+            plugin = getPluginFromPluginManagement(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
+        }
+        if (plugin == null) {
             plugin = plugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID, "LATEST");
         }
         return plugin;
+    }
+
+    protected Plugin getPluginFromPluginManagement(String groupId, String artifactId) {
+        Plugin retVal = null;
+        PluginManagement pm = project.getPluginManagement();
+        if (pm != null) {
+            for (Plugin p : pm.getPlugins()) {
+                if (groupId.equals(p.getGroupId()) && artifactId.equals(p.getArtifactId())) {
+                    retVal = p;
+                    break;
+                }
+            }
+        }
+        return retVal;
     }
 
     protected void runLibertyMojoCreate() throws MojoExecutionException {


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Fixes #780 

I think this might be all that's needed, but maybe should test a bit more.

Note that you have to look carefully to see the problem, since there's plenty of stuff in a maven invocation that works correctly even today, since it's a normal goal invocation in which pluginManagement is applied by core Maven itself, rather than an "inner" or executor, programmatic invocation of maven, for which the problem exists.

E.g. using :

    <configuration>
        <serverName>s1</serverName>
    </configuration>

I see the problem doing liberty:dev in this output:

> [INFO] Running liberty:deploy
> [INFO] CWWKM2102I: Using artifact based assembly archive : io.openliberty:openliberty-kernel:null:20.0.0.11:zip.
> [INFO] CWWKM2102I: Using installDirectory : C:\git\guide-microprofile-reactive-messaging\finish\inventory\target\liberty\wlp.
> [INFO] CWWKM2102I: Using serverName : defaultServer.
> [INFO] CWWKM2102I: Using serverDirectory : C:\git\guide-microprofile-reactive-messaging\finish\inventory\target\liberty\wlp\usr\servers\defaultServer.
> [INFO] Copying 1 file to C:\git\guide-microprofile-reactive-messaging\finish\inventory\target\liberty\wlp\usr\servers\defaultServer
> 

However, my 's1' server is still the thing started... because the start happens from the "outer" invocation.

