### PR TITLE
Passthrough containerName directly when calling install feature

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -251,7 +251,7 @@ public class StartDebugMojoSupport extends BasicSupport {
         if (features != null) {
             config = Xpp3Dom.mergeXpp3Dom(configuration(features), config);
         }
-        if (project.getProperties().containsKey("container") && containerName != null) {
+        if (containerName != null) {
             config.addChild(element(name("containerName"), containerName).toDom());
         }
         runLibertyMojo("install-feature", config);   


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1066

Do not need to check project properties.  Directly pass through containerName if it is defined.