### PR TITLE
Add recompileDependencies option and set default behaviour

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
@@ -257,6 +257,22 @@ public class BaseDevTest {
       assertTrue(wasModified);
    }
 
+   protected static void testModifyWithRecompileDeps() throws IOException, InterruptedException {
+      File targetHelloLogger = getTargetFile("src/main/java/com/demo/HelloLogger.java",
+            "classes/com/demo/HelloLogger.class");
+      long helloLoggerLastModified = targetHelloLogger.lastModified();
+
+      File targetHelloServlet = getTargetFile("src/main/java/com/demo/HelloServlet.java",
+            "classes/com/demo/HelloServlet.class");
+      long helloServletLastModified = targetHelloServlet.lastModified();
+
+      testModifyJavaFile();
+
+      // check that all files were recompiled
+      assertTrue(targetHelloLogger.lastModified() > helloLoggerLastModified);
+      assertTrue(targetHelloServlet.lastModified() > helloServletLastModified);
+   }
+
    protected static boolean readFile(String str, File file) throws FileNotFoundException, IOException {
       BufferedReader br = new BufferedReader(new FileReader(file));
       String line = br.readLine();
@@ -320,5 +336,12 @@ public class BaseDevTest {
       }
       return false;
    }
-   
+
+   protected static File getTargetFile(String srcFilePath, String targetFilePath) throws IOException, InterruptedException {
+      File srcClass = new File(tempProj, srcFilePath);
+      File targetClass = new File(targetDir, targetFilePath);
+      assertTrue(srcClass.exists());
+      assertTrue(targetClass.exists());
+      return targetClass;
+   }
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
@@ -38,7 +38,8 @@ import org.junit.Test;
 public class BaseMultiModuleTest extends BaseDevTest {
 
    public static void setUpMultiModule(String testcaseFolder, String libertyModule, String pomModule) throws Exception {
-      setUpBeforeClass(null, "../resources/multi-module-projects/" + testcaseFolder, true, false, libertyModule, pomModule);
+      setUpBeforeClass(null, "../resources/multi-module-projects/" + testcaseFolder, true, false,
+            libertyModule, pomModule);
 
       optionalReplaceVersion(tempProj);
       optionalReplaceVersion(new File(tempProj, "pom"));
@@ -49,12 +50,20 @@ public class BaseMultiModuleTest extends BaseDevTest {
       optionalReplaceVersion(new File(tempProj, "war2"));
    }
 
-   protected static void run() throws Exception {
-      run(true);
+   protected static void run(String params) throws Exception {
+      run(params, true);
    }
 
    protected static void run(boolean devMode) throws Exception {
-      startProcess(null, devMode, "mvn io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":");
+      run(null, devMode);
+   }
+
+   protected static void run() throws Exception {
+      run(null, true);
+   }
+
+   protected static void run(String params, boolean devMode) throws Exception {
+      startProcess(params, devMode, "mvn io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":");
    }
 
    private static void replaceVersion(File dir) throws IOException {
@@ -141,6 +150,14 @@ public class BaseMultiModuleTest extends BaseDevTest {
    @AfterClass
    public static void cleanUpAfterClass() throws Exception {
       BaseDevTest.cleanUpAfterClass();
+   }
+
+   protected static File getTargetFileForModule(String srcFilePath, String targetFilePath) throws IOException, InterruptedException {
+      File srcClass = new File(tempProj, srcFilePath);
+      File targetClass = new File(tempProj, targetFilePath);
+      assertTrue(srcClass.exists());
+      assertTrue(targetClass.exists());
+      return targetClass;
    }
 }
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevRecompileDepsTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevRecompileDepsTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DevRecompileDepsTest extends BaseDevTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      setUpBeforeClass("-DrecompileDependencies=true");
+   }
+
+   @AfterClass
+   public static void cleanUpAfterClass() throws Exception {
+      BaseDevTest.cleanUpAfterClass();
+   }
+
+   @Test
+   public void verifyRecompileDeps() throws Exception {
+      assertTrue(verifyLogMessageExists(
+            "The recompileDependencies parameter is set to \"true\". On a file change the entire project will be recompiled.",
+            20000));
+
+      testModifyWithRecompileDeps();
+   }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRecompileDepsTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRecompileDepsTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MultiModuleRecompileDepsTest extends BaseMultiModuleTest {
+
+      @BeforeClass
+      public static void setUpBeforeClass() throws Exception {
+            setUpMultiModule("typeA", "ear", null);
+            run("-DrecompileDependencies=false");
+      }
+
+      @Test
+      public void runTest() throws Exception {
+            // test setting recompileDependencies to false for a multi module project
+            assertTrue(verifyLogMessageExists(
+                        "The recompileDependencies parameter is set to \"false\". On a file change only the affected classes will be recompiled.",
+                        20000));
+
+            super.manualTestsInvocationTest("guide-maven-multimodules-jar", "guide-maven-multimodules-war",
+                        "guide-maven-multimodules-ear");
+
+            // verify that when modifying a jar class, classes in dependent modules are
+            // not recompiled as well
+            File targetWebClass = getTargetFileForModule(
+                        "war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java",
+                        "war/target/classes/io/openliberty/guides/multimodules/web/HeightsBean.class");
+            long webLastModified = targetWebClass.lastModified();
+
+            File targetEarClass = getTargetFileForModule(
+                        "ear/src/test/java/it/io/openliberty/guides/multimodules/ConverterAppIT.java",
+                        "ear/target/test-classes/it/io/openliberty/guides/multimodules/ConverterAppIT.class");
+            long targetLastModified = targetEarClass.lastModified();
+
+            testEndpointsAndUpstreamRecompile();
+
+            // verify a source class in the war module was not compiled
+            assertTrue(targetWebClass.lastModified() == webLastModified);
+
+            // verify a test class in the ear module was not compiled
+            assertTrue(targetEarClass.lastModified() == targetLastModified);
+      }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeATest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeATest.java
@@ -39,9 +39,31 @@ public class MultiModuleTypeATest extends BaseMultiModuleTest {
 
    @Test
    public void runTest() throws Exception {
-      super.manualTestsInvocationTest("guide-maven-multimodules-jar", "guide-maven-multimodules-war", "guide-maven-multimodules-ear");
+      assertTrue(verifyLogMessageExists(
+            "The recompileDependencies parameter is set to \"true\". On a file change all dependent modules will be recompiled.",
+            20000));
+
+      super.manualTestsInvocationTest("guide-maven-multimodules-jar", "guide-maven-multimodules-war",
+            "guide-maven-multimodules-ear");
+
+      // // verify that when modifying a jar class, classes in dependent modules are
+      // recompiled as well
+      File targetWebClass = getTargetFileForModule("war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java",
+            "war/target/classes/io/openliberty/guides/multimodules/web/HeightsBean.class");
+      long webLastModified = targetWebClass.lastModified();
+
+      File targetEarClass = getTargetFileForModule(
+            "ear/src/test/java/it/io/openliberty/guides/multimodules/ConverterAppIT.java",
+            "ear/target/test-classes/it/io/openliberty/guides/multimodules/ConverterAppIT.class");
+      long targetLastModified = targetEarClass.lastModified();
 
       testEndpointsAndUpstreamRecompile();
+
+      // verify a source class in the war module was compiled
+      assertTrue(targetWebClass.lastModified() > webLastModified);
+
+      // verify a test class in the ear module was compiled
+      assertTrue(targetEarClass.lastModified() > targetLastModified);
    }
 
 }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -843,11 +843,17 @@ public class DevMojo extends StartDebugMojoSupport {
                         "The recompileDependencies parameter was not explicitly set. The default value for multi module projects -DrecompileDependencies=true will be used.");
                 recompileDependencies = "true";
             }
-        } else if (!recompileDependencies.equals("true") || !recompileDependencies.equals("false")) {
-            log.warn(
-                    "A value other than \"true\" or \"false\" was specified for the recompileDependencies parameter, recompileDependencies will be set to \"false\".");
         }
         boolean recompileDeps = Boolean.parseBoolean(recompileDependencies);
+        if (recompileDeps) {
+            if (!upstreamMavenProjects.isEmpty()) {
+                log.info("The recompileDependencies parameter is set to \"true\". On a file change all dependent modules will be recompiled.");
+            } else {
+                log.info("The recompileDependencies parameter is set to \"true\". On a file change the entire project will be recompiled.");
+            }
+        } else {
+            log.info("The recompileDependencies parameter is set to \"false\". On a file change only the affected classes will be recompiled.");
+        }
 
         // Check if this is a Boost application
         boostPlugin = project.getPlugin("org.microshed.boost:boost-maven-plugin");


### PR DESCRIPTION
Fixes #1174 
Default behaviour for `recompileDependencies`:
- multi module projects, recompileDependencies=true
- single module projects, recompileDependencies=false

In order to set different default behaviour depending on the project structure, recompileDependencies is a String parameter that is cast to a boolean. 

Adds base integration tests for `recompileDependencies` parameter. See DevRecompileDepsTest, MultiModuleRecompileDepsTest and MultiModuleTypeATest.