### PR TITLE
Use getArtifactId() for name used as container image tag.

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -288,7 +288,7 @@ public class DevMojo extends StartDebugMojoSupport {
 
         @Override
         public String getProjectName() {
-            return project.getName();
+            return project.getArtifactId();
         }
 
         @Override


### PR DESCRIPTION
This name is, for now, used only as the tag for the container image. The artifactId is better for this purpose because it is unique in the group, usually shorter, and less likely to use special characters than the <name> string in the POM.