### PR TITLE
Find common project root for multi module loose app

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
@@ -106,7 +106,7 @@ public class DeployMojoSupport extends PluginConfigSupport {
     private void setLooseProjectRootForContainer(MavenProject proj, LooseConfigData config) throws MojoExecutionException {
         try {
             // Set up the config to replace the absolute path names with ${variable}/target type references
-            String projectRoot = multiModuleProjectDirectory == null ? proj.getBasedir().getCanonicalPath() : multiModuleProjectDirectory.getCanonicalPath();
+            String projectRoot = DevUtil.getLooseAppProjectRoot(proj.getBasedir(), multiModuleProjectDirectory).getCanonicalPath();
             config.setProjectRoot(projectRoot);
             config.setSourceOnDiskName("${"+DevUtil.DEVMODE_PROJECT_ROOT+"}");
             if (copyLibsDirectory == null) { // in container mode, copy dependencies from .m2 dir to the target dir to mount in container


### PR DESCRIPTION
In a multi module project, if the projectDirectory and the multiModuleProjectDirectory are different, use the longest common directory as the project root for mounting the loose application files to container.

This allows devc to work in a multi module project with the following layout:
```
+ /parent
   - /pom/pom.xml (contains <module> element pointing to `../ear`) - this is the `multiModuleProjectDirectory`
   - /ear/pom.xml - this is the `projectDirectory`
   - (other files)
```

Loose app should mount /parent as the project root in the above case.

Requires https://github.com/OpenLiberty/ci.common/pull/253