### PR TITLE
Purge locally installed upstream modules when using loose app

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/.vscode/launch.json
+++ b/liberty-maven-plugin/src/it/dev-it/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "java",
+            "name": "Attach",
+            "request": "attach",
+            "hostName": "localhost",
+            "port": 8000
+        }
+    ]
+}

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
@@ -170,5 +170,20 @@ public class BaseMultiModuleTest extends BaseDevTest {
       assertTrue(targetClass.exists());
       return targetClass;
    }
+
+   protected static void runCommand(String commandLineString) throws Exception {
+      StringBuilder command = new StringBuilder(commandLineString);
+      ProcessBuilder builder = buildProcess(command.toString());
+
+      builder.redirectOutput(logFile);
+      builder.redirectError(logFile);
+      if (customPomModule != null) {
+         builder.directory(new File(tempProj, customPomModule));
+      }
+      Process process = builder.start();
+      assertTrue(process.isAlive());
+      process.waitFor(120, TimeUnit.SECONDS);
+      assertEquals(0, process.exitValue());
+   }
 }
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleM2InstalledTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleM2InstalledTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MultiModuleM2InstalledTest extends BaseMultiModuleTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      setUpMultiModule("typeA", "ear", null);
+   }
+
+   @Test
+   public void purgeLocallyInstalledModule_DevMode_Test() throws Exception {
+
+      // install everything to m2
+      runCommand("mvn install");
+
+      // ensure class was compiled
+      File targetClass = new File(tempProj, "jar/target/classes/io/openliberty/guides/multimodules/lib/Converter.class");
+      assertTrue(targetClass.exists());
+
+      // delete the source file
+      File srcClass = new File(tempProj, "jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java");
+      assertTrue(srcClass.delete());
+
+      // clean targets
+      runCommand("mvn clean");
+
+      // dev mode should purge the jar module from m2, so that the war module will show a failure due to the missing dependency.
+      // i.e. it should not find the jar dependency from m2
+      startProcess(null, true, "mvn io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":", false);
+      
+      // TODO when https://github.com/OpenLiberty/ci.maven/issues/1203 is fixed, check for compilation error instead
+      assertTrue(getLogTail(logFile), verifyLogMessageExists("Could not resolve dependencies for project", 5000));
+      
+      assertFalse(getLogTail(logFile), targetClass.exists());
+   }
+
+   @AfterClass
+   public static void cleanUpAfterClass() throws Exception {
+      // use a run-style cleanup (e.g. kill the process), and skip checking for server
+      // shutdown since dev mode should not have fully started
+      BaseDevTest.cleanUpAfterClass(false, false);
+   }
+
+}
+

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunM2InstalledTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunM2InstalledTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MultiModuleRunM2InstalledTest extends BaseMultiModuleTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      setUpMultiModule("typeA", "ear", null);
+   }
+
+   @Test
+   public void purgeLocallyInstalledModule_LibertyRun_Test() throws Exception {
+
+      // install everything to m2
+      runCommand("mvn install");
+
+      // ensure class was compiled
+      File targetClass = new File(tempProj, "jar/target/classes/io/openliberty/guides/multimodules/lib/Converter.class");
+      assertTrue(targetClass.exists());
+
+      // delete the source file
+      File srcClass = new File(tempProj, "jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java");
+      assertTrue(srcClass.delete());
+
+      // clean targets
+      runCommand("mvn clean");
+
+      // run goal should purge the jar module from m2, so that the war module will show a failure due to the missing dependency.
+      // i.e. it should not find the jar dependency from m2
+      startProcess(null, false, "mvn io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":", false);
+      
+      // TODO when https://github.com/OpenLiberty/ci.maven/issues/1203 is fixed, check for compilation error instead
+      assertTrue(getLogTail(logFile), verifyLogMessageExists("Could not resolve dependencies for project", 5000));
+      
+      assertFalse(getLogTail(logFile), targetClass.exists());
+   }
+
+   @AfterClass
+   public static void cleanUpAfterClass() throws Exception {
+      // use a run-style cleanup (e.g. kill the process), and skip checking for server
+      // shutdown since server should not have fully started
+      BaseDevTest.cleanUpAfterClass(false, false);
+   }
+
+}
+

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -817,6 +817,8 @@ public class DevMojo extends StartDebugMojoSupport {
                 } else if (project.getPackaging().equals("pom")) {
                     log.debug("Skipping compile/resources on module with pom packaging type");
                 } else {
+                    purgeLocalRepositoryModule(project);
+
                     runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
                     runCompileMojoLogWarning();
                 }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -817,7 +817,7 @@ public class DevMojo extends StartDebugMojoSupport {
                 } else if (project.getPackaging().equals("pom")) {
                     log.debug("Skipping compile/resources on module with pom packaging type");
                 } else {
-                    purgeLocalRepositoryModule(project);
+                    purgeLocalRepositoryArtifact();
 
                     runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
                     runCompileMojoLogWarning();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -82,6 +82,10 @@ public class RunServerMojo extends PluginConfigSupport {
         } else if (projectPackaging.equals("pom")) {
             log.debug("Skipping compile/resources on module with pom packaging type");
         } else {
+            if (hasDownstreamProjects && looseApplication) {
+                purgeLocalRepositoryModule(project);
+            }
+            
             runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
             runMojo("org.apache.maven.plugins", "maven-compiler-plugin", "compile");
         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -83,7 +83,7 @@ public class RunServerMojo extends PluginConfigSupport {
             log.debug("Skipping compile/resources on module with pom packaging type");
         } else {
             if (hasDownstreamProjects && looseApplication) {
-                purgeLocalRepositoryModule(project);
+                purgeLocalRepositoryArtifact();
             }
             
             runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -964,6 +964,20 @@ public class StartDebugMojoSupport extends BasicSupport {
         }
     }
 
+    protected void purgeLocalRepositoryModule(MavenProject project) throws MojoExecutionException {
+        Plugin plugin = getPlugin("org.apache.maven.plugins", "maven-dependency-plugin");
+        String goal = "purge-local-repository";
+        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(plugin, goal, log);
+        config = Xpp3Dom.mergeXpp3Dom(configuration(
+            element(name("reResolve"), "false"), 
+            element(name("actTransitively"), "false"), 
+            element(name("manualIncludes"), project.getGroupId()+":"+project.getArtifactId())
+            ), config);
+        log.info("Running maven-dependency-plugin:" + goal);
+        log.debug("configuration:\n" + config);
+        executeMojo(plugin, goal(goal), config, executionEnvironment(project, session, pluginManager));
+    }
+
     /**
      * Returns whether potentialTopModule is a multi module project that has potentialSubModule as one of its sub-modules.
      */

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -31,8 +31,6 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -49,7 +47,9 @@ import java.util.regex.Pattern;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 
+import org.apache.maven.Maven;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.ProjectDependencyGraph;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginManagement;
@@ -964,7 +964,15 @@ public class StartDebugMojoSupport extends BasicSupport {
         }
     }
 
-    protected void purgeLocalRepositoryModule(MavenProject project) throws MojoExecutionException {
+    /**
+     * Purge the installed artifact for the current project from the local .m2
+     * repository, so that any downstream modules (when using loose application)
+     * will not rely on the installed artifact for their compilation.
+     * 
+     * @throws MojoExecutionException If an exception occurred while running
+     *                                dependency:purge-local-repository
+     */
+    protected void purgeLocalRepositoryArtifact() throws MojoExecutionException {
         Plugin plugin = getPlugin("org.apache.maven.plugins", "maven-dependency-plugin");
         String goal = "purge-local-repository";
         Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(plugin, goal, log);


### PR DESCRIPTION
Purge locally installed upstream modules when using loose app, otherwise if the upstream module has compilation errors in the user's workspace, Maven will use the dependency from .m2 to handle compilations for downstream modules and allow them to pass (even though they should not pass).

Fixes https://github.com/OpenLiberty/ci.maven/issues/1201