### PR TITLE
Support multi module projects with run goal

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -60,15 +60,17 @@ public class RunServerMojo extends PluginConfigSupport {
             List<MavenProject> downstreamProjects = graph.getDownstreamProjects(project, true);
             if (!downstreamProjects.isEmpty()) {
                 log.debug("Downstream projects: " + downstreamProjects);
-                if (projectPackaging.equals("ear")) {
-                    runMojo("org.apache.maven.plugins", "maven-ear-plugin", "generate-application-xml");
-                    runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
-                } else {
-                    runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
-                    runMojo("org.apache.maven.plugins", "maven-compiler-plugin", "compile");
-                }
                 skipRunServer = true;
             }
+        }
+
+        // Proceed to build this module (regardless of whether Liberty will run on it afterwards)
+        if (projectPackaging.equals("ear")) {
+            runMojo("org.apache.maven.plugins", "maven-ear-plugin", "generate-application-xml");
+            runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
+        } else {
+            runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
+            runMojo("org.apache.maven.plugins", "maven-compiler-plugin", "compile");
         }
 
         if (!looseApplication) {
@@ -96,6 +98,7 @@ public class RunServerMojo extends PluginConfigSupport {
             }
         }
 
+        // Return if Liberty should not be run on this module
         if (skipRunServer) {
             return;
         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -92,7 +92,7 @@ public class RunServerMojo extends PluginConfigSupport {
             } catch (MojoExecutionException e) {
                 if (graph != null && !graph.getUpstreamProjects(project, true).isEmpty()) {
                     // this module is a non-loose app, so warn that any upstream modules must also be set to non-loose
-                    log.warn("The looseApplication parameter was set to false for this module. Ensure all modules use the same value for this parameter by including -DlooseApplication=false in the Maven command from your multi module project.");
+                    log.warn("The looseApplication parameter was set to false for the module with artifactId " + project.getArtifactId() + ". Ensure that all modules use the same value for the looseApplication parameter by including -DlooseApplication=false in the Maven command for your multi module project.");
                     throw e;
                 }
             }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -15,9 +15,14 @@
  */
 package io.openliberty.tools.maven.server;
 
+import java.util.List;
+
+import org.apache.maven.execution.ProjectDependencyGraph;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
 
 import io.openliberty.tools.ant.ServerTask;
 
@@ -47,23 +52,52 @@ public class RunServerMojo extends PluginConfigSupport {
         }
         String projectPackaging = project.getPackaging();
 
-        runMojo("org.apache.maven.plugins", "maven-compiler-plugin", "compile");
-
-        if(projectPackaging.equals("ear")) {
-            runMojo("org.apache.maven.plugins", "maven-ear-plugin", "generate-application-xml");
+        // If there are downstream projects (e.g. other modules depend on this module in the Maven Reactor build order),
+        // then skip running Liberty on this module but only build it.
+        boolean skipRunServer = false;
+        ProjectDependencyGraph graph = session.getProjectDependencyGraph();
+        if (graph != null) {
+            List<MavenProject> downstreamProjects = graph.getDownstreamProjects(project, true);
+            if (!downstreamProjects.isEmpty()) {
+                log.debug("Downstream projects: " + downstreamProjects);
+                if (projectPackaging.equals("ear")) {
+                    runMojo("org.apache.maven.plugins", "maven-ear-plugin", "generate-application-xml");
+                    runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
+                } else {
+                    runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
+                    runMojo("org.apache.maven.plugins", "maven-compiler-plugin", "compile");
+                }
+                skipRunServer = true;
+            }
         }
 
-        runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
-        
-        if(!looseApplication) {
-            switch (projectPackaging) {
-                case "war":
-                    runMojo("org.apache.maven.plugins", "maven-war-plugin", "war");
-                    break;
-                case "ear":
-                    runMojo("org.apache.maven.plugins", "maven-ear-plugin", "ear");
-                    break;
+        if (!looseApplication) {
+            try {
+                switch (projectPackaging) {
+                    case "war":
+                        runMojo("org.apache.maven.plugins", "maven-war-plugin", "war");
+                        break;
+                    case "ear":
+                        runMojo("org.apache.maven.plugins", "maven-ear-plugin", "ear");
+                        break;
+                    case "ejb":
+                        runMojo("org.apache.maven.plugins", "maven-ejb-plugin", "ejb");
+                        break;
+                    case "jar":
+                        runMojo("org.apache.maven.plugins", "maven-jar-plugin", "jar");
+                        break;
+                }
+            } catch (MojoExecutionException e) {
+                if (graph != null && !graph.getUpstreamProjects(project, true).isEmpty()) {
+                    // this module is a non-loose app, so warn that any upstream modules must also be set to non-loose
+                    log.warn("The looseApplication parameter was set to false for this module. Ensure all modules use the same value for this parameter by including -DlooseApplication=false in the Maven command from your multi module project.");
+                    throw e;
+                }
             }
+        }
+
+        if (skipRunServer) {
+            return;
         }
         
         runLibertyMojoCreate();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -35,8 +35,6 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
@@ -147,7 +147,29 @@ public class ExecuteMojoUtil {
                     "includeLibInApplicationXml", "jboss", "mainArtifactId", "modules", "nonFilteredFileExtensions", "outputTimestamp",
                     "packagingExcludes", "packagingIncludes", "skinnyModules", "skinnyWars", "skipClassPathModification", "unpackTypes",
                     "useBaseVersion", "useJvmChmod", "version"));
-            
+
+    // https://maven.apache.org/plugins/maven-jar-plugin/jar-mojo.html
+    private static final ArrayList<String> JAR_PARAMS = new ArrayList<>(
+            Arrays.asList("classesDirectory", "outputDirectory", "archive", "classifier", "excludes", "forceCreation",
+                    "includes", "outputTimestamp", "skipIfEmpty", "useDefaultManifestFile"));
+    
+    // https://maven.apache.org/plugins/maven-ejb-plugin/ejb-mojo.html
+    private static final ArrayList<String> EJB_PARAMS = new ArrayList<>(
+            Arrays.asList("sourceDirectory", "archive", "classifier", "clientClassifier", "clientExcludes",
+                    "clientIncludes", "ejbJar", "ejbVersion", "escapeBackslashesInFilePath", "escapeString", "excludes",
+                    "filterDeploymentDescriptor", "filters", "generateClient", "outputTimestamp"));
+
+    // https://maven.apache.org/plugins/maven-war-plugin/war-mojo.html
+    private static final ArrayList<String> WAR_PARAMS = new ArrayList<>(Arrays.asList("outputDirectory",
+            "warSourceDirectory", "webappDirectory", "workDirectory", "archive", "archiveClasses", "attachClasses",
+            "classesClassifier", "classifier", "containerConfigXML", "delimiters", "dependentWarExcludes",
+            "dependentWarIncludes", "escapeString", "escapedBackslashesInFilePath", "failOnMissingWebXml",
+            "filteringDeploymentDescriptors", "filters", "includeEmptyDirectories", "nonFilteredFileExtensions",
+            "outdatedCheckPath", "outputFileNameMapping", "outputTimestamp", "overlays", "packagingExcludes",
+            "packagingIncludes", "primaryArtifact", "recompressZippedFiles", "resourceEncoding", "skip",
+            "supportMultiLineFiltering", "useDefaultDelimiters", "useJvmChmod", "warSourceExcludes",
+            "warSourceIncludes", "webResources", "webXml"));
+
     // https://maven.apache.org/plugins/maven-ear-plugin/generate-application-xml-mojo.html
     private static final ArrayList<String> EAR_GENERATE_APPLICATION_XML_PARAMS = new ArrayList<>(
             Arrays.asList("outputFileNameMapping", "tempFolder", "workDirectory", "applicationId", "applicationName",
@@ -305,6 +327,15 @@ public class ExecuteMojoUtil {
             break;
         case "maven-ear-plugin:ear":
             goalConfig = stripConfigElements(config, EAR_PARAMS);
+            break;
+        case "maven-jar-plugin:jar":
+            goalConfig = stripConfigElements(config, JAR_PARAMS);
+            break;
+        case "maven-ejb-plugin:ejb":
+            goalConfig = stripConfigElements(config, EJB_PARAMS);
+            break;
+        case "maven-war-plugin:war":
+            goalConfig = stripConfigElements(config, WAR_PARAMS);
             break;
         default:
             goalConfig = config;


### PR DESCRIPTION
For each module, look at the Reactor build to determine if it has any downstream projects (any other modules that depend on it).  If it does, build the module but not actually run Liberty.  Only run Liberty on the module that has no downstream projects.

Usage:

From a multi module project, call the `run` goal like the following (where `module-ear` is the module with Liberty configuration):
`mvn io.openliberty.tools:liberty-maven-plugin:3.3.5-M2-SNAPSHOT:run -pl module-ear -am`

Note that if `<looseApplication>false</looseApplication>` is set in one of the modules, you must set the same value for all modules from the Maven command, e.g.:
`mvn io.openliberty.tools:liberty-maven-plugin:3.3.5-M2-SNAPSHOT:run -pl module-ear -am -DlooseApplication=false`

Fixes https://github.com/OpenLiberty/ci.maven/issues/1148