### PR TITLE
Honour skipUTs value that is set in each pom for multi-module projects

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -876,11 +876,10 @@ public class DevMojo extends StartDebugMojoSupport {
 
                 // only force skipping unit test for ear modules otherwise honour existing skip
                 // test params
-                boolean upstreamSkipUTs = skipUTs;
+                boolean upstreamSkipUTs = Boolean.parseBoolean(props.getProperty("skipUTs"));
                 if (p.getPackaging().equals("ear")) {
                     upstreamSkipUTs = true;
                 }
-
                 UpstreamProject upstreamProject = new UpstreamProject(p.getFile(), p.getArtifactId(), compileArtifacts,
                         testArtifacts, upstreamSourceDir, upstreamOutputDir, upstreamTestSourceDir,
                         upstreamTestOutputDir, upstreamResourceDirs, upstreamSkipTests, upstreamSkipUTs,


### PR DESCRIPTION
Fix so that `skipUTs` honours the value set in the individual module pom.xml file. This will match the behaviour we have for `skipTests` and `skipITs`. 

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>