### PR TITLE
Add header to common-server-parameters.md

### DIFF
--- a/docs/common-server-parameters.md
+++ b/docs/common-server-parameters.md
@@ -111,6 +111,7 @@ Example of copying dependencies with the `copyDependencies` parameter:
 </project>
 ```
 
+##### Liberty configuration with Maven properties
 Starting with the 3.1 release of the liberty-maven-plugin, support is added to specify Liberty configuration with Maven properties. Use the following property name formats to update the desired Liberty configuration.
 
 | Property name format | Content generated | File generated | Additional info |


### PR DESCRIPTION
I think the `property name formats` table is super useful, and I'd love to be able to link to it from a blog.

I think making it a header adds an "anchor" so I can link to that specific part of this page...? I couldn't actually check in the preview.