### PR TITLE
Get LMP info from Maven 3's plugin descriptor

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -53,6 +53,7 @@ import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginManagement;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.tools.ant.taskdefs.Copy;
@@ -121,6 +122,12 @@ public class StartDebugMojoSupport extends BasicSupport {
 
     @Parameter
     protected List<String> jvmOptions;
+
+    /**
+     * The current plugin's descriptor. This is auto-filled by Maven 3.
+     */
+    @Parameter( defaultValue = "${plugin}", readonly = true )
+    private PluginDescriptor plugin;
 
     private enum PropertyType {
         BOOTSTRAP("liberty.bootstrap."),
@@ -202,14 +209,19 @@ public class StartDebugMojoSupport extends BasicSupport {
     }
     
     protected Plugin getLibertyPlugin() {
-        Plugin plugin = project.getPlugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID + ":" + LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
-        if (plugin == null) {
-            plugin = getPluginFromPluginManagement(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
+        // Try getting the plugin from Maven 3's plugin descriptor
+        if (plugin != null && plugin.getPlugin() != null) {
+            return plugin.getPlugin();
         }
-        if (plugin == null) {
-            plugin = plugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID, "LATEST");
+        // Otherwise fallback
+        Plugin fallbackPlugin = project.getPlugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID + ":" + LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
+        if (fallbackPlugin == null) {
+            fallbackPlugin = getPluginFromPluginManagement(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
         }
-        return plugin;
+        if (fallbackPlugin == null) {
+            fallbackPlugin = plugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID, "LATEST");
+        }
+        return fallbackPlugin;
     }
 
     protected Plugin getPluginFromPluginManagement(String groupId, String artifactId) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -209,19 +209,23 @@ public class StartDebugMojoSupport extends BasicSupport {
     }
     
     protected Plugin getLibertyPlugin() {
-        // Try getting the plugin from Maven 3's plugin descriptor
+        // Try getting the version from Maven 3's plugin descriptor
+        String version = null;
         if (plugin != null && plugin.getPlugin() != null) {
-            return plugin.getPlugin();
+            version = plugin.getVersion();
+            log.debug("Setting plugin version to " + version);
         }
-        // Otherwise fallback
-        Plugin fallbackPlugin = project.getPlugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID + ":" + LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
-        if (fallbackPlugin == null) {
-            fallbackPlugin = getPluginFromPluginManagement(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
+        Plugin plugin = project.getPlugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID + ":" + LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
+        if (plugin == null) {
+            plugin = getPluginFromPluginManagement(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
         }
-        if (fallbackPlugin == null) {
-            fallbackPlugin = plugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID, "LATEST");
+        if (plugin == null) {
+            plugin = plugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID, "LATEST");
         }
-        return fallbackPlugin;
+        if (version != null) {
+            plugin.setVersion(version);
+        }
+        return plugin;
     }
 
     protected Plugin getPluginFromPluginManagement(String groupId, String artifactId) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -215,17 +215,17 @@ public class StartDebugMojoSupport extends BasicSupport {
             version = plugin.getVersion();
             log.debug("Setting plugin version to " + version);
         }
-        Plugin plugin = project.getPlugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID + ":" + LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
-        if (plugin == null) {
-            plugin = getPluginFromPluginManagement(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
+        Plugin projectPlugin = project.getPlugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID + ":" + LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
+        if (projectPlugin == null) {
+            projectPlugin = getPluginFromPluginManagement(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
         }
-        if (plugin == null) {
-            plugin = plugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID, "LATEST");
+        if (projectPlugin == null) {
+            projectPlugin = plugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID, "LATEST");
         }
         if (version != null) {
-            plugin.setVersion(version);
+            projectPlugin.setVersion(version);
         }
-        return plugin;
+        return projectPlugin;
     }
 
     protected Plugin getPluginFromPluginManagement(String groupId, String artifactId) {


### PR DESCRIPTION
When getting the LMP version for running other LMP goals through MojoExecutor, try using the version from the [plugin descriptor provided by Maven 3](https://maven.apache.org/ref/3.1.1/maven-core/apidocs/org/apache/maven/plugin/PluginParameterExpressionEvaluator.html).  This is because the current running version of the plugin may be different than what is defined in the pom (for example, if the plugin version is specified in the command line).

To reproduce:
1. Clone `devc` branch of https://github.com/OpenLiberty/demo-devmode/tree/devc
2. Change the LMP version in pom.xml to an old version like `3.0`
3. Run `io.openliberty.tools:liberty-maven-plugin:3.3.4:devc` - a WARNING is shown and the app is not deployed properly (because 3.0 did not have the code to handle deploy for containers)
3. Run `io.openliberty.tools:liberty-maven-plugin:3.3.5-SNAPSHOT:devc` with this PR's changes.  The app is deployed properly. 

@scottkurz It would be great if you can review as well since I think you have looked at this code before.