### PR TITLE
Skip dev mode on modules with downstream dependencies, fix ear lifecycle goals

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -704,6 +704,7 @@ public class DevMojo extends StartDebugMojoSupport {
             if (!downstreamProjects.isEmpty()) {
                 log.debug("Downstream projects: " + downstreamProjects);
                 log.info("Running compile for module " + project.getBasedir().getName() + "...");
+                runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
                 runCompileMojoLogWarning();
                 return;
             }
@@ -741,10 +742,10 @@ public class DevMojo extends StartDebugMojoSupport {
             runMojo("org.apache.maven.plugins", "maven-ear-plugin", "generate-application-xml");
             runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
         } else {
-            runCompileMojoLogWarning();
             runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
-            runTestCompileMojoLogWarning();
+            runCompileMojoLogWarning();
             runMojo("org.apache.maven.plugins", "maven-resources-plugin", "testResources");    
+            runTestCompileMojoLogWarning();
         }
 
         sourceDirectory = new File(sourceDirectoryString.trim());


### PR DESCRIPTION
- For multi-module projects, if other modules depend on the current module in the Maven Reactor build order, skip dev mode on the current module but only run resources and compile.  Only run dev mode on module that does not have anything depending on it.
- For `ear` packaging type, only run `generate-application-xml` and `resources` according to the default lifecycle in https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle-bindings-packaging-ear
- Call `resources` before `compile` in general, since that is the order in the default lifecycle for `jar` and `war`