### PR TITLE
Support hot compilation of test directories and running test for multi module Maven projects

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -879,11 +879,8 @@ public class DevMojo extends StartDebugMojoSupport {
         // pom.xml
         File pom = project.getFile();
 
-
-        if (!(hotTests && testSourceDirectory.exists())) {
-            // if not hot testing, watch for keypresses immediately
-            util.runHotkeyReaderThread(executor);
-        }
+        // start watching for keypresses immediately
+        util.runHotkeyReaderThread(executor);
 
         // Note that serverXmlFile can be null. DevUtil will automatically watch
         // all files in the configDirectory,
@@ -980,7 +977,6 @@ public class DevMojo extends StartDebugMojoSupport {
         ProjectBuildingResult build;
         MavenProject currentProject = project; // default to main project
         try {
-            // TODO consider using Files.isSameFile
             if (buildFile != null && !project.getFile().getCanonicalPath().equals(buildFile.getCanonicalPath())) {
                 build = mavenProjectBuilder.build(buildFile,
                         session.getProjectBuildingRequest().setResolveDependencies(true));

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -501,7 +501,6 @@ public class DevMojo extends StartDebugMojoSupport {
         public boolean updateArtifactPaths(File buildFile, List<String> compileArtifactPaths,
                 List<String> testArtifactPaths, boolean redeployCheck, ThreadPoolExecutor executor) throws PluginExecutionException {
             ProjectBuildingResult build;
-            boolean redeployApp = false;
             try {
                 build = mavenProjectBuilder.build(buildFile,
                         session.getProjectBuildingRequest().setResolveDependencies(true));
@@ -528,11 +527,8 @@ public class DevMojo extends StartDebugMojoSupport {
                     if (!deps.equals(oldDeps)) {
                         // detect compile dependency changes
                         if (!getCompileDependency(deps).equals(getCompileDependency(oldDeps))) {
-                            redeployApp = true;
+                            runLibertyMojoDeploy();
                         }
-                    }
-                    if (redeployApp) {
-                        runLibertyMojoDeploy();
                     }
                 }
             } catch (ProjectBuildingException | DependencyResolutionRequiredException | IOException

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -28,7 +28,6 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -260,7 +259,7 @@ public class DevMojo extends StartDebugMojoSupport {
 
         public DevMojoUtil(File installDir, File userDir, File serverDirectory, File sourceDirectory,
                 File testSourceDirectory, File configDirectory, File projectDirectory, File multiModuleProjectDirectory, List<File> resourceDirs,
-                JavaCompilerOptions compilerOptions, String mavenCacheLocation, Set<UpstreamProject> upstreamProjects) throws IOException {
+                JavaCompilerOptions compilerOptions, String mavenCacheLocation, List<UpstreamProject> upstreamProjects) throws IOException {
             super(new File(project.getBuild().getDirectory()), serverDirectory, sourceDirectory, testSourceDirectory,
                     configDirectory, projectDirectory, multiModuleProjectDirectory, resourceDirs, hotTests, skipTests, skipUTs, skipITs,
                     project.getArtifactId(), serverStartTimeout, verifyTimeout, verifyTimeout,
@@ -747,7 +746,7 @@ public class DevMojo extends StartDebugMojoSupport {
 
         // If there are downstream projects (e.g. other modules depend on this module in the Maven Reactor build order),
         // then skip dev mode on this module but only run compile.
-        Set<MavenProject> upstreamMavenProjects = new HashSet<MavenProject>();
+        List<MavenProject> upstreamMavenProjects = new ArrayList<MavenProject>();
         ProjectDependencyGraph graph = session.getProjectDependencyGraph();
         if (graph != null) {
             List<MavenProject> downstreamProjects = graph.getDownstreamProjects(project, true);
@@ -830,7 +829,7 @@ public class DevMojo extends StartDebugMojoSupport {
         JavaCompilerOptions compilerOptions = getMavenCompilerOptions();
 
         // collect upstream projects
-        Set<UpstreamProject> upstreamProjects = new HashSet<UpstreamProject>();
+        List<UpstreamProject> upstreamProjects = new ArrayList<UpstreamProject>();
         if (!upstreamMavenProjects.isEmpty()) {
             for (MavenProject p : upstreamMavenProjects) {
                 List<String> compileArtifacts = new ArrayList<String>();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -497,12 +497,14 @@ public class DevMojo extends StartDebugMojoSupport {
 
         @Override
         public boolean updateArtifactPaths(File buildFile, List<String> compileArtifactPaths,
-                ThreadPoolExecutor executor) throws PluginExecutionException {
+                List<String> testArtifactPaths, ThreadPoolExecutor executor) throws PluginExecutionException {
             ProjectBuildingResult build;
             try {
                 build = mavenProjectBuilder.build(buildFile,
                         session.getProjectBuildingRequest().setResolveDependencies(true));
                 MavenProject upstreamProject = build.getProject();
+                testArtifactPaths.clear();
+                testArtifactPaths.addAll(upstreamProject.getTestClasspathElements());
                 compileArtifactPaths.clear();
                 compileArtifactPaths.addAll(upstreamProject.getCompileClasspathElements());
             } catch (ProjectBuildingException | DependencyResolutionRequiredException e) {
@@ -858,14 +860,18 @@ public class DevMojo extends StartDebugMojoSupport {
                 Set<UpstreamProject> upstreamProjects = new HashSet<UpstreamProject>();
                 for (MavenProject p : upstreamMavenProjects) {
                     List<String> compileArtifacts = new ArrayList<String>();
+                    List<String> testArtifacts = new ArrayList<String>();
                     Build build = p.getBuild();
                     File upstreamSourceDir = new File(build.getSourceDirectory());
                     File upstreamOutputDir = new File(build.getOutputDirectory());
+                    File upstreamTestSourceDir = new File(build.getTestSourceDirectory());
+                    File upstreamTestOutputDir = new File(build.getTestOutputDirectory());
                     // resource directories
                     List<File> upstreamResourceDirs = getResourceDirectories(p, upstreamOutputDir);
 
                     UpstreamProject upstreamProject = new UpstreamProject(p.getFile(), p.getArtifactId(),
-                            compileArtifacts, upstreamSourceDir, upstreamOutputDir, upstreamResourceDirs);
+                            compileArtifacts, testArtifacts, upstreamSourceDir, upstreamOutputDir,
+                            upstreamTestSourceDir, upstreamTestOutputDir, upstreamResourceDirs);
                     upstreamProjects.add(upstreamProject);
                 }
                 // watch upstream projects for hot compilation if they exist

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -54,6 +54,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
 import org.apache.tools.ant.taskdefs.Copy;
 import org.apache.tools.ant.types.FileSet;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
@@ -206,7 +207,27 @@ public class StartDebugMojoSupport extends BasicSupport {
         }
         return plugin;
     }
-    
+
+    /**
+     * Given the groupId and artifactId get the corresponding plugin for the
+     * specified project
+     * 
+     * @param groupId
+     * @param artifactId
+     * @param currentProject
+     * @return Plugin
+     */
+    protected Plugin getPluginForProject(String groupId, String artifactId, MavenProject currentProject) {
+        Plugin plugin = currentProject.getPlugin(groupId + ":" + artifactId);
+        if (plugin == null) {
+            plugin = getPluginFromPluginManagement(groupId, artifactId);
+        }
+        if (plugin == null) {
+            plugin = plugin(groupId(groupId), artifactId(artifactId), version("RELEASE"));
+        }
+        return plugin;
+    }
+
     protected Plugin getLibertyPlugin() {
         // Try getting the version from Maven 3's plugin descriptor
         String version = null;


### PR DESCRIPTION
See https://github.com/OpenLiberty/ci.common/pull/263 

Supports hot compilation of test directories and running tests for multi module Maven projects.

Regardless of whether the `hotTests=true` flag is set, always start watching for keypresses as soon as the Liberty server has started. The initial run of all tests when `hotTests=true` flag is set is handled by the [processJavaCompilation method](https://github.com/OpenLiberty/ci.common/pull/263/files#diff-d8b4217f048364ad127bea282a1726d1523aa8359775cee2f4b71eec9cba7140R3137-R3146) in DevUtil.