### PR TITLE
Enable ubuntu tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,13 +12,13 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     strategy:
       fail-fast: false
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
-        os: [windows-latest]
+        os: [ubuntu-18.04, windows-latest]
         java: [ 8, 11 ]
         RUNTIME: [ ol, wlp ]
         RUNTIME_VERSION: [ 20.0.0.6, 20.0.0.9 ]


### PR DESCRIPTION
Without Travis CI builds, we need to enable builds for Ubuntu in Github Actions.