### PR TITLE
Use 3.4-SNAPSHOT

### DIFF
--- a/liberty-archetype-ear/pom.xml
+++ b/liberty-archetype-ear/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven</artifactId>
-        <version>3.3.5-M3-SNAPSHOT</version>
+        <version>3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>liberty-archetype-ear</artifactId>

--- a/liberty-archetype-webapp/pom.xml
+++ b/liberty-archetype-webapp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven</artifactId>
-        <version>3.3.5-M3-SNAPSHOT</version>
+        <version>3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>liberty-archetype-webapp</artifactId>

--- a/liberty-maven-app-parent/pom.xml
+++ b/liberty-maven-app-parent/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven</artifactId>
-        <version>3.3.5-M3-SNAPSHOT</version>
+        <version>3.4-SNAPSHOT</version>
     </parent>
     
     <artifactId>liberty-maven-app-parent</artifactId>
@@ -44,7 +44,7 @@
                 <plugin>
                     <groupId>io.openliberty.tools</groupId>
                     <artifactId>liberty-maven-plugin</artifactId>
-                    <version>3.3.5-M3-SNAPSHOT</version>
+                    <version>3.4-SNAPSHOT</version>
                     <executions>
                         <execution>
                             <id>stop-before-clean</id>

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven</artifactId>
-        <version>3.3.5-M3-SNAPSHOT</version>
+        <version>3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>liberty-maven-plugin</artifactId>

--- a/liberty-plugin-archetype/pom.xml
+++ b/liberty-plugin-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven</artifactId>
-        <version>3.3.5-M3-SNAPSHOT</version>
+        <version>3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>liberty-plugin-archetype</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.openliberty.tools</groupId>
     <artifactId>liberty-maven</artifactId>
-    <version>3.3.5-M3-SNAPSHOT</version>
+    <version>3.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Liberty Tools for Maven</name>
     <description>


### PR DESCRIPTION
Left the example in https://github.com/OpenLiberty/ci.maven#configuration as `[3.3.4,)` though, otherwise it make break the example before 3.4 is released.