### PR TITLE
Run ear plugin for ear modules when a downstream project depends on it

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -696,6 +696,14 @@ public class DevMojo extends StartDebugMojoSupport {
             return;
         }
 
+        boolean isEar = false;
+        if (project.getPackaging().equals("ear")) {
+            isEar = true;
+
+            // skip unit tests for ear packaging
+            skipUTs = true;
+        }
+
         // If there are downstream projects (e.g. other modules depend on this module in the Maven Reactor build order),
         // then skip dev mode on this module but only run compile.
         ProjectDependencyGraph graph = session.getProjectDependencyGraph();
@@ -703,19 +711,17 @@ public class DevMojo extends StartDebugMojoSupport {
             List<MavenProject> downstreamProjects = graph.getDownstreamProjects(project, true);
             if (!downstreamProjects.isEmpty()) {
                 log.debug("Downstream projects: " + downstreamProjects);
-                log.info("Running compile for module " + project.getBasedir().getName() + "...");
-                runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
-                runCompileMojoLogWarning();
+                if (isEar) {
+                    log.info("Running ear:generate-application-xml for module " + project.getBasedir().getName() + "...");
+                    runMojo("org.apache.maven.plugins", "maven-ear-plugin", "generate-application-xml");
+                    runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
+                } else {
+                    log.info("Running compiler:compile for module " + project.getBasedir().getName() + "...");
+                    runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
+                    runCompileMojoLogWarning();
+                }
                 return;
             }
-        }
-
-        boolean isEar = false;
-        if (project.getPackaging().equals("ear")) {
-            isEar = true;
-
-            // skip unit tests for ear packaging
-            skipUTs = true;
         }
 
         // Check if this is a Boost application

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -712,11 +712,9 @@ public class DevMojo extends StartDebugMojoSupport {
             if (!downstreamProjects.isEmpty()) {
                 log.debug("Downstream projects: " + downstreamProjects);
                 if (isEar) {
-                    log.info("Running ear:generate-application-xml for module " + project.getBasedir().getName() + "...");
                     runMojo("org.apache.maven.plugins", "maven-ear-plugin", "generate-application-xml");
                     runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
                 } else {
-                    log.info("Running compiler:compile for module " + project.getBasedir().getName() + "...");
                     runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
                     runCompileMojoLogWarning();
                 }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
@@ -138,6 +138,15 @@ public class ExecuteMojoUtil {
     // https://maven.apache.org/surefire/maven-surefire-report-plugin/failsafe-report-only-mojo.html
     private static final ArrayList<String> FAILSAFE_REPORT_ONLY_PARAMS = REPORT_ONLY_PARAMS;
 
+    // https://maven.apache.org/plugins/maven-ear-plugin/generate-application-xml-mojo.html
+    private static final ArrayList<String> EAR_GENERATE_APPLICATION_XML_PARAMS = new ArrayList<>(
+            Arrays.asList("outputFileNameMapping", "tempFolder", "workDirectory", "applicationId", "applicationName",
+                    "artifactTypeMappings", "defaultLibBundleDir", "description", "displayName", "ejbRefs", "encoding",
+                    "envEntries", "fileNameMapping", "generateApplicationXml", "generateModuleId",
+                    "generatedDescriptorLocation", "includeLibInApplicationXml", "initializeInOrder", "jboss",
+                    "libraryDirectoryMode", "mainArtifactId", "modules", "resourceRefs", "security", "useBaseVersion",
+                    "version"));
+
     private static final ArrayList<String> LIBERTY_COMMON_PARAMS = new ArrayList<>(Arrays.asList(
             "installDirectory", "assemblyArchive", "assemblyArtifact", "libertyRuntimeVersion",
             "install", "licenseArtifact", "serverName", "userDirectory", "outputDirectory",
@@ -280,6 +289,9 @@ public class ExecuteMojoUtil {
             break;
         case "maven-surefire-report-plugin:failsafe-report-only":
             goalConfig = stripConfigElements(config, FAILSAFE_REPORT_ONLY_PARAMS);
+            break;
+        case "maven-ear-plugin:generate-application-xml":
+            goalConfig = stripConfigElements(config, EAR_GENERATE_APPLICATION_XML_PARAMS);
             break;
         default:
             goalConfig = config;


### PR DESCRIPTION
If a `liberty-assembly` or `pom` typed module (where the server config is located) depends on an `ear` typed module, run the `maven-ear-plugin:generate-application-xml` goal on the `ear` typed module so that the application.xml is generated.  

This is needed so that the loose app xml in the `liberty-assembly` or `pom` typed module can point to the EAR's application.xml, e.g. the loose app would have an entry like `<file sourceOnDisk="/myproject/ear/target/application.xml" targetInArchive="/META-INF/application.xml"/>`