### PR TITLE
Generating archive in run based on project packaging type

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -50,7 +50,14 @@ public class RunServerMojo extends PluginConfigSupport {
         runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
         
         if(!looseApplication) {
-            runMojo("org.apache.maven.plugins", "maven-war-plugin", "war");
+            switch (project.getPackaging()) {
+                case "war":
+                    runMojo("org.apache.maven.plugins", "maven-war-plugin", "war");
+                    break;
+                case "ear":
+                    runMojo("org.apache.maven.plugins", "maven-ear-plugin", "ear");
+                    break;
+            }
         }
         
         runLibertyMojoCreate();


### PR DESCRIPTION
Checking the project packaging type when generating the project archive in `liberty:run`.

Fixes #1054 