### PR TITLE
Dev mode support for multi module compiler options

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -996,8 +996,8 @@ public class DevMojo extends StartDebugMojoSupport {
     }
 
     /**
-     * Gets a compiler option's value from maven-compiler-plugin's configuration or
-     * project properties.
+     * Gets a compiler option's value from CLI paramaters, maven-compiler-plugin's
+     * configuration or project properties.
      * 
      * @param configuration       The maven-compiler-plugin's configuration from
      *                            pom.xml
@@ -1011,9 +1011,12 @@ public class DevMojo extends StartDebugMojoSupport {
      */
     private String getCompilerOption(Xpp3Dom configuration, String mavenParameterName, String projectPropertyName,
             MavenProject currentProject) {
-        // Plugin configuration takes precedence over project property
         String option = null;
-        if (configuration != null) {
+        // CLI parameter takes precedence over plugin configuration
+        option = session.getUserProperties().getProperty(projectPropertyName);
+
+        // Plugin configuration takes precedence over project property
+        if (option == null && configuration != null) {
             Xpp3Dom child = configuration.getChild(mavenParameterName);
             if (child != null) {
                 option = child.getValue();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -198,14 +198,7 @@ public class StartDebugMojoSupport extends BasicSupport {
      * @return Plugin
      */
     protected Plugin getPlugin(String groupId, String artifactId) {
-        Plugin plugin = project.getPlugin(groupId + ":" + artifactId);
-        if (plugin == null) {
-            plugin = getPluginFromPluginManagement(groupId, artifactId);
-        }
-        if (plugin == null) {
-            plugin = plugin(groupId(groupId), artifactId(artifactId), version("RELEASE"));
-        }
-        return plugin;
+       return getPluginForProject(groupId, artifactId, project);
     }
 
     /**
@@ -220,7 +213,7 @@ public class StartDebugMojoSupport extends BasicSupport {
     protected Plugin getPluginForProject(String groupId, String artifactId, MavenProject currentProject) {
         Plugin plugin = currentProject.getPlugin(groupId + ":" + artifactId);
         if (plugin == null) {
-            plugin = getPluginFromPluginManagement(groupId, artifactId);
+            plugin = getPluginFromPluginManagement(groupId, artifactId, currentProject);
         }
         if (plugin == null) {
             plugin = plugin(groupId(groupId), artifactId(artifactId), version("RELEASE"));
@@ -237,7 +230,7 @@ public class StartDebugMojoSupport extends BasicSupport {
         }
         Plugin projectPlugin = project.getPlugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID + ":" + LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
         if (projectPlugin == null) {
-            projectPlugin = getPluginFromPluginManagement(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
+            projectPlugin = getPluginFromPluginManagement(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID, project);
         }
         if (projectPlugin == null) {
             projectPlugin = plugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID, LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID, "LATEST");
@@ -248,9 +241,9 @@ public class StartDebugMojoSupport extends BasicSupport {
         return projectPlugin;
     }
 
-    protected Plugin getPluginFromPluginManagement(String groupId, String artifactId) {
+    protected Plugin getPluginFromPluginManagement(String groupId, String artifactId, MavenProject currentProject) {
         Plugin retVal = null;
-        PluginManagement pm = project.getPluginManagement();
+        PluginManagement pm = currentProject.getPluginManagement();
         if (pm != null) {
             for (Plugin p : pm.getPlugins()) {
                 if (groupId.equals(p.getGroupId()) && artifactId.equals(p.getArtifactId())) {


### PR DESCRIPTION
Fixes #1159 
- Dev mode will honour the Maven compiler options set for multi module projects
- Dev mode will watch the pom.xml (single module and multi module projects) for changes to the Maven compiler options. Any changes will take effect on future compilation calls. Marked as a "TODO" is to recompile the entire module when there is a change to the Maven compiler options. 
- Any Maven compiler options set via CLI params (`-Dmaven.compiler.source=1.8`) will take precedence over options set via Maven compiler plugin configuration or properties defined in the `pom.xml`. This matches the behaviour of `mvn install`. This affects both single module and multi module projects.