### PR TITLE
Get plugins from pluginMgmt if not in project

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -190,6 +190,9 @@ public class StartDebugMojoSupport extends BasicSupport {
     protected Plugin getPlugin(String groupId, String artifactId) {
         Plugin plugin = project.getPlugin(groupId + ":" + artifactId);
         if (plugin == null) {
+            plugin = getPluginFromPluginManagement(groupId, artifactId);
+        }
+        if (plugin == null) {
             plugin = plugin(groupId(groupId), artifactId(artifactId), version("RELEASE"));
         }
         return plugin;


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

This is a similar fix to https://github.com/OpenLiberty/ci.maven/pull/1009.

It is of some value, for plugin invocations like those of the 'failsafe' plugin which aren't part of the WAR lifecycle already.
(See https://maven.apache.org/ref/3.6.3/maven-core/default-bindings.html#Plugin_bindings_for_war_packaging).

If the plugin exists in the project the pluginManagement has always been correctly applied...it was only the case where it didn't exist in the project /build/plugins  that the fix was needed... other things like 'compiler' plugin don't need this fix.