### PR TITLE
Automate workaround to install ear to .m2

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
@@ -52,24 +52,7 @@ public class BaseMultiModuleTest extends BaseDevTest {
    }
 
    protected static void run(boolean devMode) throws Exception {
-      // TODO remove mvn install when https://github.com/OpenLiberty/ci.maven/issues/1176 is fixed 
-      runMvnInstall();
       startProcess(null, devMode, "mvn io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":");
-   }
-
-   private static void runMvnInstall() throws Exception {
-      StringBuilder command = new StringBuilder("mvn install");
-      ProcessBuilder builder = buildProcess(command.toString());
-
-      builder.redirectOutput(logFile);
-      builder.redirectError(logFile);
-      if (customPomModule != null) {
-         builder.directory(new File(tempProj, customPomModule));
-      }
-      Process mvnInstallProcess = builder.start();
-      assertTrue(mvnInstallProcess.isAlive());
-      mvnInstallProcess.waitFor(120, TimeUnit.SECONDS);
-      assertEquals(0, mvnInstallProcess.exitValue());
    }
 
    private static void replaceVersion(File dir) throws IOException {

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunInstallEarTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunInstallEarTest.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpException;
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.methods.GetMethod;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MultiModuleRunInstallEarTest extends BaseMultiModuleTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      setUpMultiModule("typeH", "pom", "pom");
+      run(false);
+   }
+
+   /**
+    * setUpBeforeClass will install an empty EAR file to m2, or a real EAR file may already exist there from a previous run.
+    * Then in this test case, install a real EAR file, and verify that running liberty:run again will not overwrite the real EAR file that is in m2.
+    */
+   @Test
+   public void notOverwriteExistingM2Test() throws Exception {
+      // Check that the file was already created (from the run() during setup)
+      File ear = new File(System.getProperty("user.home"), ".m2/repository/io/openliberty/guides/guide-maven-multimodules-ear/1.0-SNAPSHOT/guide-maven-multimodules-ear-1.0-SNAPSHOT.ear");
+      assertTrue(ear.exists());
+      long lastModified = ear.lastModified();
+
+      // Install the real EAR file through Maven command
+      runMvnInstallEar();
+
+      // Check file is updated
+      long newModified = ear.lastModified();
+      assertNotEquals(lastModified, newModified);
+
+      // Cleanup (stop Liberty)
+      cleanUpAfterClass(false);
+
+      // Setup and run Liberty again
+      setUpBeforeClass();
+
+      // Check file is not overwritten by liberty:run
+      long newModified2 = ear.lastModified();
+      assertEquals(newModified2, newModified);
+   }
+
+   private static void runMvnInstallEar() throws Exception {
+      StringBuilder command = new StringBuilder("mvn install -pl ../ear -am");
+      ProcessBuilder builder = buildProcess(command.toString());
+
+      builder.redirectOutput(logFile);
+      builder.redirectError(logFile);
+      builder.directory(new File(tempProj, "pom"));
+
+      Process mvnInstallProcess = builder.start();
+      assertTrue(mvnInstallProcess.isAlive());
+      mvnInstallProcess.waitFor(120, TimeUnit.SECONDS);
+      assertEquals(0, mvnInstallProcess.exitValue());
+   }
+
+   @AfterClass
+   public static void cleanUpAfterClass() throws Exception {
+      BaseDevTest.cleanUpAfterClass(false);
+   }
+
+}
+

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -803,7 +803,7 @@ public class DevMojo extends StartDebugMojoSupport {
                     runMojo("org.apache.maven.plugins", "maven-ear-plugin", "generate-application-xml");
                     runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
 
-                    installEmptyEAR(project);
+                    installEmptyEarIfNotFound(project);
                 } else {
                     runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
                     runCompileMojoLogWarning();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -802,6 +802,9 @@ public class DevMojo extends StartDebugMojoSupport {
                 if (isEar) {
                     runMojo("org.apache.maven.plugins", "maven-ear-plugin", "generate-application-xml");
                     runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
+
+                    // if the ear artifact is not in .m2, install a dummy ear as a workaround so that downstream modules can build
+                    installEarToM2(project);
                 } else {
                     runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
                     runCompileMojoLogWarning();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -803,8 +803,7 @@ public class DevMojo extends StartDebugMojoSupport {
                     runMojo("org.apache.maven.plugins", "maven-ear-plugin", "generate-application-xml");
                     runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
 
-                    // if the ear artifact is not in .m2, install a dummy ear as a workaround so that downstream modules can build
-                    installEarToM2(project);
+                    installEmptyEAR(project);
                 } else {
                     runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
                     runCompileMojoLogWarning();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -54,7 +54,7 @@ public class RunServerMojo extends PluginConfigSupport {
 
         // If there are downstream projects (e.g. other modules depend on this module in the Maven Reactor build order),
         // then skip running Liberty on this module but only build it.
-        boolean skipRunServer = false;
+        boolean hasDownstreamProjects = false;
         ProjectDependencyGraph graph = session.getProjectDependencyGraph();
         if (graph != null) {
             checkMultiModuleConflicts(graph);
@@ -62,7 +62,7 @@ public class RunServerMojo extends PluginConfigSupport {
             List<MavenProject> downstreamProjects = graph.getDownstreamProjects(project, true);
             if (!downstreamProjects.isEmpty()) {
                 log.debug("Downstream projects: " + downstreamProjects);
-                skipRunServer = true;
+                hasDownstreamProjects = true;
             }
 
             if (containsPreviousLibertyModule(graph)) {
@@ -75,6 +75,10 @@ public class RunServerMojo extends PluginConfigSupport {
         if (projectPackaging.equals("ear")) {
             runMojo("org.apache.maven.plugins", "maven-ear-plugin", "generate-application-xml");
             runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
+
+            if (hasDownstreamProjects && looseApplication) {
+                installEmptyEAR(project);
+            }
         } else {
             runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
             runMojo("org.apache.maven.plugins", "maven-compiler-plugin", "compile");
@@ -106,7 +110,7 @@ public class RunServerMojo extends PluginConfigSupport {
         }
 
         // Return if Liberty should not be run on this module
-        if (skipRunServer) {
+        if (hasDownstreamProjects) {
             return;
         }
         

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -77,7 +77,7 @@ public class RunServerMojo extends PluginConfigSupport {
             runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
 
             if (hasDownstreamProjects && looseApplication) {
-                installEmptyEAR(project);
+                installEmptyEarIfNotFound(project);
             }
         } else {
             runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -61,6 +61,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.tools.ant.taskdefs.Copy;
 import org.apache.tools.ant.types.FileSet;
+import org.codehaus.mojo.pluginsupport.util.ArtifactItem;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.twdata.maven.mojoexecutor.MojoExecutor.Element;
 
@@ -922,9 +923,18 @@ public class StartDebugMojoSupport extends BasicSupport {
      * @param earProject
      * @throws MojoExecutionException If the empty ear artifact could not be installed. Prompts the user to run a manual command as a workaround.
      */
-    protected void installEmptyEAR(MavenProject earProject) throws MojoExecutionException {
-        log.debug("Installing empty EAR artifact to .m2 directory...");
+    protected void installEmptyEarIfNotFound(MavenProject earProject) throws MojoExecutionException {
+        ArtifactItem existingEarItem = createArtifactItem(earProject.getGroupId(), earProject.getArtifactId(), earProject.getPackaging(), earProject.getVersion());
+        try {
+            Artifact existingEarArtifact = getArtifact(existingEarItem);
+            log.debug("EAR artifact already exists at " + existingEarArtifact.getFile());
+        } catch (MojoExecutionException e) {
+            log.debug("Installing empty EAR artifact to .m2 directory...");
+            installEmptyEAR(earProject);
+        }
+    }
 
+    private void installEmptyEAR(MavenProject earProject) throws MojoExecutionException {
         String goal = "install-file";
         Plugin plugin = getPlugin("org.apache.maven.plugins", "maven-install-plugin");
         log.debug("Running maven-install-plugin:" + goal);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -915,7 +915,14 @@ public class StartDebugMojoSupport extends BasicSupport {
         return multiModuleProjectDirectory.toPath().relativize(module.getBasedir().toPath()).toString();
     }
 
-    protected void installEarToM2(MavenProject earProject) throws MojoExecutionException {
+    /**
+     * If the ear artifact is not in .m2, install an empty ear as a workaround so that downstream modules can build.
+     * Only needed if using loose application.
+     * 
+     * @param earProject
+     * @throws MojoExecutionException If the empty ear artifact could not be installed. Prompts the user to run a manual command as a workaround.
+     */
+    protected void installEmptyEAR(MavenProject earProject) throws MojoExecutionException {
         log.debug("Installing empty EAR artifact to .m2 directory...");
 
         String goal = "install-file";

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -944,7 +944,9 @@ public class StartDebugMojoSupport extends BasicSupport {
             tempFile = File.createTempFile(earProject.getArtifactId(), ".ear");
             tempFile.deleteOnExit();
         } catch (IOException e) {
-            throw new MojoExecutionException("Could not install empty EAR artifact for " + earProject.toString() + ". Run 'mvn install -pl " + getModuleRelativePath(earProject) + " -am' once before running Liberty dev mode.", e);
+            String module = getModuleRelativePath(earProject);
+            log.debug(e);
+            throw new MojoExecutionException("Could not install placeholder EAR artifact for module " + module + ". Manually run the following command to resolve this issue: mvn install -pl " + module + " -am");
         }
 
         Xpp3Dom config = configuration(
@@ -956,7 +958,9 @@ public class StartDebugMojoSupport extends BasicSupport {
         try {
             executeMojo(plugin, goal(goal), config, executionEnvironment(project, session, pluginManager));
         } catch (MojoExecutionException e) {
-            throw new MojoExecutionException("Could not install empty EAR artifact for " + earProject.toString() + ". Run 'mvn install -pl " + getModuleRelativePath(earProject) + " -am' once before running Liberty dev mode.", e);
+            String module = getModuleRelativePath(earProject);
+            log.debug(e);
+            throw new MojoExecutionException("Could not install placeholder EAR artifact for module " + module + ". Manually run the following command to resolve this issue: mvn install -pl " + module + " -am");
         }
     }
 


### PR DESCRIPTION
For a multi module project, when running `dev` or `run` with `looseApplication=true`:
If an ear module is not the most downstream module in the build order, it must be installed to .m2 before building the downstream modules, otherwise Maven will fail.  However, the file in .m2 won't be used for the rest of `dev` or `run`, so it can be an empty file.

The following will occur to automate the above:
1. Check if the ear artifact already exists in .m2
2. If it doesn't exist, install an empty file as the ear artifact to .m2, along with the actual pom.  If this fails, give an error to tell the user to run a command manually.
3. If it does exist, do nothing.   

Fixes #1176