### PR TITLE
Skip dev/run on top-level multi module project if it already ran in a module

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -810,33 +810,8 @@ public class DevMojo extends StartDebugMojoSupport {
                 upstreamMavenProjects.addAll(graph.getUpstreamProjects(project, true));
             }
 
-            // If there was a previous module without downstream projects, assume dev mode already ran.
-            // Then if THIS module is a top-level multi module pom that includes that other module, skip THIS module.
-            List<MavenProject> allReactorProjects = graph.getAllProjects();
-            MavenProject mostDownstreamModule = null;
-            for (MavenProject reactorProject : allReactorProjects) {
-                if (graph.getDownstreamProjects(reactorProject, true).isEmpty()) {
-                    mostDownstreamModule = reactorProject;
-                    break;
-                }
-                // Stop if reach the current module in Reactor build order
-                if (reactorProject.equals(project)) {
-                    break;
-                }
-            }
-            log.debug("Module without downstream dependencies: " + mostDownstreamModule);
-            if (mostDownstreamModule != null && !mostDownstreamModule.equals(project)) {
-                log.debug("Found a previous module in the Reactor build order that does not have downstream dependencies.");
-                List<String> multiModules = project.getModules();
-                if (multiModules != null) {
-                    for (String module : multiModules) {
-                        // If this multi module pom contains the previous module which does not have downstream dependencies
-                        if (new File(project.getBasedir(), module).equals(mostDownstreamModule.getBasedir())) {
-                            log.debug("Detected that this multi module pom contains another module that does not have downstream dependencies. Skipping dev goal on this module.");
-                            return;
-                        }
-                    }
-                }
+            if (containsPreviousDownstreamModule(graph)) {
+                return;
             }
         }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -62,6 +62,12 @@ public class RunServerMojo extends PluginConfigSupport {
                 log.debug("Downstream projects: " + downstreamProjects);
                 skipRunServer = true;
             }
+
+            if (containsPreviousDownstreamModule(graph)) {
+                // Assuming Liberty already ran on a previous module without downstream
+                // dependencies, return immediately.
+                return;
+            }
         }
 
         // Proceed to build this module (regardless of whether Liberty will run on it afterwards)

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -863,18 +863,17 @@ public class StartDebugMojoSupport extends BasicSupport {
         List<MavenProject> allReactorProjects = graph.getAllProjects();
         MavenProject mostDownstreamModule = null;
         for (MavenProject reactorProject : allReactorProjects) {
+            // Stop if reached the current module in Reactor build order
+            if (reactorProject.equals(project)) {
+                break;
+            }
             if (graph.getDownstreamProjects(reactorProject, true).isEmpty()) {
                 mostDownstreamModule = reactorProject;
                 break;
             }
-            // Stop if reach the current module in Reactor build order
-            if (reactorProject.equals(project)) {
-                break;
-            }
         }
-        log.debug("Module without downstream dependencies: " + mostDownstreamModule);
         if (mostDownstreamModule != null && !mostDownstreamModule.equals(project)) {
-            log.debug("Found a previous module in the Reactor build order that does not have downstream dependencies.");
+            log.debug("Found a previous module in the Reactor build order that does not have downstream dependencies: " + mostDownstreamModule);
             List<String> multiModules = project.getModules();
             if (multiModules != null) {
                 for (String module : multiModules) {


### PR DESCRIPTION
If the current module has a `<modules>` definition for another module that does not have any downstream modules, assume Liberty dev/run already ran on that other module.  Then skip the dev/run goal on the current module.

Fixes https://github.com/OpenLiberty/ci.maven/issues/1158