### PR TITLE
Add integration tests for dev mode with multi module

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/pom.xml
@@ -32,6 +32,11 @@
             <version>3.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.10.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/.gitignore
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/.gitignore
@@ -1,0 +1,5 @@
+**/target
+**/.classpath
+**/.project
+**/.settings
+**/.DS_Store

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/LICENSE
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/LICENSE
@@ -1,0 +1,601 @@
+Code and build scripts are licensed under the Eclipse Public License v1
+
+Documentation files (e.g. files with an adoc file extension) are licensed under
+Creative Commons Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and documentation
+   distributed under this Agreement, and
+b) in the case of each subsequent Contributor:
+    i) changes to the Program, and
+   ii) additions to the Program;
+
+   where such changes and/or additions to the Program originate from and are
+   distributed by that particular Contributor. A Contribution 'originates'
+   from a Contributor if it was added to the Program by such Contributor
+   itself or anyone acting on such Contributor's behalf. Contributions do not
+   include additions to the Program which: (i) are separate modules of
+   software distributed in conjunction with the Program under their own
+   license agreement, and (ii) are not derivative works of the Program.
+
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+  a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+  b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+  c) Recipient understands that although each Contributor grants the licenses
+     to its Contributions set forth herein, no assurances are provided by any
+     Contributor that the Program does not infringe the patent or other
+     intellectual property rights of any other entity. Each Contributor
+     disclaims any liability to Recipient for claims brought by any other
+     entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+  d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+  a) it complies with the terms and conditions of this Agreement; and
+  b) its license agreement:
+      i) effectively disclaims on behalf of all Contributors all warranties
+         and conditions, express and implied, including warranties or
+         conditions of title and non-infringement, and implied warranties or
+         conditions of merchantability and fitness for a particular purpose;
+     ii) effectively excludes on behalf of all Contributors all liability for
+         damages, including direct, indirect, special, incidental and
+         consequential damages, such as lost profits;
+    iii) states that any provisions which differ from this Agreement are
+         offered by that Contributor alone and not by any other party; and
+     iv) states that source code for the Program is available from such
+         Contributor, and informs licensees how to obtain it in a reasonable
+         manner on or through a medium customarily used for software exchange.
+
+When the Program is made available in source code form:
+
+  a) it must be made available under this Agreement; and
+  b) a copy of this Agreement must be included with each copy of the Program.
+     Contributors may not remove or alter any copyright notices contained
+     within the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if
+any, in a manner that reasonably allows subsequent Recipients to identify the
+originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must:
+a) promptly notify the Commercial Contributor in writing of such claim, and
+b) allow the Commercial Contributor to control, and cooperate with the
+Commercial Contributor in, the defense and any related settlement
+negotiations. The Indemnified Contributor may participate in any such claim at
+its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial in
+any resulting litigation.
+
+--------------------------------------------------------------------------------
+
+Attribution-NoDerivatives 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+	wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More_considerations
+     for the public:
+	wiki.creativecommons.org/Considerations_for_licensees
+
+
+=======================================================================
+
+Creative Commons Attribution-NoDerivatives 4.0 International Public
+License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-NoDerivatives 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  c. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  d. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  e. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  f. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  g. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  h. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  i. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  j. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce and reproduce, but not Share, Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material, You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+          For the avoidance of doubt, You do not have permission under
+          this Public License to Share Adapted Material.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database, provided You do not Share
+     Adapted Material;
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multiModuleTestCases.md
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multiModuleTestCases.md
@@ -1,0 +1,40 @@
+## Multi module project layouts
+
+a)  pom, ear+war+jar
+- Server info in ear module
+- Main pom: ./pom.xml
+- Tests exist in every module
+
+a.2) pom folder at the same level as (sibling folder of) ear+war+jar
+- Server info in ear module
+ - Main pom: ./pom/pom.xml
+
+b)  pom, war+jar
+- Server info in war module
+- Main pom: ./pom.xml
+
+e)  pom, liberty-assembly+ear+war+jar    
+- Server info in pom module
+- Main pom: ./pom.xml
+- For devc, use -Ddockerfile=../Dockerfile
+- Tests exist in every module
+
+g)  pom,  server(pom)+ear+war+jar    
+- Server info in pom module
+- Main pom: ./pom.xml
+- For devc, use -Ddockerfile=../Dockerfile
+
+h)  server(pom)+ear+war+jar    
+- Server info in pom module
+- Main pom: ./pom/pom.xml
+- For devc, use -Ddockerfile=../Dockerfile
+
+i)   same as (a) but "ear" project has a `<parent>` which is not the "pom" project
+- Server info in ear module
+- Main pom: ./pom.xml
+
+j) server(pom)+war1+war2+jar
+- Server info in pom module
+- Main pom: ./pom.xml
+- For devc, use -Ddockerfile=../Dockerfile
+- This project contains two web applications, war1 (/converter1) and war2 (/converter2)

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/Dockerfile
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/Dockerfile
@@ -1,0 +1,8 @@
+FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+
+# Add config
+COPY --chown=1001:0  target/liberty/wlp/usr/servers/defaultServer/server.xml /config/
+COPY --chown=1001:0  target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/liberty-plugin-variable-config.xml /config/configDropins/overrides/
+
+# Add application
+COPY --chown=1001:0  target/guide-maven-multimodules-ear.ear /config/apps/ 

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
@@ -1,0 +1,116 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-ear</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>ear</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Liberty configuration -->
+        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <!-- Test Configuration -->
+        <!-- <skipTests>true</skipTests> -->
+        <!-- <skipITs>true</skipITs> -->
+        <!-- <skipUTs>true</skipUTs> -->
+    </properties>
+
+    <dependencies>
+        <!-- web and jar modules as dependencies -->
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-war</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>war</type>
+        </dependency>
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <modules>
+                        <jarModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-jar</artifactId>
+                            <uri>/guide-maven-multimodules-jar-1.0-SNAPSHOT.jar</uri>
+                        </jarModule>
+                        <webModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-war</artifactId>
+                            <uri>/guide-maven-multimodules-war-1.0-SNAPSHOT.war</uri>
+                            <!-- Set custom context root -->
+                            <contextRoot>/converter</contextRoot>
+                        </webModule>
+                    </modules>
+                </configuration>
+            </plugin>
+
+            <!-- Enable liberty-maven plugin -->
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.3.5-M2-SNAPSHOT</version>
+            </plugin>
+
+            <!-- Since the package type is ear,
+            need to run testCompile to compile the tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Plugin to run integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <default.http.port>
+                            ${liberty.var.default.http.port}
+                        </default.http.port>
+                        <default.https.port>
+                            ${liberty.var.default.https.port}
+                        </default.https.port>
+                        <cf.context.root>/converter</cf.context.root>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
@@ -75,7 +75,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.3.5-M2-SNAPSHOT</version>
+                <version>SUB_VERSION</version>
             </plugin>
 
             <!-- Since the package type is ear,

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/src/main/liberty/config/server.xml
@@ -1,0 +1,16 @@
+<server description="Sample Liberty server">
+
+    <featureManager>
+        <feature>jsp-2.3</feature>
+    </featureManager>
+
+    <variable name="default.http.port" defaultValue="9080" />
+    <variable name="default.https.port" defaultValue="9443" />
+
+    <httpEndpoint host="*" httpPort="${default.http.port}"
+        httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+
+    <enterpriseApplication id="guide-maven-multimodules-ear"
+        location="guide-maven-multimodules-ear.ear"
+        name="guide-maven-multimodules-ear" />
+</server>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/src/test/java/it/io/openliberty/guides/multimodules/ConverterAppIT.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/src/test/java/it/io/openliberty/guides/multimodules/ConverterAppIT.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package it.io.openliberty.guides.multimodules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+public class ConverterAppIT {
+    String port = System.getProperty("default.http.port");
+    String war = "converter";
+    String urlBase = "http://localhost:" + port + "/" + war + "/";
+
+    @Test
+    public void testIndexPage() throws Exception {
+        String url = this.urlBase;
+        HttpURLConnection con = testRequestHelper(url, "GET");
+        assertEquals(200, con.getResponseCode(), "Incorrect response code from " + url);
+        assertTrue(testBufferHelper(con).contains("Enter the height in centimeters"),
+                        "Incorrect response from " + url);
+    }
+
+    @Test
+    public void testHeightsPage() throws Exception {
+        String url = this.urlBase + "heights.jsp?heightCm=10";
+        HttpURLConnection con = testRequestHelper(url, "POST");
+        assertTrue(testBufferHelper(con).contains("3        inches"),
+                        "Incorrect response from " + url);
+    }
+
+    private HttpURLConnection testRequestHelper(String url, String method)
+                    throws Exception {
+        URL obj = new URL(url);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        // optional default is GET
+        con.setRequestMethod(method);
+        return con;
+    }
+
+    private String testBufferHelper(HttpURLConnection con) throws Exception {
+        BufferedReader in = new BufferedReader(
+                        new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        return response.toString();
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/jar/pom.xml
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-jar</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Surefire plugin to run unit tests --> 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.lib;
+
+public class Converter {
+
+    public static int getFeet(int cm) {
+        int feet = (int) (cm / 30.48);
+        return feet;
+    }
+
+    public static int getInches(int cm) {
+        double feet = cm / 30.48;
+        int inches = (int) (cm / 2.54) - ((int) feet * 12);
+        return inches;
+    }
+
+    public static int sum(int a, int b) {
+        return a + b;
+    }
+
+    public static int diff(int a, int b) {
+        return a - b;
+    }
+
+    public static int product(int a, int b) {
+        return a * b;
+    }
+
+    public static int quotient(int a, int b) {
+        return a / b;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/jar/src/test/java/io/openliberty/guides/multimodules/lib/ConverterUnitTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/jar/src/test/java/io/openliberty/guides/multimodules/lib/ConverterUnitTest.java
@@ -1,0 +1,15 @@
+package io.openliberty.guides.multimodules.lib;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConverterUnitTest {
+
+    @Test
+    public void testHeightFeet() {
+        int feet = Converter.getFeet(61);
+        assertEquals(2, feet);
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/pom.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>jar</module>
+        <module>war</module>
+        <module>ear</module>
+    </modules>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/pom.xml
@@ -1,0 +1,81 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-war</artifactId>
+    <packaging>war</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>guide-maven-multimodules-war</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Test Configuration -->
+        <!-- <skipTests>true</skipTests> -->
+        <!-- <skipITs>true</skipITs> -->
+        <!-- <skipUTs>true</skipUTs> -->
+    </properties>
+
+    <dependencies>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>9.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>3.3</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Plugin to run integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <!-- Surefire plugin to run unit tests --> 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.web;
+
+public class HeightsBean implements java.io.Serializable {
+    private String heightCm = null;
+    private String heightFeet = null;
+    private String heightInches = null;
+    private int cm = 0;
+    private int feet = 0;
+    private int inches = 0;
+
+    public HeightsBean() {
+
+    }
+
+    // Capitalize the first letter of the name i.e. first letter after get
+    // If first letter is not capitalized, it must match the property name in
+    // index.jsp
+    public String getHeightCm() {
+        return heightCm;
+    }
+
+    public String getHeightFeet() {
+        return heightFeet;
+    }
+
+    public String getHeightInches() {
+        return heightInches;
+    }
+
+    public void setHeightCm(String heightcm) {
+        this.heightCm = heightcm;
+    }
+
+    // Need an input as placeholder, you can choose not to use the input
+    public void setHeightFeet(String heightfeet) {
+        this.cm = Integer.valueOf(heightCm);
+        this.feet = io.openliberty.guides.multimodules.lib.Converter.getFeet(cm);
+        String result = String.valueOf(feet);
+        this.heightFeet = result;
+    }
+
+    public void setHeightInches(String heightinches) {
+        this.cm = Integer.valueOf(heightCm);
+        this.inches = io.openliberty.guides.multimodules.lib.Converter.getInches(cm);
+        String result = String.valueOf(inches);
+        this.heightInches = result;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/src/main/resources/META-INF/MANIFEST.mf
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/src/main/resources/META-INF/MANIFEST.mf
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Ant-Version: Apache Ant 1.7.1
+Created-By: 2.6 (IBM Corporation)

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/src/main/webapp/WEB-INF/web.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE web-app PUBLIC
+ "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+ "http://java.sun.com/dtd/web-app_2_3.dtd" >
+
+<web-app>
+    <display-name>Archetype Created Web Application</display-name>
+</web-app>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/src/main/webapp/heights.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/src/main/webapp/heights.jsp
@@ -1,0 +1,42 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+
+    <jsp:useBean id="height" class="io.openliberty.guides.multimodules.web.HeightsBean"></jsp:useBean>
+    <jsp:setProperty name="height" property="heightCm" />
+    <jsp:setProperty name="height" property="heightFeet" value="0" />
+    <jsp:setProperty name="height" property="heightInches" value="0" />
+
+    <p>
+        Height in centimeters:
+        <jsp:getProperty name="height" property="heightCm" />
+        cm
+    </p>
+
+    <br>
+
+    <p>
+        Height in feet and inches:
+        <jsp:getProperty name="height" property="heightFeet" />
+        feet
+        <jsp:getProperty name="height" property="heightInches" />
+        inches
+    </p>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/src/main/webapp/index.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/src/main/webapp/index.jsp
@@ -1,0 +1,27 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+    <h2>Enter the height in centimeters</h2>
+
+    <form action="heights.jsp" method="post">
+        <input type="text" name="heightCm" /> cm <br> <input type="submit"
+            value="SUBMIT" />
+    </form>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/src/test/java/it/io/openliberty/guides/mutlimodules/web/HeightsBeanIT.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/src/test/java/it/io/openliberty/guides/mutlimodules/web/HeightsBeanIT.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package it.io.openliberty.guides.multimodules.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+public class HeightsBeanIT {
+    String war = "converter";
+    String urlBase = "http://localhost:" + "9080" + "/" + war + "/";
+
+    @Test
+    public void testIndexPage() throws Exception {
+        String url = this.urlBase;
+        HttpURLConnection con = testRequestHelper(url, "GET");
+        assertEquals(200, con.getResponseCode(), "Incorrect response code from " + url);
+        assertTrue(testBufferHelper(con).contains("Enter the height in centimeters"),
+                        "Incorrect response from " + url);
+    }
+
+    @Test
+    public void testHeightsPage() throws Exception {
+        String url = this.urlBase + "heights.jsp?heightCm=10";
+        HttpURLConnection con = testRequestHelper(url, "POST");
+        assertTrue(testBufferHelper(con).contains("3        inches"),
+                        "Incorrect response from " + url);
+    }
+
+    private HttpURLConnection testRequestHelper(String url, String method)
+                    throws Exception {
+        URL obj = new URL(url);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        // optional default is GET
+        con.setRequestMethod(method);
+        return con;
+    }
+
+    private String testBufferHelper(HttpURLConnection con) throws Exception {
+        BufferedReader in = new BufferedReader(
+                        new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        return response.toString();
+    }
+
+}
+

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/src/test/java/it/io/openliberty/guides/mutlimodules/web/HeightsBeanUnitTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/src/test/java/it/io/openliberty/guides/mutlimodules/web/HeightsBeanUnitTest.java
@@ -1,0 +1,16 @@
+package it.io.openliberty.guides.multimodules.web;
+
+import org.junit.jupiter.api.Test;
+import io.openliberty.guides.multimodules.web.HeightsBean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HeightsBeanUnitTest {
+
+    @Test
+    public void testGetHeightCm() {
+        HeightsBean heightBean = new HeightsBean();
+        heightBean.setHeightCm("2");
+        assertEquals("2", heightBean.getHeightCm());
+    }
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/README.txt
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/README.txt
@@ -1,0 +1,1 @@
+Server info in ear module

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/Dockerfile
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/Dockerfile
@@ -1,0 +1,8 @@
+FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+
+# Add config
+COPY --chown=1001:0  target/liberty/wlp/usr/servers/defaultServer/server.xml /config/
+COPY --chown=1001:0  target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/liberty-plugin-variable-config.xml /config/configDropins/overrides/
+
+# Add application
+COPY --chown=1001:0  target/guide-maven-multimodules-ear.ear /config/apps/ 

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
@@ -72,7 +72,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>SUB_VERSION</version>
             </plugin>
 
             <!-- Since the package type is ear,

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
@@ -1,0 +1,114 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-ear</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>ear</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Liberty configuration -->
+        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    </properties>
+
+    <dependencies>
+        <!-- web and jar modules as dependencies -->
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-war</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>war</type>
+        </dependency>
+
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <modules>
+                        <jarModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-jar</artifactId>
+                            <uri>/guide-maven-multimodules-jar-1.0-SNAPSHOT.jar</uri>
+                        </jarModule>
+                        <webModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-war</artifactId>
+                            <uri>/guide-maven-multimodules-war-1.0-SNAPSHOT.war</uri>
+                            <!-- Set custom context root -->
+                            <contextRoot>/converter</contextRoot>
+                        </webModule>
+                    </modules>
+                </configuration>
+            </plugin>
+
+            <!-- Enable liberty-maven plugin -->
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.2.3</version>
+            </plugin>
+
+            <!-- Since the package type is ear,
+            need to run testCompile to compile the tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Plugin to run integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <default.http.port>
+                            ${liberty.var.default.http.port}
+                        </default.http.port>
+                        <default.https.port>
+                            ${liberty.var.default.https.port}
+                        </default.https.port>
+                        <cf.context.root>/converter</cf.context.root>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/src/main/liberty/config/server.xml
@@ -1,0 +1,16 @@
+<server description="Sample Liberty server">
+
+    <featureManager>
+        <feature>jsp-2.3</feature>
+    </featureManager>
+
+    <variable name="default.http.port" defaultValue="9080" />
+    <variable name="default.https.port" defaultValue="9443" />
+
+    <httpEndpoint host="*" httpPort="${default.http.port}"
+        httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+
+    <enterpriseApplication id="guide-maven-multimodules-ear"
+        location="guide-maven-multimodules-ear.ear"
+        name="guide-maven-multimodules-ear" />
+</server>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/src/test/java/it/io/openliberty/guides/multimodules/IT.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/src/test/java/it/io/openliberty/guides/multimodules/IT.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package it.io.openliberty.guides.multimodules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+public class IT {
+    String port = System.getProperty("default.http.port");
+    String war = "converter";
+    String urlBase = "http://localhost:" + port + "/" + war + "/";
+
+    @Test
+    public void testIndexPage() throws Exception {
+        String url = this.urlBase;
+        HttpURLConnection con = testRequestHelper(url, "GET");
+        assertEquals(200, con.getResponseCode(), "Incorrect response code from " + url);
+        assertTrue(testBufferHelper(con).contains("Enter the height in centimeters"),
+                        "Incorrect response from " + url);
+    }
+
+    @Test
+    public void testHeightsPage() throws Exception {
+        String url = this.urlBase + "heights.jsp?heightCm=10";
+        HttpURLConnection con = testRequestHelper(url, "POST");
+        assertTrue(testBufferHelper(con).contains("3        inches"),
+                        "Incorrect response from " + url);
+    }
+
+    private HttpURLConnection testRequestHelper(String url, String method)
+                    throws Exception {
+        URL obj = new URL(url);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        // optional default is GET
+        con.setRequestMethod(method);
+        return con;
+    }
+
+    private String testBufferHelper(HttpURLConnection con) throws Exception {
+        BufferedReader in = new BufferedReader(
+                        new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        return response.toString();
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/jar/pom.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-jar</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.lib;
+
+public class Converter {
+
+    public static int getFeet(int cm) {
+        int feet = (int) (cm / 30.48);
+        return feet;
+    }
+
+    public static int getInches(int cm) {
+        double feet = cm / 30.48;
+        int inches = (int) (cm / 2.54) - ((int) feet * 12);
+        return inches;
+    }
+
+    public static int sum(int a, int b) {
+        return a + b;
+    }
+
+    public static int diff(int a, int b) {
+        return a - b;
+    }
+
+    public static int product(int a, int b) {
+        return a * b;
+    }
+
+    public static int quotient(int a, int b) {
+        return a / b;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/pom/pom.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>../jar</module>
+        <module>../war</module>
+        <module>../ear</module>
+    </modules>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/war/pom.xml
@@ -1,0 +1,54 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-war</artifactId>
+    <packaging>war</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>guide-maven-multimodules-war</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>3.3</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.web;
+
+public class HeightsBean implements java.io.Serializable {
+    private String heightCm = null;
+    private String heightFeet = null;
+    private String heightInches = null;
+    private int cm = 0;
+    private int feet = 0;
+    private int inches = 0;
+
+    public HeightsBean() {
+    }
+
+    // Capitalize the first letter of the name i.e. first letter after get
+    // If first letter is not capitalized, it must match the property name in
+    // index.jsp
+    public String getHeightCm() {
+        return heightCm;
+    }
+
+    public String getHeightFeet() {
+        return heightFeet;
+    }
+
+    public String getHeightInches() {
+        return heightInches;
+    }
+
+    public void setHeightCm(String heightcm) {
+        this.heightCm = heightcm;
+    }
+
+    // Need an input as placeholder, you can choose not to use the input
+    public void setHeightFeet(String heightfeet) {
+        this.cm = Integer.valueOf(heightCm);
+        this.feet = io.openliberty.guides.multimodules.lib.Converter.getFeet(cm);
+        String result = String.valueOf(feet);
+        this.heightFeet = result;
+    }
+
+    public void setHeightInches(String heightinches) {
+        this.cm = Integer.valueOf(heightCm);
+        this.inches = io.openliberty.guides.multimodules.lib.Converter.getInches(cm);
+        String result = String.valueOf(inches);
+        this.heightInches = result;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/war/src/main/webapp/WEB-INF/web.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE web-app PUBLIC
+ "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+ "http://java.sun.com/dtd/web-app_2_3.dtd" >
+
+<web-app>
+    <display-name>Archetype Created Web Application</display-name>
+</web-app>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/war/src/main/webapp/heights.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/war/src/main/webapp/heights.jsp
@@ -1,0 +1,42 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+
+    <jsp:useBean id="height" class="io.openliberty.guides.multimodules.web.HeightsBean"></jsp:useBean>
+    <jsp:setProperty name="height" property="heightCm" />
+    <jsp:setProperty name="height" property="heightFeet" value="0" />
+    <jsp:setProperty name="height" property="heightInches" value="0" />
+
+    <p>
+        Height in centimeters:
+        <jsp:getProperty name="height" property="heightCm" />
+        cm
+    </p>
+
+    <br>
+
+    <p>
+        Height in feet and inches:
+        <jsp:getProperty name="height" property="heightFeet" />
+        feet
+        <jsp:getProperty name="height" property="heightInches" />
+        inches
+    </p>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/war/src/main/webapp/index.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/war/src/main/webapp/index.jsp
@@ -1,0 +1,27 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+    <h2>Enter the height in centimeters</h2>
+
+    <form action="heights.jsp" method="post">
+        <input type="text" name="heightCm" /> cm <br> <input type="submit"
+            value="SUBMIT" />
+    </form>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/jar/pom.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-jar</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.lib;
+
+public class Converter {
+
+    public static int getFeet(int cm) {
+        int feet = (int) (cm / 30.48);
+        return feet;
+    }
+
+    public static int getInches(int cm) {
+        double feet = cm / 30.48;
+        int inches = (int) (cm / 2.54) - ((int) feet * 12);
+        return inches;
+    }
+
+    public static int sum(int a, int b) {
+        return a + b;
+    }
+
+    public static int diff(int a, int b) {
+        return a - b;
+    }
+
+    public static int product(int a, int b) {
+        return a * b;
+    }
+
+    public static int quotient(int a, int b) {
+        return a / b;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/pom.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>jar</module>
+        <module>war</module>
+    </modules>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/Dockerfile
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/Dockerfile
@@ -1,0 +1,8 @@
+FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+
+# Add config
+COPY --chown=1001:0  target/liberty/wlp/usr/servers/defaultServer/server.xml /config/
+COPY --chown=1001:0  target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/liberty-plugin-variable-config.xml /config/configDropins/overrides/
+
+# Add application
+COPY --chown=1001:0  target/liberty/wlp/usr/servers/defaultServer/apps/guide-maven-multimodules-war.war /config/apps/

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
@@ -68,7 +68,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>SUB_VERSION</version>
+                <version>3.3.1</version>
                 <configuration>
                     <modules>
                         <jarModule>
@@ -91,7 +91,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>SUB_VERSION</version>
+                <version>3.3.1</version>
             </plugin>
 
             <!-- Since the package type is ear,

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
@@ -68,7 +68,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>SUB_VERSION</version>
                 <configuration>
                     <modules>
                         <jarModule>
@@ -91,7 +91,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>SUB_VERSION</version>
             </plugin>
 
             <!-- Since the package type is ear,

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
@@ -1,0 +1,133 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-war</artifactId>
+    <packaging>war</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>guide-maven-multimodules-war</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Liberty configuration -->
+        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    </properties>
+
+    <dependencies>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>3.3</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <modules>
+                        <jarModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-jar</artifactId>
+                            <uri>/guide-maven-multimodules-jar-1.0-SNAPSHOT.jar</uri>
+                        </jarModule>
+                        <webModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-war</artifactId>
+                            <uri>/guide-maven-multimodules-war-1.0-SNAPSHOT.war</uri>
+                            <!-- Set custom context root -->
+                            <contextRoot>/converter</contextRoot>
+                        </webModule>
+                    </modules>
+                </configuration>
+            </plugin>
+
+            <!-- Enable liberty-maven plugin -->
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.2.3</version>
+            </plugin>
+
+            <!-- Since the package type is ear,
+            need to run testCompile to compile the tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Plugin to run integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <default.http.port>
+                            ${liberty.var.default.http.port}
+                        </default.http.port>
+                        <default.https.port>
+                            ${liberty.var.default.https.port}
+                        </default.https.port>
+                        <cf.context.root>/converter</cf.context.root>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.web;
+
+public class HeightsBean implements java.io.Serializable {
+    private String heightCm = null;
+    private String heightFeet = null;
+    private String heightInches = null;
+    private int cm = 0;
+    private int feet = 0;
+    private int inches = 0;
+
+    public HeightsBean() {
+    }
+
+    // Capitalize the first letter of the name i.e. first letter after get
+    // If first letter is not capitalized, it must match the property name in
+    // index.jsp
+    public String getHeightCm() {
+        return heightCm;
+    }
+
+    public String getHeightFeet() {
+        return heightFeet;
+    }
+
+    public String getHeightInches() {
+        return heightInches;
+    }
+
+    public void setHeightCm(String heightcm) {
+        this.heightCm = heightcm;
+    }
+
+    // Need an input as placeholder, you can choose not to use the input
+    public void setHeightFeet(String heightfeet) {
+        this.cm = Integer.valueOf(heightCm);
+        this.feet = io.openliberty.guides.multimodules.lib.Converter.getFeet(cm);
+        String result = String.valueOf(feet);
+        this.heightFeet = result;
+    }
+
+    public void setHeightInches(String heightinches) {
+        this.cm = Integer.valueOf(heightCm);
+        this.inches = io.openliberty.guides.multimodules.lib.Converter.getInches(cm);
+        String result = String.valueOf(inches);
+        this.heightInches = result;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/src/main/liberty/config/server.xml
@@ -1,0 +1,15 @@
+<server description="Sample Liberty server">
+
+    <featureManager>
+        <feature>jsp-2.3</feature>
+    </featureManager>
+
+    <variable name="default.http.port" defaultValue="9080" />
+    <variable name="default.https.port" defaultValue="9443" />
+
+    <httpEndpoint host="*" httpPort="${default.http.port}"
+        httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+
+    <webApplication id="guide-maven-multimodules-war"
+        location="guide-maven-multimodules-war.war" contextRoot="/converter/"/>
+</server>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/src/main/webapp/WEB-INF/web.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE web-app PUBLIC
+ "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+ "http://java.sun.com/dtd/web-app_2_3.dtd" >
+
+<web-app>
+    <display-name>Archetype Created Web Application</display-name>
+</web-app>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/src/main/webapp/heights.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/src/main/webapp/heights.jsp
@@ -1,0 +1,42 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+
+    <jsp:useBean id="height" class="io.openliberty.guides.multimodules.web.HeightsBean"></jsp:useBean>
+    <jsp:setProperty name="height" property="heightCm" />
+    <jsp:setProperty name="height" property="heightFeet" value="0" />
+    <jsp:setProperty name="height" property="heightInches" value="0" />
+
+    <p>
+        Height in centimeters:
+        <jsp:getProperty name="height" property="heightCm" />
+        cm
+    </p>
+
+    <br>
+
+    <p>
+        Height in feet and inches:
+        <jsp:getProperty name="height" property="heightFeet" />
+        feet
+        <jsp:getProperty name="height" property="heightInches" />
+        inches
+    </p>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/src/main/webapp/index.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/src/main/webapp/index.jsp
@@ -1,0 +1,27 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+    <h2>Enter the height in centimeters</h2>
+
+    <form action="heights.jsp" method="post">
+        <input type="text" name="heightCm" /> cm <br> <input type="submit"
+            value="SUBMIT" />
+    </form>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/Dockerfile
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/Dockerfile
@@ -1,0 +1,8 @@
+FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+
+# Add config
+COPY --chown=1001:0  pom/target/liberty/wlp/usr/servers/defaultServer/server.xml /config/
+COPY --chown=1001:0  pom/target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/liberty-plugin-variable-config.xml /config/configDropins/overrides/
+
+# Add application
+COPY --chown=1001:0  ear/target/guide-maven-multimodules-ear.ear /config/apps/ 

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/ear/pom.xml
@@ -1,0 +1,70 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-ear</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>ear</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <!-- web and jar modules as dependencies -->
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-war</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>war</type>
+        </dependency>
+
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <modules>
+                        <jarModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-jar</artifactId>
+                            <uri>/guide-maven-multimodules-jar-1.0-SNAPSHOT.jar</uri>
+                        </jarModule>
+                        <webModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-war</artifactId>
+                            <uri>/guide-maven-multimodules-war-1.0-SNAPSHOT.war</uri>
+                            <!-- Set custom context root -->
+                            <contextRoot>/converter</contextRoot>
+                        </webModule>
+                    </modules>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/ear/src/test/java/it/io/openliberty/guides/multimodules/ConverterAppIT.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/ear/src/test/java/it/io/openliberty/guides/multimodules/ConverterAppIT.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package it.io.openliberty.guides.multimodules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+public class ConverterAppIT {
+    String port = System.getProperty("default.http.port");
+    String war = "converter";
+    String urlBase = "http://localhost:" + "9080" + "/" + war + "/";
+
+    @Test
+    public void testIndexPage() throws Exception {
+        String url = this.urlBase;
+        HttpURLConnection con = testRequestHelper(url, "GET");
+        assertEquals(200, con.getResponseCode(), "Incorrect response code from " + url);
+        assertTrue(testBufferHelper(con).contains("Enter the height in centimeters"),
+                        "Incorrect response from " + url);
+    }
+
+    @Test
+    public void testHeightsPage() throws Exception {
+        String url = this.urlBase + "heights.jsp?heightCm=10";
+        HttpURLConnection con = testRequestHelper(url, "POST");
+        assertTrue(testBufferHelper(con).contains("3        inches"),
+                        "Incorrect response from " + url);
+    }
+
+    private HttpURLConnection testRequestHelper(String url, String method)
+                    throws Exception {
+        URL obj = new URL(url);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        // optional default is GET
+        con.setRequestMethod(method);
+        return con;
+    }
+
+    private String testBufferHelper(HttpURLConnection con) throws Exception {
+        BufferedReader in = new BufferedReader(
+                        new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        return response.toString();
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/jar/pom.xml
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-jar</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.lib;
+
+public class Converter {
+
+    public static int getFeet(int cm) {
+        int feet = (int) (cm / 30.48);
+        return feet;
+    }
+
+    public static int getInches(int cm) {
+        double feet = cm / 30.48;
+        int inches = (int) (cm / 2.54) - ((int) feet * 12);
+        return inches;
+    }
+
+    public static int sum(int a, int b) {
+        return a + b;
+    }
+
+    public static int diff(int a, int b) {
+        return a - b;
+    }
+
+    public static int product(int a, int b) {
+        return a * b;
+    }
+
+    public static int quotient(int a, int b) {
+        return a / b;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/jar/src/test/java/io/openliberty/guides/multimodules/lib/ConverterUnitTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/jar/src/test/java/io/openliberty/guides/multimodules/lib/ConverterUnitTest.java
@@ -1,0 +1,15 @@
+package io.openliberty.guides.multimodules.lib;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConverterUnitTest {
+
+    @Test
+    public void testHeightFeet() {
+        int feet = Converter.getFeet(61);
+        assertEquals(2, feet);
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>jar</module>
+        <module>war</module>
+        <module>ear</module>
+        <module>pom</module>
+    </modules>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
@@ -42,7 +42,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.3.3</version>
+                <version>SUB_VERSION</version>
                 <extensions>true</extensions>
                 <configuration>
                     <looseApplication>true</looseApplication>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
@@ -1,0 +1,89 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-pom</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>liberty-assembly</packaging>
+
+    <properties>
+        <!-- Liberty configuration -->
+        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-ear</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>ear</type>
+        </dependency>
+
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+
+            <!-- Enable liberty-maven plugin -->
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.3.3</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <looseApplication>true</looseApplication>
+                    <deployPackages>all</deployPackages>
+                </configuration>
+            </plugin>
+
+            <!-- Since the package type is liberty-assembly,
+            need to run testCompile to compile the tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Plugin to run integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <default.http.port>
+                            ${liberty.var.default.http.port}
+                        </default.http.port>
+                        <default.https.port>
+                            ${liberty.var.default.https.port}
+                        </default.https.port>
+                        <cf.context.root>/converter</cf.context.root>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/src/main/liberty/config/server.xml
@@ -1,0 +1,18 @@
+<server description="Sample Liberty server">
+
+    <featureManager>
+        <feature>jsp-2.3</feature>
+
+    </featureManager>
+
+    <variable name="default.http.port" defaultValue="9080" />
+    <variable name="default.https.port" defaultValue="9443" />
+
+    <httpEndpoint host="*" httpPort="${default.http.port}"
+        httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+
+    <enterpriseApplication id="guide-maven-multimodules-ear"
+        location="guide-maven-multimodules-ear.ear"
+        name="guide-maven-multimodules-ear" />
+
+</server>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/src/test/java/it/io/openliberty/guides/multimodules/IT.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/src/test/java/it/io/openliberty/guides/multimodules/IT.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package it.io.openliberty.guides.multimodules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+public class IT {
+    String port = System.getProperty("default.http.port");
+    String war = "converter";
+    String urlBase = "http://localhost:" + port + "/" + war + "/";
+
+    @Test
+    public void testIndexPage() throws Exception {
+        String url = this.urlBase;
+        HttpURLConnection con = testRequestHelper(url, "GET");
+        assertEquals(200, con.getResponseCode(), "Incorrect response code from " + url);
+        assertTrue(testBufferHelper(con).contains("Enter the height in centimeters"),
+                        "Incorrect response from " + url);
+    }
+
+    @Test
+    public void testHeightsPage() throws Exception {
+        String url = this.urlBase + "heights.jsp?heightCm=10";
+        HttpURLConnection con = testRequestHelper(url, "POST");
+        assertTrue(testBufferHelper(con).contains("3        inches"),
+                        "Incorrect response from " + url);
+    }
+
+    private HttpURLConnection testRequestHelper(String url, String method)
+                    throws Exception {
+        URL obj = new URL(url);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        // optional default is GET
+        con.setRequestMethod(method);
+        return con;
+    }
+
+    private String testBufferHelper(HttpURLConnection con) throws Exception {
+        BufferedReader in = new BufferedReader(
+                        new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        return response.toString();
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/war/pom.xml
@@ -1,0 +1,62 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-war</artifactId>
+    <packaging>war</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>guide-maven-multimodules-war</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>3.3</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.web;
+
+public class HeightsBean implements java.io.Serializable {
+    private String heightCm = null;
+    private String heightFeet = null;
+    private String heightInches = null;
+    private int cm = 0;
+    private int feet = 0;
+    private int inches = 0;
+
+    public HeightsBean() {
+    }
+
+    // Capitalize the first letter of the name i.e. first letter after get
+    // If first letter is not capitalized, it must match the property name in
+    // index.jsp
+    public String getHeightCm() {
+        return heightCm;
+    }
+
+    public String getHeightFeet() {
+        return heightFeet;
+    }
+
+    public String getHeightInches() {
+        return heightInches;
+    }
+
+    public void setHeightCm(String heightcm) {
+        this.heightCm = heightcm;
+    }
+
+    // Need an input as placeholder, you can choose not to use the input
+    public void setHeightFeet(String heightfeet) {
+        this.cm = Integer.valueOf(heightCm);
+        this.feet = io.openliberty.guides.multimodules.lib.Converter.getFeet(cm);
+        String result = String.valueOf(feet);
+        this.heightFeet = result;
+    }
+
+    public void setHeightInches(String heightinches) {
+        this.cm = Integer.valueOf(heightCm);
+        this.inches = io.openliberty.guides.multimodules.lib.Converter.getInches(cm);
+        String result = String.valueOf(inches);
+        this.heightInches = result;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/war/src/main/webapp/WEB-INF/web.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE web-app PUBLIC
+ "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+ "http://java.sun.com/dtd/web-app_2_3.dtd" >
+
+<web-app>
+    <display-name>Archetype Created Web Application</display-name>
+</web-app>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/war/src/main/webapp/heights.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/war/src/main/webapp/heights.jsp
@@ -1,0 +1,42 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+
+    <jsp:useBean id="height" class="io.openliberty.guides.multimodules.web.HeightsBean"></jsp:useBean>
+    <jsp:setProperty name="height" property="heightCm" />
+    <jsp:setProperty name="height" property="heightFeet" value="0" />
+    <jsp:setProperty name="height" property="heightInches" value="0" />
+
+    <p>
+        Height in centimeters:
+        <jsp:getProperty name="height" property="heightCm" />
+        cm
+    </p>
+
+    <br>
+
+    <p>
+        Height in feet and inches:
+        <jsp:getProperty name="height" property="heightFeet" />
+        feet
+        <jsp:getProperty name="height" property="heightInches" />
+        inches
+    </p>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/war/src/main/webapp/index.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/war/src/main/webapp/index.jsp
@@ -1,0 +1,27 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+    <h2>Enter the height in centimeters</h2>
+
+    <form action="heights.jsp" method="post">
+        <input type="text" name="heightCm" /> cm <br> <input type="submit"
+            value="SUBMIT" />
+    </form>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/war/src/test/java/it/io/openliberty/guides/mutlimodules/web/HeightsBeanIT.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/war/src/test/java/it/io/openliberty/guides/mutlimodules/web/HeightsBeanIT.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package it.io.openliberty.guides.multimodules.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+public class HeightsBeanIT {
+    String port = System.getProperty("default.http.port");
+    String war = "converter";
+    String urlBase = "http://localhost:" + "9080" + "/" + war + "/";
+
+    @Test
+    public void testIndexPage() throws Exception {
+        String url = this.urlBase;
+        HttpURLConnection con = testRequestHelper(url, "GET");
+        assertEquals(200, con.getResponseCode(), "Incorrect response code from " + url);
+        assertTrue(testBufferHelper(con).contains("Enter the height in centimeters"),
+                        "Incorrect response from " + url);
+    }
+
+    @Test
+    public void testHeightsPage() throws Exception {
+        String url = this.urlBase + "heights.jsp?heightCm=10";
+        HttpURLConnection con = testRequestHelper(url, "POST");
+        assertTrue(testBufferHelper(con).contains("3        inches"),
+                        "Incorrect response from " + url);
+    }
+
+    private HttpURLConnection testRequestHelper(String url, String method)
+                    throws Exception {
+        URL obj = new URL(url);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        // optional default is GET
+        con.setRequestMethod(method);
+        return con;
+    }
+
+    private String testBufferHelper(HttpURLConnection con) throws Exception {
+        BufferedReader in = new BufferedReader(
+                        new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        return response.toString();
+    }
+
+}
+

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/war/src/test/java/it/io/openliberty/guides/mutlimodules/web/HeightsBeanUnitTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/war/src/test/java/it/io/openliberty/guides/mutlimodules/web/HeightsBeanUnitTest.java
@@ -1,0 +1,16 @@
+package it.io.openliberty.guides.multimodules.web;
+
+import org.junit.jupiter.api.Test;
+import io.openliberty.guides.multimodules.web.HeightsBean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HeightsBeanUnitTest {
+
+    @Test
+    public void testGetHeightCm() {
+        HeightsBean heightBean = new HeightsBean();
+        heightBean.setHeightCm("2");
+        assertEquals("2", heightBean.getHeightCm());
+    }
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/Dockerfile
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/Dockerfile
@@ -1,0 +1,8 @@
+FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+
+# Add config
+COPY --chown=1001:0  pom/target/liberty/wlp/usr/servers/defaultServer/server.xml /config/
+COPY --chown=1001:0  pom/target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/liberty-plugin-variable-config.xml /config/configDropins/overrides/
+
+# Add application
+COPY --chown=1001:0  ear/target/guide-maven-multimodules-ear.ear /config/apps/ 

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/ear/pom.xml
@@ -1,0 +1,62 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-ear</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>ear</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <!-- web and jar modules as dependencies -->
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-war</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>war</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <modules>
+                        <jarModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-jar</artifactId>
+                            <uri>/guide-maven-multimodules-jar-1.0-SNAPSHOT.jar</uri>
+                        </jarModule>
+                        <webModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-war</artifactId>
+                            <uri>/guide-maven-multimodules-war-1.0-SNAPSHOT.war</uri>
+                            <!-- Set custom context root -->
+                            <contextRoot>/converter</contextRoot>
+                        </webModule>
+                    </modules>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/jar/pom.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-jar</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.lib;
+
+public class Converter {
+
+    public static int getFeet(int cm) {
+        int feet = (int) (cm / 30.48);
+        return feet;
+    }
+
+    public static int getInches(int cm) {
+        double feet = cm / 30.48;
+        int inches = (int) (cm / 2.54) - ((int) feet * 12);
+        return inches;
+    }
+
+    public static int sum(int a, int b) {
+        return a + b;
+    }
+
+    public static int diff(int a, int b) {
+        return a - b;
+    }
+
+    public static int product(int a, int b) {
+        return a * b;
+    }
+
+    public static int quotient(int a, int b) {
+        return a / b;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>jar</module>
+        <module>war</module>
+        <module>ear</module>
+        <module>pom</module>
+    </modules>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
@@ -1,0 +1,89 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-pom</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <!-- Liberty configuration -->
+        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-ear</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>ear</type>
+        </dependency>
+
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+
+            <!-- Enable liberty-maven plugin -->
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.3.5-M2-SNAPSHOT</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <deployPackages>dependencies</deployPackages>
+                    <stripVersion>true</stripVersion>
+                </configuration>
+            </plugin>
+
+            <!-- Since the package type is ear,
+            need to run testCompile to compile the tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Plugin to run integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <default.http.port>
+                            ${liberty.var.default.http.port}
+                        </default.http.port>
+                        <default.https.port>
+                            ${liberty.var.default.https.port}
+                        </default.https.port>
+                        <cf.context.root>/converter</cf.context.root>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
@@ -42,7 +42,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.3.5-M2-SNAPSHOT</version>
+                <version>SUB_VERSION</version>
                 <extensions>true</extensions>
                 <configuration>
                     <deployPackages>dependencies</deployPackages>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/src/main/liberty/config/server.xml
@@ -1,0 +1,18 @@
+<server description="Sample Liberty server">
+
+    <featureManager>
+        <feature>jsp-2.3</feature>
+        <feature>mpHealth-2.2</feature>
+    </featureManager>
+
+    <variable name="default.http.port" defaultValue="9080" />
+    <variable name="default.https.port" defaultValue="9443" />
+
+    <httpEndpoint host="*" httpPort="${default.http.port}"
+        httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+
+    <enterpriseApplication id="guide-maven-multimodules-ear"
+        location="guide-maven-multimodules-ear.ear"
+        name="guide-maven-multimodules-ear" />
+
+</server>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/src/test/java/it/io/openliberty/guides/multimodules/IT.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/src/test/java/it/io/openliberty/guides/multimodules/IT.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package it.io.openliberty.guides.multimodules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+public class IT {
+    String port = System.getProperty("default.http.port");
+    String war = "converter";
+    String urlBase = "http://localhost:" + port + "/" + war + "/";
+
+    @Test
+    public void testIndexPage() throws Exception {
+        String url = this.urlBase;
+        HttpURLConnection con = testRequestHelper(url, "GET");
+        assertEquals(200, con.getResponseCode(), "Incorrect response code from " + url);
+        assertTrue(testBufferHelper(con).contains("Enter the height in centimeters"),
+                        "Incorrect response from " + url);
+    }
+
+    @Test
+    public void testHeightsPage() throws Exception {
+        String url = this.urlBase + "heights.jsp?heightCm=10";
+        HttpURLConnection con = testRequestHelper(url, "POST");
+        assertTrue(testBufferHelper(con).contains("3        inches"),
+                        "Incorrect response from " + url);
+    }
+
+    private HttpURLConnection testRequestHelper(String url, String method)
+                    throws Exception {
+        URL obj = new URL(url);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        // optional default is GET
+        con.setRequestMethod(method);
+        return con;
+    }
+
+    private String testBufferHelper(HttpURLConnection con) throws Exception {
+        BufferedReader in = new BufferedReader(
+                        new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        return response.toString();
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/war/pom.xml
@@ -1,0 +1,54 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-war</artifactId>
+    <packaging>war</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>guide-maven-multimodules-war</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>3.3</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.web;
+
+public class HeightsBean implements java.io.Serializable {
+    private String heightCm = null;
+    private String heightFeet = null;
+    private String heightInches = null;
+    private int cm = 0;
+    private int feet = 0;
+    private int inches = 0;
+
+    public HeightsBean() {
+    }
+
+    // Capitalize the first letter of the name i.e. first letter after get
+    // If first letter is not capitalized, it must match the property name in
+    // index.jsp
+    public String getHeightCm() {
+        return heightCm;
+    }
+
+    public String getHeightFeet() {
+        return heightFeet;
+    }
+
+    public String getHeightInches() {
+        return heightInches;
+    }
+
+    public void setHeightCm(String heightcm) {
+        this.heightCm = heightcm;
+    }
+
+    // Need an input as placeholder, you can choose not to use the input
+    public void setHeightFeet(String heightfeet) {
+        this.cm = Integer.valueOf(heightCm);
+        this.feet = io.openliberty.guides.multimodules.lib.Converter.getFeet(cm);
+        String result = String.valueOf(feet);
+        this.heightFeet = result;
+    }
+
+    public void setHeightInches(String heightinches) {
+        this.cm = Integer.valueOf(heightCm);
+        this.inches = io.openliberty.guides.multimodules.lib.Converter.getInches(cm);
+        String result = String.valueOf(inches);
+        this.heightInches = result;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/war/src/main/webapp/WEB-INF/web.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE web-app PUBLIC
+ "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+ "http://java.sun.com/dtd/web-app_2_3.dtd" >
+
+<web-app>
+    <display-name>Archetype Created Web Application</display-name>
+</web-app>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/war/src/main/webapp/heights.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/war/src/main/webapp/heights.jsp
@@ -1,0 +1,42 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+
+    <jsp:useBean id="height" class="io.openliberty.guides.multimodules.web.HeightsBean"></jsp:useBean>
+    <jsp:setProperty name="height" property="heightCm" />
+    <jsp:setProperty name="height" property="heightFeet" value="0" />
+    <jsp:setProperty name="height" property="heightInches" value="0" />
+
+    <p>
+        Height in centimeters:
+        <jsp:getProperty name="height" property="heightCm" />
+        cm
+    </p>
+
+    <br>
+
+    <p>
+        Height in feet and inches:
+        <jsp:getProperty name="height" property="heightFeet" />
+        feet
+        <jsp:getProperty name="height" property="heightInches" />
+        inches
+    </p>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/war/src/main/webapp/index.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/war/src/main/webapp/index.jsp
@@ -1,0 +1,27 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+    <h2>Enter the height in centimeters</h2>
+
+    <form action="heights.jsp" method="post">
+        <input type="text" name="heightCm" /> cm <br> <input type="submit"
+            value="SUBMIT" />
+    </form>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/Dockerfile
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/Dockerfile
@@ -1,0 +1,8 @@
+FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+
+# Add config
+COPY --chown=1001:0  pom/target/liberty/wlp/usr/servers/defaultServer/server.xml /config/
+COPY --chown=1001:0  pom/target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/liberty-plugin-variable-config.xml /config/configDropins/overrides/
+
+# Add application
+COPY --chown=1001:0  ear/target/guide-maven-multimodules-ear.ear /config/apps/ 

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/ear/pom.xml
@@ -1,0 +1,62 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-ear</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>ear</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <!-- web and jar modules as dependencies -->
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-war</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>war</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <modules>
+                        <jarModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-jar</artifactId>
+                            <uri>/guide-maven-multimodules-jar-1.0-SNAPSHOT.jar</uri>
+                        </jarModule>
+                        <webModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-war</artifactId>
+                            <uri>/guide-maven-multimodules-war-1.0-SNAPSHOT.war</uri>
+                            <!-- Set custom context root -->
+                            <contextRoot>/converter</contextRoot>
+                        </webModule>
+                    </modules>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/jar/pom.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-jar</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.lib;
+
+public class Converter {
+
+    public static int getFeet(int cm) {
+        int feet = (int) (cm / 30.48);
+        return feet;
+    }
+
+    public static int getInches(int cm) {
+        double feet = cm / 30.48;
+        int inches = (int) (cm / 2.54) - ((int) feet * 12);
+        return inches;
+    }
+
+    public static int sum(int a, int b) {
+        return a + b;
+    }
+
+    public static int diff(int a, int b) {
+        return a - b;
+    }
+
+    public static int product(int a, int b) {
+        return a * b;
+    }
+
+    public static int quotient(int a, int b) {
+        return a / b;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
@@ -1,0 +1,95 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-pom</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <!-- Liberty configuration -->
+        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-ear</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>ear</type>
+        </dependency>
+
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+
+            <!-- Enable liberty-maven plugin -->
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.3.5-M2-SNAPSHOT</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <deployPackages>dependencies</deployPackages>
+                    <stripVersion>true</stripVersion>
+                </configuration>
+            </plugin>
+
+            <!-- Since the package type is ear,
+            need to run testCompile to compile the tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Plugin to run integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <default.http.port>
+                            ${liberty.var.default.http.port}
+                        </default.http.port>
+                        <default.https.port>
+                            ${liberty.var.default.https.port}
+                        </default.https.port>
+                        <cf.context.root>/converter</cf.context.root>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <modules>
+        <module>../jar</module>
+        <module>../war</module>
+        <module>../ear</module>
+    </modules>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
@@ -42,7 +42,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.3.5-M2-SNAPSHOT</version>
+                <version>SUB_VERSION</version>
                 <extensions>true</extensions>
                 <configuration>
                     <deployPackages>dependencies</deployPackages>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/src/main/liberty/config/server.xml
@@ -1,0 +1,18 @@
+<server description="Sample Liberty server">
+
+    <featureManager>
+        <feature>jsp-2.3</feature>
+        <feature>mpHealth-2.2</feature>
+    </featureManager>
+
+    <variable name="default.http.port" defaultValue="9080" />
+    <variable name="default.https.port" defaultValue="9443" />
+
+    <httpEndpoint host="*" httpPort="${default.http.port}"
+        httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+
+    <enterpriseApplication id="guide-maven-multimodules-ear"
+        location="guide-maven-multimodules-ear.ear"
+        name="guide-maven-multimodules-ear" />
+
+</server>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/src/test/java/it/io/openliberty/guides/multimodules/IT.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/src/test/java/it/io/openliberty/guides/multimodules/IT.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package it.io.openliberty.guides.multimodules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+public class IT {
+    String port = System.getProperty("default.http.port");
+    String war = "converter";
+    String urlBase = "http://localhost:" + port + "/" + war + "/";
+
+    @Test
+    public void testIndexPage() throws Exception {
+        String url = this.urlBase;
+        HttpURLConnection con = testRequestHelper(url, "GET");
+        assertEquals(200, con.getResponseCode(), "Incorrect response code from " + url);
+        assertTrue(testBufferHelper(con).contains("Enter the height in centimeters"),
+                        "Incorrect response from " + url);
+    }
+
+    @Test
+    public void testHeightsPage() throws Exception {
+        String url = this.urlBase + "heights.jsp?heightCm=10";
+        HttpURLConnection con = testRequestHelper(url, "POST");
+        assertTrue(testBufferHelper(con).contains("3        inches"),
+                        "Incorrect response from " + url);
+    }
+
+    private HttpURLConnection testRequestHelper(String url, String method)
+                    throws Exception {
+        URL obj = new URL(url);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        // optional default is GET
+        con.setRequestMethod(method);
+        return con;
+    }
+
+    private String testBufferHelper(HttpURLConnection con) throws Exception {
+        BufferedReader in = new BufferedReader(
+                        new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        return response.toString();
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/war/pom.xml
@@ -1,0 +1,54 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-war</artifactId>
+    <packaging>war</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>guide-maven-multimodules-war</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>3.3</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.web;
+
+public class HeightsBean implements java.io.Serializable {
+    private String heightCm = null;
+    private String heightFeet = null;
+    private String heightInches = null;
+    private int cm = 0;
+    private int feet = 0;
+    private int inches = 0;
+
+    public HeightsBean() {
+    }
+
+    // Capitalize the first letter of the name i.e. first letter after get
+    // If first letter is not capitalized, it must match the property name in
+    // index.jsp
+    public String getHeightCm() {
+        return heightCm;
+    }
+
+    public String getHeightFeet() {
+        return heightFeet;
+    }
+
+    public String getHeightInches() {
+        return heightInches;
+    }
+
+    public void setHeightCm(String heightcm) {
+        this.heightCm = heightcm;
+    }
+
+    // Need an input as placeholder, you can choose not to use the input
+    public void setHeightFeet(String heightfeet) {
+        this.cm = Integer.valueOf(heightCm);
+        this.feet = io.openliberty.guides.multimodules.lib.Converter.getFeet(cm);
+        String result = String.valueOf(feet);
+        this.heightFeet = result;
+    }
+
+    public void setHeightInches(String heightinches) {
+        this.cm = Integer.valueOf(heightCm);
+        this.inches = io.openliberty.guides.multimodules.lib.Converter.getInches(cm);
+        String result = String.valueOf(inches);
+        this.heightInches = result;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/war/src/main/webapp/WEB-INF/web.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE web-app PUBLIC
+ "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+ "http://java.sun.com/dtd/web-app_2_3.dtd" >
+
+<web-app>
+    <display-name>Archetype Created Web Application</display-name>
+</web-app>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/war/src/main/webapp/heights.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/war/src/main/webapp/heights.jsp
@@ -1,0 +1,42 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+
+    <jsp:useBean id="height" class="io.openliberty.guides.multimodules.web.HeightsBean"></jsp:useBean>
+    <jsp:setProperty name="height" property="heightCm" />
+    <jsp:setProperty name="height" property="heightFeet" value="0" />
+    <jsp:setProperty name="height" property="heightInches" value="0" />
+
+    <p>
+        Height in centimeters:
+        <jsp:getProperty name="height" property="heightCm" />
+        cm
+    </p>
+
+    <br>
+
+    <p>
+        Height in feet and inches:
+        <jsp:getProperty name="height" property="heightFeet" />
+        feet
+        <jsp:getProperty name="height" property="heightInches" />
+        inches
+    </p>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/war/src/main/webapp/index.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/war/src/main/webapp/index.jsp
@@ -1,0 +1,27 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+    <h2>Enter the height in centimeters</h2>
+
+    <form action="heights.jsp" method="post">
+        <input type="text" name="heightCm" /> cm <br> <input type="submit"
+            value="SUBMIT" />
+    </form>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/Dockerfile
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/Dockerfile
@@ -1,0 +1,8 @@
+FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+
+# Add config
+COPY --chown=1001:0  target/liberty/wlp/usr/servers/defaultServer/server.xml /config/
+COPY --chown=1001:0  target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/liberty-plugin-variable-config.xml /config/configDropins/overrides/
+
+# Add application
+COPY --chown=1001:0  target/guide-maven-multimodules-ear.ear /config/apps/ 

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/pom.xml
@@ -77,7 +77,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>SUB_VERSION</version>
             </plugin>
 
             <!-- Since the package type is ear,

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/pom.xml
@@ -1,0 +1,119 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-ear</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>ear</packaging>
+
+    <parent>
+        <groupId>io.openliberty.guides</groupId>
+        <artifactId>guide-maven-multimodules-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../parent/pom.xml</relativePath>
+    </parent>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Liberty configuration in parent-->
+    </properties>
+
+    <dependencies>
+        <!-- web and jar modules as dependencies -->
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-war</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>war</type>
+        </dependency>
+
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <modules>
+                        <jarModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-jar</artifactId>
+                            <uri>/guide-maven-multimodules-jar-1.0-SNAPSHOT.jar</uri>
+                        </jarModule>
+                        <webModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-war</artifactId>
+                            <uri>/guide-maven-multimodules-war-1.0-SNAPSHOT.war</uri>
+                            <!-- Set custom context root -->
+                            <contextRoot>/converter</contextRoot>
+                        </webModule>
+                    </modules>
+                </configuration>
+            </plugin>
+
+            <!-- Enable liberty-maven plugin -->
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.2.3</version>
+            </plugin>
+
+            <!-- Since the package type is ear,
+            need to run testCompile to compile the tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Plugin to run integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <default.http.port>
+                            ${liberty.var.default.http.port}
+                        </default.http.port>
+                        <default.https.port>
+                            ${liberty.var.default.https.port}
+                        </default.https.port>
+                        <cf.context.root>/converter</cf.context.root>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/src/main/liberty/config/server.xml
@@ -1,0 +1,16 @@
+<server description="Sample Liberty server">
+
+    <featureManager>
+        <feature>jsp-2.3</feature>
+    </featureManager>
+
+    <variable name="default.http.port" defaultValue="9080" />
+    <variable name="default.https.port" defaultValue="9443" />
+
+    <httpEndpoint host="*" httpPort="${default.http.port}"
+        httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+
+    <enterpriseApplication id="guide-maven-multimodules-ear"
+        location="guide-maven-multimodules-ear.ear"
+        name="guide-maven-multimodules-ear" />
+</server>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/src/test/java/it/io/openliberty/guides/multimodules/IT.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/src/test/java/it/io/openliberty/guides/multimodules/IT.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package it.io.openliberty.guides.multimodules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+public class IT {
+    String port = System.getProperty("default.http.port");
+    String war = "converter";
+    String urlBase = "http://localhost:" + port + "/" + war + "/";
+
+    @Test
+    public void testIndexPage() throws Exception {
+        String url = this.urlBase;
+        HttpURLConnection con = testRequestHelper(url, "GET");
+        assertEquals(200, con.getResponseCode(), "Incorrect response code from " + url);
+        assertTrue(testBufferHelper(con).contains("Enter the height in centimeters"),
+                        "Incorrect response from " + url);
+    }
+
+    @Test
+    public void testHeightsPage() throws Exception {
+        String url = this.urlBase + "heights.jsp?heightCm=10";
+        HttpURLConnection con = testRequestHelper(url, "POST");
+        assertTrue(testBufferHelper(con).contains("3        inches"),
+                        "Incorrect response from " + url);
+    }
+
+    private HttpURLConnection testRequestHelper(String url, String method)
+                    throws Exception {
+        URL obj = new URL(url);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        // optional default is GET
+        con.setRequestMethod(method);
+        return con;
+    }
+
+    private String testBufferHelper(HttpURLConnection con) throws Exception {
+        BufferedReader in = new BufferedReader(
+                        new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        return response.toString();
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/jar/pom.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-jar</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.lib;
+
+public class Converter {
+
+    public static int getFeet(int cm) {
+        int feet = (int) (cm / 30.48);
+        return feet;
+    }
+
+    public static int getInches(int cm) {
+        double feet = cm / 30.48;
+        int inches = (int) (cm / 2.54) - ((int) feet * 12);
+        return inches;
+    }
+
+    public static int sum(int a, int b) {
+        return a + b;
+    }
+
+    public static int diff(int a, int b) {
+        return a - b;
+    }
+
+    public static int product(int a, int b) {
+        return a * b;
+    }
+
+    public static int quotient(int a, int b) {
+        return a / b;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/parent/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/parent/pom.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Liberty configuration: something child project will need -->
+        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    </properties>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/pom.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>jar</module>
+        <module>war</module>
+        <module>ear</module>
+    </modules>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/war/pom.xml
@@ -1,0 +1,54 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-war</artifactId>
+    <packaging>war</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>guide-maven-multimodules-war</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>3.3</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.web;
+
+public class HeightsBean implements java.io.Serializable {
+    private String heightCm = null;
+    private String heightFeet = null;
+    private String heightInches = null;
+    private int cm = 0;
+    private int feet = 0;
+    private int inches = 0;
+
+    public HeightsBean() {
+    }
+
+    // Capitalize the first letter of the name i.e. first letter after get
+    // If first letter is not capitalized, it must match the property name in
+    // index.jsp
+    public String getHeightCm() {
+        return heightCm;
+    }
+
+    public String getHeightFeet() {
+        return heightFeet;
+    }
+
+    public String getHeightInches() {
+        return heightInches;
+    }
+
+    public void setHeightCm(String heightcm) {
+        this.heightCm = heightcm;
+    }
+
+    // Need an input as placeholder, you can choose not to use the input
+    public void setHeightFeet(String heightfeet) {
+        this.cm = Integer.valueOf(heightCm);
+        this.feet = io.openliberty.guides.multimodules.lib.Converter.getFeet(cm);
+        String result = String.valueOf(feet);
+        this.heightFeet = result;
+    }
+
+    public void setHeightInches(String heightinches) {
+        this.cm = Integer.valueOf(heightCm);
+        this.inches = io.openliberty.guides.multimodules.lib.Converter.getInches(cm);
+        String result = String.valueOf(inches);
+        this.heightInches = result;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/war/src/main/webapp/WEB-INF/web.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE web-app PUBLIC
+ "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+ "http://java.sun.com/dtd/web-app_2_3.dtd" >
+
+<web-app>
+    <display-name>Archetype Created Web Application</display-name>
+</web-app>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/war/src/main/webapp/heights.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/war/src/main/webapp/heights.jsp
@@ -1,0 +1,42 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+
+    <jsp:useBean id="height" class="io.openliberty.guides.multimodules.web.HeightsBean"></jsp:useBean>
+    <jsp:setProperty name="height" property="heightCm" />
+    <jsp:setProperty name="height" property="heightFeet" value="0" />
+    <jsp:setProperty name="height" property="heightInches" value="0" />
+
+    <p>
+        Height in centimeters:
+        <jsp:getProperty name="height" property="heightCm" />
+        cm
+    </p>
+
+    <br>
+
+    <p>
+        Height in feet and inches:
+        <jsp:getProperty name="height" property="heightFeet" />
+        feet
+        <jsp:getProperty name="height" property="heightInches" />
+        inches
+    </p>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/war/src/main/webapp/index.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/war/src/main/webapp/index.jsp
@@ -1,0 +1,27 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+    <h2>Enter the height in centimeters</h2>
+
+    <form action="heights.jsp" method="post">
+        <input type="text" name="heightCm" /> cm <br> <input type="submit"
+            value="SUBMIT" />
+    </form>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/Dockerfile
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/Dockerfile
@@ -1,0 +1,8 @@
+FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+
+# Add config
+COPY --chown=1001:0  pom/target/liberty/wlp/usr/servers/defaultServer/server.xml /config/
+COPY --chown=1001:0  pom/target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/liberty-plugin-variable-config.xml /config/configDropins/overrides/
+
+# Add application
+COPY --chown=1001:0  ear/target/guide-maven-multimodules-ear.ear /config/apps/ 

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/jar/pom.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-jar</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.lib;
+
+public class Converter {
+
+    public static int getFeet(int cm) {
+        int feet = (int) (cm / 30.48);
+        return feet;
+    }
+
+    public static int getInches(int cm) {
+        double feet = cm / 30.48;
+        int inches = (int) (cm / 2.54) - ((int) feet * 12);
+        return inches;
+    }
+
+    public static int sum(int a, int b) {
+        return a + b;
+    }
+
+    public static int diff(int a, int b) {
+        return a - b;
+    }
+
+    public static int product(int a, int b) {
+        return a * b;
+    }
+
+    public static int quotient(int a, int b) {
+        return a / b;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>jar</module>
+        <module>war1</module>
+        <module>war2</module>
+        <module>pom</module>
+    </modules>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.3.5-SNAPSHOT</version>
+                <version>SUB_VERSION</version>
                 <extensions>true</extensions>
                 <configuration>
                     <deployPackages>dependencies</deployPackages>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
@@ -1,0 +1,96 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-pom</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <!-- Liberty configuration -->
+        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-war1</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>war</type>
+        </dependency>
+
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-war2</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>war</type>
+        </dependency>
+
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+
+            <!-- Enable liberty-maven plugin -->
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.3.5-SNAPSHOT</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <deployPackages>dependencies</deployPackages>
+                    <stripVersion>true</stripVersion>
+                </configuration>
+            </plugin>
+
+            <!-- Since the package type is ear,
+            need to run testCompile to compile the tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Plugin to run integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <default.http.port>
+                            ${liberty.var.default.http.port}
+                        </default.http.port>
+                        <default.https.port>
+                            ${liberty.var.default.https.port}
+                        </default.https.port>
+                        <cf.context.root>/converter</cf.context.root>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/src/main/liberty/config/server.xml
@@ -1,0 +1,16 @@
+<server description="Sample Liberty server">
+    <featureManager>
+        <feature>jsp-2.3</feature>
+        <feature>mpHealth-2.2</feature>
+    </featureManager>
+
+    <variable name="default.http.port" defaultValue="9080" />
+    <variable name="default.https.port" defaultValue="9443" />
+
+    <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+
+    <webApplication id="guide-maven-multimodules-war1-test" location="guide-maven-multimodules-war1.war" name="Converter web app 1" contextRoot="/converter1/" />
+
+    <webApplication id="guide-maven-multimodules-war2" location="guide-maven-multimodules-war2.war" name="Converter web app 2" contextRoot="/converter2/" />
+
+</server>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/src/test/java/it/io/openliberty/guides/multimodules/IT.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/src/test/java/it/io/openliberty/guides/multimodules/IT.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package it.io.openliberty.guides.multimodules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+public class IT {
+    String port = System.getProperty("default.http.port");
+    String war = "converter1";
+    String urlBase = "http://localhost:" + port + "/" + war + "/";
+
+    @Test
+    public void testIndexPage() throws Exception {
+        String url = this.urlBase;
+        HttpURLConnection con = testRequestHelper(url, "GET");
+        assertEquals(200, con.getResponseCode(), "Incorrect response code from " + url);
+        assertTrue(testBufferHelper(con).contains("Enter the height in centimeters"),
+                        "Incorrect response from " + url);
+    }
+
+    @Test
+    public void testHeightsPage() throws Exception {
+        String url = this.urlBase + "heights.jsp?heightCm=10";
+        HttpURLConnection con = testRequestHelper(url, "POST");
+        assertTrue(testBufferHelper(con).contains("3        inches"),
+                        "Incorrect response from " + url);
+    }
+
+    private HttpURLConnection testRequestHelper(String url, String method)
+                    throws Exception {
+        URL obj = new URL(url);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        // optional default is GET
+        con.setRequestMethod(method);
+        return con;
+    }
+
+    private String testBufferHelper(HttpURLConnection con) throws Exception {
+        BufferedReader in = new BufferedReader(
+                        new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        return response.toString();
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/pom.xml
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>SUB_VERSION</version>
+                <version>3.3.1</version>
                 <configuration>
                     <modules>
                         <jarModule>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/pom.xml
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>SUB_VERSION</version>
                 <configuration>
                     <modules>
                         <jarModule>
@@ -90,7 +90,7 @@
             <!-- <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>SUB_VERSION</version>
             </plugin> -->
 
             <!-- Since the package type is ear,

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/pom.xml
@@ -1,0 +1,132 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-war1</artifactId>
+    <packaging>war</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>guide-maven-multimodules-war1</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Liberty configuration -->
+        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    </properties>
+
+    <dependencies>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>3.3</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <modules>
+                        <jarModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-jar</artifactId>
+                            <uri>/guide-maven-multimodules-jar-1.0-SNAPSHOT.jar</uri>
+                        </jarModule>
+                        <webModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-war</artifactId>
+                            <uri>/guide-maven-multimodules-war-1.0-SNAPSHOT.war</uri>
+                            <!-- Set custom context root -->
+                            <contextRoot>/converter1</contextRoot>
+                        </webModule>
+                    </modules>
+                </configuration>
+            </plugin>
+
+            <!-- Enable liberty-maven plugin -->
+            <!-- <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.2.3</version>
+            </plugin> -->
+
+            <!-- Since the package type is ear,
+            need to run testCompile to compile the tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Plugin to run integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <default.http.port>
+                            ${liberty.var.default.http.port}
+                        </default.http.port>
+                        <default.https.port>
+                            ${liberty.var.default.https.port}
+                        </default.https.port>
+                        <cf.context.root>/converter1</cf.context.root>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.web;
+
+public class HeightsBean implements java.io.Serializable {
+    private String heightCm = null;
+    private String heightFeet = null;
+    private String heightInches = null;
+    private int cm = 0;
+    private int feet = 0;
+    private int inches = 0;
+
+    public HeightsBean() {
+    }
+
+    // Capitalize the first letter of the name i.e. first letter after get
+    // If first letter is not capitalized, it must match the property name in
+    // index.jsp
+    public String getHeightCm() {
+        return heightCm;
+    }
+
+    public String getHeightFeet() {
+        return heightFeet;
+    }
+
+    public String getHeightInches() {
+        return heightInches;
+    }
+
+    public void setHeightCm(String heightcm) {
+        this.heightCm = heightcm;
+    }
+
+    // Need an input as placeholder, you can choose not to use the input
+    public void setHeightFeet(String heightfeet) {
+        this.cm = Integer.valueOf(heightCm);
+        this.feet = io.openliberty.guides.multimodules.lib.Converter.getFeet(cm);
+        String result = String.valueOf(feet);
+        this.heightFeet = result;
+    }
+
+    public void setHeightInches(String heightinches) {
+        this.cm = Integer.valueOf(heightCm);
+        this.inches = io.openliberty.guides.multimodules.lib.Converter.getInches(cm);
+        String result = String.valueOf(inches);
+        this.heightInches = result;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/src/main/webapp/WEB-INF/web.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE web-app PUBLIC
+ "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+ "http://java.sun.com/dtd/web-app_2_3.dtd" >
+
+<web-app>
+    <display-name>Archetype Created Web Application</display-name>
+</web-app>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/src/main/webapp/heights.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/src/main/webapp/heights.jsp
@@ -1,0 +1,42 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+
+    <jsp:useBean id="height" class="io.openliberty.guides.multimodules.web.HeightsBean"></jsp:useBean>
+    <jsp:setProperty name="height" property="heightCm" />
+    <jsp:setProperty name="height" property="heightFeet" value="0" />
+    <jsp:setProperty name="height" property="heightInches" value="0" />
+
+    <p>
+        Height in centimeters:
+        <jsp:getProperty name="height" property="heightCm" />
+        cm
+    </p>
+
+    <br>
+
+    <p>
+        Height in feet and inches:
+        <jsp:getProperty name="height" property="heightFeet" />
+        feet
+        <jsp:getProperty name="height" property="heightInches" />
+        inches
+    </p>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/src/main/webapp/index.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/src/main/webapp/index.jsp
@@ -1,0 +1,27 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter 1</title>
+</head>
+<body>
+    <h1>Height Converter 1</h1>
+    <h2>Enter the height in centimeters</h2>
+
+    <form action="heights.jsp" method="post">
+        <input type="text" name="heightCm" /> cm <br> <input type="submit"
+            value="SUBMIT" />
+    </form>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/pom.xml
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>SUB_VERSION</version>
+                <version>3.3.1</version>
                 <configuration>
                     <modules>
                         <jarModule>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/pom.xml
@@ -1,0 +1,132 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-war2</artifactId>
+    <packaging>war</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>guide-maven-multimodules-war2</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Liberty configuration -->
+        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    </properties>
+
+    <dependencies>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>3.3</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <modules>
+                        <jarModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-jar</artifactId>
+                            <uri>/guide-maven-multimodules-jar-1.0-SNAPSHOT.jar</uri>
+                        </jarModule>
+                        <webModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-war</artifactId>
+                            <uri>/guide-maven-multimodules-war-1.0-SNAPSHOT.war</uri>
+                            <!-- Set custom context root -->
+                            <contextRoot>/converter2</contextRoot>
+                        </webModule>
+                    </modules>
+                </configuration>
+            </plugin>
+
+            <!-- Enable liberty-maven plugin -->
+            <!-- <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.2.3</version>
+            </plugin> -->
+
+            <!-- Since the package type is ear,
+            need to run testCompile to compile the tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Plugin to run integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <default.http.port>
+                            ${liberty.var.default.http.port}
+                        </default.http.port>
+                        <default.https.port>
+                            ${liberty.var.default.https.port}
+                        </default.https.port>
+                        <cf.context.root>/converter2</cf.context.root>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/pom.xml
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>SUB_VERSION</version>
                 <configuration>
                     <modules>
                         <jarModule>
@@ -90,7 +90,7 @@
             <!-- <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>SUB_VERSION</version>
             </plugin> -->
 
             <!-- Since the package type is ear,

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.web;
+
+public class HeightsBean implements java.io.Serializable {
+    private String heightCm = null;
+    private String heightFeet = null;
+    private String heightInches = null;
+    private int cm = 0;
+    private int feet = 0;
+    private int inches = 0;
+
+    public HeightsBean() {
+    }
+
+    // Capitalize the first letter of the name i.e. first letter after get
+    // If first letter is not capitalized, it must match the property name in
+    // index.jsp
+    public String getHeightCm() {
+        return heightCm;
+    }
+
+    public String getHeightFeet() {
+        return heightFeet;
+    }
+
+    public String getHeightInches() {
+        return heightInches;
+    }
+
+    public void setHeightCm(String heightcm) {
+        this.heightCm = heightcm;
+    }
+
+    // Need an input as placeholder, you can choose not to use the input
+    public void setHeightFeet(String heightfeet) {
+        this.cm = Integer.valueOf(heightCm);
+        this.feet = io.openliberty.guides.multimodules.lib.Converter.getFeet(cm);
+        String result = String.valueOf(feet);
+        this.heightFeet = result;
+    }
+
+    public void setHeightInches(String heightinches) {
+        this.cm = Integer.valueOf(heightCm);
+        this.inches = io.openliberty.guides.multimodules.lib.Converter.getInches(cm);
+        String result = String.valueOf(inches);
+        this.heightInches = result;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/src/main/webapp/WEB-INF/web.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE web-app PUBLIC
+ "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+ "http://java.sun.com/dtd/web-app_2_3.dtd" >
+
+<web-app>
+    <display-name>Archetype Created Web Application</display-name>
+</web-app>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/src/main/webapp/heights.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/src/main/webapp/heights.jsp
@@ -1,0 +1,42 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+
+    <jsp:useBean id="height" class="io.openliberty.guides.multimodules.web.HeightsBean"></jsp:useBean>
+    <jsp:setProperty name="height" property="heightCm" />
+    <jsp:setProperty name="height" property="heightFeet" value="0" />
+    <jsp:setProperty name="height" property="heightInches" value="0" />
+
+    <p>
+        Height in centimeters:
+        <jsp:getProperty name="height" property="heightCm" />
+        cm
+    </p>
+
+    <br>
+
+    <p>
+        Height in feet and inches:
+        <jsp:getProperty name="height" property="heightFeet" />
+        feet
+        <jsp:getProperty name="height" property="heightInches" />
+        inches
+    </p>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/src/main/webapp/index.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/src/main/webapp/index.jsp
@@ -1,0 +1,27 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter 2</title>
+</head>
+<body>
+    <h1>Height Converter 2</h1>
+    <h2>Enter the height in centimeters</h2>
+
+    <form action="heights.jsp" method="post">
+        <input type="text" name="heightCm" /> cm <br> <input type="submit"
+            value="SUBMIT" />
+    </form>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright IBM Corporation 2019.
+ * (c) Copyright IBM Corporation 2019, 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
@@ -48,10 +48,8 @@ import org.junit.Test;
 
 public class BaseDevTest {
 
-   static boolean startProcessDuringSetup = true;
-   static String libertyConfigModule;
-   static String pomModule;
-
+   static String customLibertyModule;
+   static String customPomModule;
    static File tempProj;
    static File basicDevProj;
    static File logFile;
@@ -73,6 +71,13 @@ public class BaseDevTest {
    }
 
    protected static void setUpBeforeClass(String params, String projectRoot, boolean isDevMode) throws IOException, InterruptedException, FileNotFoundException {
+      setUpBeforeClass(params, projectRoot, isDevMode, true, null, null);
+   }
+
+   protected static void setUpBeforeClass(String params, String projectRoot, boolean isDevMode, boolean startProcessDuringSetup, String libertyConfigModule, String pomModule) throws IOException, InterruptedException, FileNotFoundException {
+      customLibertyModule = libertyConfigModule;
+      customPomModule = pomModule;
+
       basicDevProj = new File(projectRoot);
 
       tempProj = Files.createTempDirectory("temp").toFile();
@@ -86,10 +91,10 @@ public class BaseDevTest {
       logFile = new File(basicDevProj, "logFile.txt");
       assertTrue(logFile.createNewFile());
 
-      if (pomModule == null) {
+      if (customPomModule == null) {
          pom = new File(tempProj, "pom.xml");
       } else {
-         pom = new File(new File(tempProj, pomModule), "pom.xml");
+         pom = new File(new File(tempProj, customPomModule), "pom.xml");
       }
       assertTrue(pom.exists());
 
@@ -121,8 +126,8 @@ public class BaseDevTest {
 
       builder.redirectOutput(logFile);
       builder.redirectError(logFile);
-      if (pomModule != null) {
-         builder.directory(new File(tempProj, pomModule));
+      if (customPomModule != null) {
+         builder.directory(new File(tempProj, customPomModule));
       }
       process = builder.start();
       assertTrue(process.isAlive());
@@ -139,10 +144,10 @@ public class BaseDevTest {
       }
 
       // verify that the target directory was created
-      if (libertyConfigModule == null) {
+      if (customLibertyModule == null) {
          targetDir = new File(tempProj, "target");
       } else {
-         targetDir = new File(new File(tempProj, libertyConfigModule), "target");
+         targetDir = new File(new File(tempProj, customLibertyModule), "target");
       }
       assertTrue(targetDir.exists());
    }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
@@ -48,6 +48,8 @@ import org.junit.Test;
 
 public class BaseDevTest {
 
+   static boolean startProcessDuringSetup = true;
+   static String libertyConfigModule;
    static File tempProj;
    static File basicDevProj;
    static File logFile;
@@ -87,10 +89,16 @@ public class BaseDevTest {
 
       replaceVersion();
 
-      startProcess(params, isDevMode);
+      if (startProcessDuringSetup) {
+         startProcess(params, isDevMode);
+      }
    }
 
-   private static void startProcess(String params, boolean isDevMode) throws IOException, InterruptedException, FileNotFoundException {
+   protected static void startProcess(String params, boolean isDevMode) throws IOException, InterruptedException, FileNotFoundException {
+      startProcess(params, isDevMode, "mvn liberty:");
+   }
+
+   protected static void startProcess(String params, boolean isDevMode, String mavenPluginCommand) throws IOException, InterruptedException, FileNotFoundException {
       // run dev mode on project
       String goal;
       if(isDevMode) {
@@ -99,7 +107,7 @@ public class BaseDevTest {
          goal = "run";
       }
 
-      StringBuilder command = new StringBuilder("mvn liberty:" + goal);
+      StringBuilder command = new StringBuilder(mavenPluginCommand + goal);
       if (params != null) {
          command.append(" " + params);
       }
@@ -122,7 +130,11 @@ public class BaseDevTest {
       }
 
       // verify that the target directory was created
-      targetDir = new File(tempProj, "target");
+      if (libertyConfigModule == null) {
+         targetDir = new File(tempProj, "target");
+      } else {
+         targetDir = new File(new File(tempProj, libertyConfigModule), "target");
+      }
       assertTrue(targetDir.exists());
    }
 
@@ -187,7 +199,7 @@ public class BaseDevTest {
       String line = br.readLine();
       try {
          while (line != null) {
-            if (line.contains(str)) {
+            if (line.contains(str) || line.matches(str)) {
                return true;
             }
             line = br.readLine();
@@ -241,4 +253,5 @@ public class BaseDevTest {
       }
       return false;
    }
+   
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
@@ -50,6 +50,8 @@ public class BaseDevTest {
 
    static boolean startProcessDuringSetup = true;
    static String libertyConfigModule;
+   static String pomModule;
+
    static File tempProj;
    static File basicDevProj;
    static File logFile;
@@ -84,7 +86,11 @@ public class BaseDevTest {
       logFile = new File(basicDevProj, "logFile.txt");
       assertTrue(logFile.createNewFile());
 
-      pom = new File(tempProj, "pom.xml");
+      if (pomModule == null) {
+         pom = new File(tempProj, "pom.xml");
+      } else {
+         pom = new File(new File(tempProj, pomModule), "pom.xml");
+      }
       assertTrue(pom.exists());
 
       replaceVersion();
@@ -115,6 +121,9 @@ public class BaseDevTest {
 
       builder.redirectOutput(logFile);
       builder.redirectError(logFile);
+      if (pomModule != null) {
+         builder.directory(new File(tempProj, pomModule));
+      }
       process = builder.start();
       assertTrue(process.isAlive());
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
@@ -74,6 +74,19 @@ public class BaseDevTest {
       setUpBeforeClass(params, projectRoot, isDevMode, true, null, null);
    }
 
+   /**
+    * Setup and optionally start dev/run
+    *
+    * @param params Params for the dev/run goal
+    * @param projectRoot The Maven project root
+    * @param isDevMode Use dev if true, use run if false.  Ignored if startProcessDuringSetup is false.
+    * @param startProcessDuringSetup If this method should start the actual dev/run process
+    * @param libertyConfigModule For multi module project, the module where Liberty configuration is located
+    * @param pomModule For multi module project, the module where the pom is located.  If null, use the project root.
+    * @throws IOException
+    * @throws InterruptedException
+    * @throws FileNotFoundException
+    */
    protected static void setUpBeforeClass(String params, String projectRoot, boolean isDevMode, boolean startProcessDuringSetup, String libertyConfigModule, String pomModule) throws IOException, InterruptedException, FileNotFoundException {
       customLibertyModule = libertyConfigModule;
       customPomModule = pomModule;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
@@ -213,7 +213,7 @@ public class BaseDevTest {
       String line = br.readLine();
       try {
          while (line != null) {
-            if (line.contains(str) || line.matches(str)) {
+            if (line.contains(str)) {
                return true;
             }
             line = br.readLine();

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
@@ -46,7 +46,8 @@ public class BaseMultiModuleTest extends BaseDevTest {
    }
 
    protected static void run(boolean devMode) throws Exception {
-      startProcess(null, devMode, "mvn io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":");
+      // TODO remove mvn install when https://github.com/OpenLiberty/ci.maven/issues/1176 is fixed 
+      startProcess(null, devMode, "mvn install && mvn io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":");
    }
 
    private static void replaceVersion(File dir) throws IOException {

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
@@ -29,21 +29,22 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class MultiModuleTest extends BaseDevTest {
+public class BaseMultiModuleTest extends BaseDevTest {
 
-   @BeforeClass
-   public static void setUpBeforeClass() throws Exception {
+   public static void setUpMultiModule(String testcaseFolder, String libertyModule) throws Exception {
       startProcessDuringSetup = false;
 
-      setUpBeforeClass(null, "../resources/multi-module-projects/typeA");
-      libertyConfigModule = "ear";
+      setUpBeforeClass(null, "../resources/multi-module-projects/" + testcaseFolder);
+      libertyConfigModule = libertyModule;
 
       optionalReplaceVersion(tempProj);
       optionalReplaceVersion(new File(tempProj, "pom"));
       optionalReplaceVersion(new File(tempProj, "ear"));
       optionalReplaceVersion(new File(tempProj, "war"));
       optionalReplaceVersion(new File(tempProj, "war2"));
+   }
 
+   protected static void run() throws Exception {
       startProcess(null, true, "mvn io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":");
    }
 
@@ -63,7 +64,6 @@ public class MultiModuleTest extends BaseDevTest {
       }
    }
 
-   @Test
    public void manualTestsInvocationTest() throws Exception {
       assertTrue(verifyLogMessageExists("To run tests on demand, press Enter.", 30000));
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
@@ -42,7 +42,11 @@ public class BaseMultiModuleTest extends BaseDevTest {
    }
 
    protected static void run() throws Exception {
-      startProcess(null, true, "mvn io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":");
+      run(true);
+   }
+
+   protected static void run(boolean devMode) throws Exception {
+      startProcess(null, devMode, "mvn io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":");
    }
 
    private static void replaceVersion(File dir) throws IOException {

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright IBM Corporation 2019.
+ * (c) Copyright IBM Corporation 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
@@ -61,14 +61,14 @@ public class BaseMultiModuleTest extends BaseDevTest {
       }
    }
 
-   public void manualTestsInvocationTest() throws Exception {
+   public void manualTestsInvocationTest(String libertyModuleArtifactId) throws Exception {
       assertTrue(verifyLogMessageExists("To run tests on demand, press Enter.", 30000));
 
       writer.write("\n");
       writer.flush();
 
-      assertTrue(verifyLogMessageExists(".*Unit tests .* finished.", 10000));
-      assertTrue(verifyLogMessageExists(".*Integration tests .* finished.", 2000));
+      assertTrue(verifyLogMessageExists("Unit tests for " + libertyModuleArtifactId + " finished.", 10000));
+      assertTrue(verifyLogMessageExists("Integration tests for " + libertyModuleArtifactId + " finished.", 10000));
 
       assertFalse("Found CWWKM2179W message indicating incorrect app deployment", verifyLogMessageExists("CWWKM2179W", 2000));
    }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
@@ -67,7 +67,9 @@ public class BaseMultiModuleTest extends BaseDevTest {
       writer.write("\n");
       writer.flush();
 
-      assertTrue(verifyLogMessageExists("Unit tests for " + libertyModuleArtifactId + " finished.", 10000));
+      if (!libertyModuleArtifactId.endsWith("ear")) {
+         assertTrue(verifyLogMessageExists("Unit tests for " + libertyModuleArtifactId + " finished.", 10000));
+      }
       assertTrue(verifyLogMessageExists("Integration tests for " + libertyModuleArtifactId + " finished.", 10000));
 
       assertFalse("Found CWWKM2179W message indicating incorrect app deployment", verifyLogMessageExists("CWWKM2179W", 2000));

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
@@ -31,11 +31,8 @@ import org.junit.Test;
 
 public class BaseMultiModuleTest extends BaseDevTest {
 
-   public static void setUpMultiModule(String testcaseFolder, String libertyModule) throws Exception {
-      startProcessDuringSetup = false;
-
-      setUpBeforeClass(null, "../resources/multi-module-projects/" + testcaseFolder);
-      libertyConfigModule = libertyModule;
+   public static void setUpMultiModule(String testcaseFolder, String libertyModule, String pomModule) throws Exception {
+      setUpBeforeClass(null, "../resources/multi-module-projects/" + testcaseFolder, true, false, libertyModule, pomModule);
 
       optionalReplaceVersion(tempProj);
       optionalReplaceVersion(new File(tempProj, "pom"));

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.methods.GetMethod;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MultiModuleRunTest extends BaseMultiModuleTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      setUpMultiModule("typeA", "ear", null);
+      run(false);
+   }
+
+   @Test
+   public void endpointTest() throws Exception {
+      HttpClient client = new HttpClient();
+
+      GetMethod method = new GetMethod("http://localhost:9080/converter");
+      try {
+         int statusCode = client.executeMethod(method);
+
+         assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
+
+         String response = method.getResponseBodyAsString();
+
+         assertTrue("Unexpected response body", response.contains("Height Converter"));
+      } finally {
+         method.releaseConnection();
+      }
+   }
+
+   @AfterClass
+   public static void cleanUpAfterClass() throws Exception {
+      BaseDevTest.cleanUpAfterClass(false);
+   }
+
+}
+

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTest.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MultiModuleTest extends BaseDevTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      startProcessDuringSetup = false;
+
+      setUpBeforeClass(null, "../resources/multi-module-projects/typeA");
+      libertyConfigModule = "ear";
+
+      optionalReplaceVersion(tempProj);
+      optionalReplaceVersion(new File(tempProj, "pom"));
+      optionalReplaceVersion(new File(tempProj, "ear"));
+      optionalReplaceVersion(new File(tempProj, "war"));
+      optionalReplaceVersion(new File(tempProj, "war2"));
+
+      startProcess(null, true, "mvn io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":");
+   }
+
+   private static void replaceVersion(File dir) throws IOException {
+      File pom = new File(dir, "pom.xml");
+      String pluginVersion = System.getProperty("mavenPluginVersion");
+      replaceString("SUB_VERSION", pluginVersion, pom);
+      String runtimeVersion = System.getProperty("runtimeVersion");
+      replaceString("RUNTIME_VERSION", runtimeVersion, pom);
+   }
+
+   private static void optionalReplaceVersion(File pom) {
+      try {
+         replaceVersion(pom);
+      } catch (IOException e) {
+         // ignore failures
+      }
+   }
+
+   @Test
+   public void manualTestsInvocationTest() throws Exception {
+      assertTrue(verifyLogMessageExists("To run tests on demand, press Enter.", 30000));
+
+      writer.write("\n");
+      writer.flush();
+
+      assertTrue(verifyLogMessageExists(".*Unit tests .* finished.", 10000));
+      assertTrue(verifyLogMessageExists(".*Integration tests .* finished.", 2000));
+
+      assertFalse("Found CWWKM2179W message indicating incorrect app deployment", verifyLogMessageExists("CWWKM2179W", 2000));
+   }
+
+   @AfterClass
+   public static void cleanUpAfterClass() throws Exception {
+      BaseDevTest.cleanUpAfterClass();
+   }
+}
+

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA2Test.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA2Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright IBM Corporation 2019.
+ * (c) Copyright IBM Corporation 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA2Test.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA2Test.java
@@ -39,7 +39,7 @@ public class MultiModuleTypeA2Test extends BaseMultiModuleTest {
 
    @Test
    public void manualTestsInvocationTest() throws Exception {
-      super.manualTestsInvocationTest();
+      super.manualTestsInvocationTest("guide-maven-multimodules-ear");
    }
 
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA2Test.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA2Test.java
@@ -33,8 +33,7 @@ public class MultiModuleTypeA2Test extends BaseMultiModuleTest {
 
    @BeforeClass
    public static void setUpBeforeClass() throws Exception {
-      pomModule = "pom";
-      setUpMultiModule("typeA2", "ear");
+      setUpMultiModule("typeA2", "ear", "pom");
       run();
    }
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA2Test.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA2Test.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MultiModuleTypeA2Test extends BaseMultiModuleTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      pomModule = "pom";
+      setUpMultiModule("typeA2", "ear");
+      run();
+   }
+
+   @Test
+   public void manualTestsInvocationTest() throws Exception {
+      super.manualTestsInvocationTest();
+   }
+
+}
+

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeATest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeATest.java
@@ -39,7 +39,7 @@ public class MultiModuleTypeATest extends BaseMultiModuleTest {
 
    @Test
    public void manualTestsInvocationTest() throws Exception {
-      super.manualTestsInvocationTest();
+      super.manualTestsInvocationTest("guide-maven-multimodules-ear");
    }
 
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeATest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeATest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MultiModuleTypeATest extends BaseMultiModuleTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      setUpMultiModule("typeA", "ear");
+      run();
+   }
+
+   @Test
+   public void manualTestsInvocationTest() throws Exception {
+      super.manualTestsInvocationTest();
+   }
+
+}
+

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeATest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeATest.java
@@ -33,7 +33,7 @@ public class MultiModuleTypeATest extends BaseMultiModuleTest {
 
    @BeforeClass
    public static void setUpBeforeClass() throws Exception {
-      setUpMultiModule("typeA", "ear");
+      setUpMultiModule("typeA", "ear", null);
       run();
    }
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeATest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeATest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright IBM Corporation 2019.
+ * (c) Copyright IBM Corporation 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeBTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeBTest.java
@@ -39,7 +39,7 @@ public class MultiModuleTypeBTest extends BaseMultiModuleTest {
 
    @Test
    public void manualTestsInvocationTest() throws Exception {
-      super.manualTestsInvocationTest();
+      super.manualTestsInvocationTest("guide-maven-multimodules-war");
    }
 
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeBTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeBTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MultiModuleTypeBTest extends BaseMultiModuleTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      setUpMultiModule("typeB", "war");
+      run();
+   }
+
+   @Test
+   public void manualTestsInvocationTest() throws Exception {
+      super.manualTestsInvocationTest();
+   }
+
+}
+

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeBTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeBTest.java
@@ -33,7 +33,7 @@ public class MultiModuleTypeBTest extends BaseMultiModuleTest {
 
    @BeforeClass
    public static void setUpBeforeClass() throws Exception {
-      setUpMultiModule("typeB", "war");
+      setUpMultiModule("typeB", "war", null);
       run();
    }
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeBTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeBTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright IBM Corporation 2019.
+ * (c) Copyright IBM Corporation 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeETest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeETest.java
@@ -33,7 +33,7 @@ public class MultiModuleTypeETest extends BaseMultiModuleTest {
 
    @BeforeClass
    public static void setUpBeforeClass() throws Exception {
-      setUpMultiModule("typeE", "pom");
+      setUpMultiModule("typeE", "pom", null);
       run();
    }
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeETest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeETest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright IBM Corporation 2019.
+ * (c) Copyright IBM Corporation 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeETest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeETest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MultiModuleTypeETest extends BaseMultiModuleTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      setUpMultiModule("typeE", "pom");
+      run();
+   }
+
+   @Test
+   public void manualTestsInvocationTest() throws Exception {
+      super.manualTestsInvocationTest();
+   }
+
+}
+

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeETest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeETest.java
@@ -39,7 +39,7 @@ public class MultiModuleTypeETest extends BaseMultiModuleTest {
 
    @Test
    public void manualTestsInvocationTest() throws Exception {
-      super.manualTestsInvocationTest();
+      super.manualTestsInvocationTest("guide-maven-multimodules-pom");
    }
 
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeGTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeGTest.java
@@ -33,7 +33,7 @@ public class MultiModuleTypeGTest extends BaseMultiModuleTest {
 
    @BeforeClass
    public static void setUpBeforeClass() throws Exception {
-      setUpMultiModule("typeG", "pom");
+      setUpMultiModule("typeG", "pom", null);
       run();
    }
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeGTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeGTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright IBM Corporation 2019.
+ * (c) Copyright IBM Corporation 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeGTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeGTest.java
@@ -39,7 +39,7 @@ public class MultiModuleTypeGTest extends BaseMultiModuleTest {
 
    @Test
    public void manualTestsInvocationTest() throws Exception {
-      super.manualTestsInvocationTest();
+      super.manualTestsInvocationTest("guide-maven-multimodules-pom");
    }
 
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeGTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeGTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MultiModuleTypeGTest extends BaseMultiModuleTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      setUpMultiModule("typeG", "pom");
+      run();
+   }
+
+   @Test
+   public void manualTestsInvocationTest() throws Exception {
+      super.manualTestsInvocationTest();
+   }
+
+}
+

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeHTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeHTest.java
@@ -39,7 +39,7 @@ public class MultiModuleTypeHTest extends BaseMultiModuleTest {
 
    @Test
    public void manualTestsInvocationTest() throws Exception {
-      super.manualTestsInvocationTest();
+      super.manualTestsInvocationTest("guide-maven-multimodules-pom");
    }
 
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeHTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeHTest.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MultiModuleTypeHTest extends BaseMultiModuleTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      pomModule = "pom";
+      setUpMultiModule("typeH", "pom");
+      run();
+   }
+
+   @Test
+   public void manualTestsInvocationTest() throws Exception {
+      super.manualTestsInvocationTest();
+   }
+
+}
+

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeHTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeHTest.java
@@ -33,8 +33,7 @@ public class MultiModuleTypeHTest extends BaseMultiModuleTest {
 
    @BeforeClass
    public static void setUpBeforeClass() throws Exception {
-      pomModule = "pom";
-      setUpMultiModule("typeH", "pom");
+      setUpMultiModule("typeH", "pom", "pom");
       run();
    }
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeHTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeHTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright IBM Corporation 2019.
+ * (c) Copyright IBM Corporation 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeITest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeITest.java
@@ -33,7 +33,7 @@ public class MultiModuleTypeITest extends BaseMultiModuleTest {
 
    @BeforeClass
    public static void setUpBeforeClass() throws Exception {
-      setUpMultiModule("typeI", "ear");
+      setUpMultiModule("typeI", "ear", null);
       run();
    }
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeITest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeITest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MultiModuleTypeITest extends BaseMultiModuleTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      setUpMultiModule("typeI", "ear");
+      run();
+   }
+
+   @Test
+   public void manualTestsInvocationTest() throws Exception {
+      super.manualTestsInvocationTest();
+   }
+
+}
+

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeITest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright IBM Corporation 2019.
+ * (c) Copyright IBM Corporation 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeITest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeITest.java
@@ -39,7 +39,7 @@ public class MultiModuleTypeITest extends BaseMultiModuleTest {
 
    @Test
    public void manualTestsInvocationTest() throws Exception {
-      super.manualTestsInvocationTest();
+      super.manualTestsInvocationTest("guide-maven-multimodules-ear");
    }
 
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeJTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeJTest.java
@@ -39,7 +39,7 @@ public class MultiModuleTypeJTest extends BaseMultiModuleTest {
 
    @Test
    public void manualTestsInvocationTest() throws Exception {
-      super.manualTestsInvocationTest();
+      super.manualTestsInvocationTest("guide-maven-multimodules-pom");
    }
 
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeJTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeJTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MultiModuleTypeJTest extends BaseMultiModuleTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      setUpMultiModule("typeJ", "pom");
+      run();
+   }
+
+   @Test
+   public void manualTestsInvocationTest() throws Exception {
+      super.manualTestsInvocationTest();
+   }
+
+}
+

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeJTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeJTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright IBM Corporation 2019.
+ * (c) Copyright IBM Corporation 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeJTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeJTest.java
@@ -33,7 +33,7 @@ public class MultiModuleTypeJTest extends BaseMultiModuleTest {
 
    @BeforeClass
    public static void setUpBeforeClass() throws Exception {
-      setUpMultiModule("typeJ", "pom");
+      setUpMultiModule("typeJ", "pom", null);
       run();
    }
 


### PR DESCRIPTION
Part of https://github.com/OpenLiberty/ci.maven/issues/1178

Adds test projects to `src/it/dev-it/resources/multi-module-projects` based on https://github.com/turkeylurkey/lmp-multimodules/tree/main/testCases

Adds `MultiModuleType*Test.java` corresponding to each of those test projects and extending `src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java`