### PR TITLE
Check that artifact paths are not null before appending to them

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -551,14 +551,11 @@ public class DevMojo extends StartDebugMojoSupport {
                 }
 
                 // update classpath for dependencies changes
-                if (compileArtifactPaths != null) {
-                    compileArtifactPaths.clear();
-                    compileArtifactPaths.addAll(project.getCompileClasspathElements());
-                }
-                if (testArtifactPaths != null) {
-                    testArtifactPaths.clear();
-                    testArtifactPaths.addAll(project.getTestClasspathElements());
-                }
+                compileArtifactPaths.clear();
+                compileArtifactPaths.addAll(project.getCompileClasspathElements());
+
+                testArtifactPaths.clear();
+                testArtifactPaths.addAll(project.getTestClasspathElements());
 
                 if (restartServer) {
                     // - stop Server
@@ -808,8 +805,11 @@ public class DevMojo extends StartDebugMojoSupport {
         util.startServer();
 
         // collect artifacts canonical paths in order to build classpath
-        List<String> compileArtifactPaths = project.getCompileClasspathElements(); 
-        List<String> testArtifactPaths = project.getTestClasspathElements();
+        List<String> compileArtifactPaths = new ArrayList<String>();
+        compileArtifactPaths.addAll(project.getCompileClasspathElements());
+
+        List<String> testArtifactPaths = new ArrayList<String>();
+        testArtifactPaths.addAll(project.getTestClasspathElements());
 
         if (hotTests && testSourceDirectory.exists()) {
             // if hot testing, run tests on startup and then watch for

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -551,10 +551,14 @@ public class DevMojo extends StartDebugMojoSupport {
                 }
 
                 // update classpath for dependencies changes
-                compileArtifactPaths.clear();
-                compileArtifactPaths.addAll(project.getCompileClasspathElements());
-                testArtifactPaths.clear();
-                testArtifactPaths.addAll(project.getTestClasspathElements());
+                if (compileArtifactPaths != null) {
+                    compileArtifactPaths.clear();
+                    compileArtifactPaths.addAll(project.getCompileClasspathElements());
+                }
+                if (testArtifactPaths != null) {
+                    testArtifactPaths.clear();
+                    testArtifactPaths.addAll(project.getTestClasspathElements());
+                }
 
                 if (restartServer) {
                     // - stop Server


### PR DESCRIPTION
Adds null check to `artifactPath` lists, to avoid `NullPointerException` that may stop app from recompiling on build file change.
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>