### PR TITLE
Issue 1048, dev-it test failing

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -261,21 +261,6 @@
                 <runtimeKernelId>wlp-kernel</runtimeKernelId>
                 <runtimeVersion>${runtimeVersion}</runtimeVersion>
             </properties>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-invoker-plugin</artifactId>
-                            <configuration>
-                                <pomExcludes>
-                                    <pomExclude>dev-it/pom.xml</pomExclude>
-                                </pomExcludes>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
         </profile>
         <profile>
             <id>windows-ol-its</id>
@@ -303,7 +288,6 @@
                             <artifactId>maven-invoker-plugin</artifactId>
                             <configuration>
                                 <pomExcludes>
-                                    <pomExclude>dev-it/pom.xml</pomExclude>
                                     <pomExclude>basic-it/pom.xml</pomExclude>
                                     <pomExclude>assembly-it/pom.xml</pomExclude>
                                     <pomExclude>assembly-with-code-it/pom.xml</pomExclude>

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -203,22 +203,6 @@
                 <runtimeKernelId>wlp-kernel</runtimeKernelId>
                 <runtimeVersion>${runtimeVersion}</runtimeVersion>
             </properties>
-            <!-- TEMPORARILY EXCLUDE dev-it for all platforms until issue 1048 is resolved. -->
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-invoker-plugin</artifactId>
-                            <configuration>
-                                <pomExcludes>
-                                    <pomExclude>dev-it/pom.xml</pomExclude>
-                                </pomExcludes>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
         </profile>
         <profile>
             <id>ol-its</id>
@@ -243,8 +227,6 @@
                             <artifactId>maven-invoker-plugin</artifactId>
                             <configuration>
                                 <pomExcludes>
-            <!-- TEMPORARILY EXCLUDE dev-it for all platforms until issue 1048 is resolved. -->
-                                    <pomExclude>dev-it/pom.xml</pomExclude>
                                     <pomExclude>basic-it/pom.xml</pomExclude>
                                     <pomExclude>assembly-it/pom.xml</pomExclude>
                                     <pomExclude>assembly-with-code-it/pom.xml</pomExclude>

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -261,6 +261,21 @@
                 <runtimeKernelId>wlp-kernel</runtimeKernelId>
                 <runtimeVersion>${runtimeVersion}</runtimeVersion>
             </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-invoker-plugin</artifactId>
+                            <configuration>
+                                <pomExcludes>
+                                    <pomExclude>dev-it/pom.xml</pomExclude>
+                                </pomExcludes>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
         <profile>
             <id>windows-ol-its</id>
@@ -288,6 +303,7 @@
                             <artifactId>maven-invoker-plugin</artifactId>
                             <configuration>
                                 <pomExcludes>
+                                    <pomExclude>dev-it/pom.xml</pomExclude>
                                     <pomExclude>basic-it/pom.xml</pomExclude>
                                     <pomExclude>assembly-it/pom.xml</pomExclude>
                                     <pomExclude>assembly-with-code-it/pom.xml</pomExclude>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
@@ -2,11 +2,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-      <groupId>io.openliberty.tools</groupId>
-      <artifactId>liberty-maven-app-parent</artifactId>
-      <version>SUB_VERSION</version>
-  </parent>
 
   <groupId>dev-it-tests</groupId>
   <artifactId>dev-sample-proj</artifactId>


### PR DESCRIPTION
The error message appeared in target/it/dev-it/resources/basic-dev-project/logFile.txt. Instead of a server log the following error appeared:
```
Error: [ERROR] Some problems were encountered while processing the POMs: 

[INFO] [FATAL] Non-resolvable parent POM for dev-it-tests:dev-sample-proj:1.0-SNAPSHOT: Could not find artifact io.openliberty.tools:liberty-maven-app-parent:pom:3.3.4-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 5, column 11 

[INFO] @ 

Error: [ERROR] The build could not read 1 project -> [Help 1] 

Error: [ERROR] 

Error: [ERROR] The project dev-it-tests:dev-sample-proj:1.0-SNAPSHOT (/tmp/temp8418452647211183481/pom.xml) has 1 error 
```
The test case references liberty-maven-app-parent through the &lt;parent> element. However, this test case is a user-mode test which calls "mvn liberty:run". It is not actually part of the plugin so it should not specify that parent. 

The error comes about because the test case runs in a Docker container which has an empty .m2 directory every time. There are no installed jars as may be found on a developer's machine. 

New test run:
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running net.wasdev.wlp.test.dev.it.PollingDevTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 86.623 sec - in net.wasdev.wlp.test.dev.it.PollingDevTest
[INFO] Running net.wasdev.wlp.test.dev.it.DevHotTestingTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 26.669 sec - in net.wasdev.wlp.test.dev.it.DevHotTestingTest
[INFO] Running net.wasdev.wlp.test.dev.it.MPStarterTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.065 sec - in net.wasdev.wlp.test.dev.it.MPStarterTest
[INFO] Running net.wasdev.wlp.test.dev.it.DevTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 73.042 sec - in net.wasdev.wlp.test.dev.it.DevTest
[INFO] Running net.wasdev.wlp.test.dev.it.RunTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 23.751 sec - in net.wasdev.wlp.test.dev.it.RunTest
[INFO] 
[INFO] Results :
[INFO] 
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0
```
