### PR TITLE
Detect if user needs to include -pl for multi module dev/run

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -793,6 +793,11 @@ public class DevMojo extends StartDebugMojoSupport {
         List<MavenProject> upstreamMavenProjects = new ArrayList<MavenProject>();
         ProjectDependencyGraph graph = session.getProjectDependencyGraph();
         if (graph != null) {
+            if (hasMultipleLibertyModules(graph)) {
+                // skip all modules
+                return;
+            }
+
             List<MavenProject> downstreamProjects = graph.getDownstreamProjects(project, true);
 
             if (!downstreamProjects.isEmpty()) {
@@ -810,7 +815,8 @@ public class DevMojo extends StartDebugMojoSupport {
                 upstreamMavenProjects.addAll(graph.getUpstreamProjects(project, true));
             }
 
-            if (containsPreviousDownstreamModule(graph)) {
+            if (containsPreviousLibertyModule(graph)) {
+                // skip this module
                 return;
             }
         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -793,10 +793,7 @@ public class DevMojo extends StartDebugMojoSupport {
         List<MavenProject> upstreamMavenProjects = new ArrayList<MavenProject>();
         ProjectDependencyGraph graph = session.getProjectDependencyGraph();
         if (graph != null) {
-            if (hasMultipleLibertyModules(graph)) {
-                // skip all modules
-                return;
-            }
+            checkMultiModuleConflicts(graph);
 
             List<MavenProject> downstreamProjects = graph.getDownstreamProjects(project, true);
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -57,10 +57,7 @@ public class RunServerMojo extends PluginConfigSupport {
         boolean skipRunServer = false;
         ProjectDependencyGraph graph = session.getProjectDependencyGraph();
         if (graph != null) {
-            if (hasMultipleLibertyModules(graph)) {
-                // skip all modules
-                return;
-            }
+            checkMultiModuleConflicts(graph);
 
             List<MavenProject> downstreamProjects = graph.getDownstreamProjects(project, true);
             if (!downstreamProjects.isEmpty()) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -57,15 +57,19 @@ public class RunServerMojo extends PluginConfigSupport {
         boolean skipRunServer = false;
         ProjectDependencyGraph graph = session.getProjectDependencyGraph();
         if (graph != null) {
+            if (hasMultipleLibertyModules(graph)) {
+                // skip all modules
+                return;
+            }
+
             List<MavenProject> downstreamProjects = graph.getDownstreamProjects(project, true);
             if (!downstreamProjects.isEmpty()) {
                 log.debug("Downstream projects: " + downstreamProjects);
                 skipRunServer = true;
             }
 
-            if (containsPreviousDownstreamModule(graph)) {
-                // Assuming Liberty already ran on a previous module without downstream
-                // dependencies, return immediately.
+            if (containsPreviousLibertyModule(graph)) {
+                // skip this module
                 return;
             }
         }


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1173

Check the Reactor build order for conflicts and fail with an error (to tell user to use -pl and -am) if conflict occurs.  A conflict is multiple modules that do not have downstream modules depending on them, and are not submodules of each other.

Also use getSortedProjects() instead of getAllProjects() from ProjectDependencyGraph, so that it only gets projects from the current Reactor build order (limited to things from -pl and -am if specified).