### PR TITLE
Improve IT for multi module recompileDeps=false

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
@@ -170,5 +170,11 @@ public class BaseMultiModuleTest extends BaseDevTest {
       assertTrue(targetClass.exists());
       return targetClass;
    }
+
+   protected static void modifyFileForModule(String srcFilePath, String str, String replacement) throws IOException {
+      File srcClass = new File(tempProj, srcFilePath);
+      assertTrue(srcClass.exists());
+      replaceString(str, replacement, srcClass);
+   }
 }
 


### PR DESCRIPTION
Add integration tests to ensure when `recompileDependencies=false` for a multi module project, failing classes from upstream and downstream modules are still recompiled. 

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>