### PR TITLE
Update artifact paths when a parent module dependency is added

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/ear/Dockerfile
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/ear/Dockerfile
@@ -1,0 +1,8 @@
+FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+
+# Add config
+COPY --chown=1001:0  target/liberty/wlp/usr/servers/defaultServer/server.xml /config/
+COPY --chown=1001:0  target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/liberty-plugin-variable-config.xml /config/configDropins/overrides/
+
+# Add application
+COPY --chown=1001:0  target/guide-maven-multimodules-ear.ear /config/apps/ 

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/ear/pom.xml
@@ -1,0 +1,104 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.openliberty.guides</groupId>
+        <artifactId>guide-maven-multimodules</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>guide-maven-multimodules-ear</artifactId>
+    <packaging>ear</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Liberty configuration -->
+        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    </properties>
+
+    <dependencies>
+        <!-- web and jar modules as dependencies -->
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-war</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>war</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <modules>
+                        <jarModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-jar</artifactId>
+                            <uri>/guide-maven-multimodules-jar-1.0-SNAPSHOT.jar</uri>
+                        </jarModule>
+                        <webModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-war</artifactId>
+                            <uri>/guide-maven-multimodules-war-1.0-SNAPSHOT.war</uri>
+                            <!-- Set custom context root -->
+                            <contextRoot>/converter</contextRoot>
+                        </webModule>
+                    </modules>
+                </configuration>
+            </plugin>
+
+       
+
+            <!-- Since the package type is ear,
+            need to run testCompile to compile the tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Plugin to run integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <default.http.port>
+                            ${liberty.var.default.http.port}
+                        </default.http.port>
+                        <default.https.port>
+                            ${liberty.var.default.https.port}
+                        </default.https.port>
+                        <cf.context.root>/converter</cf.context.root>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/ear/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/ear/src/main/liberty/config/server.xml
@@ -1,0 +1,16 @@
+<server description="Sample Liberty server">
+
+    <featureManager>
+        <feature>jsp-2.3</feature>
+    </featureManager>
+
+    <variable name="default.http.port" defaultValue="9080" />
+    <variable name="default.https.port" defaultValue="9443" />
+
+    <httpEndpoint host="*" httpPort="${default.http.port}"
+        httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+
+    <enterpriseApplication id="guide-maven-multimodules-ear"
+        location="guide-maven-multimodules-ear.ear"
+        name="guide-maven-multimodules-ear" />
+</server>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/ear/src/test/java/it/io/openliberty/guides/multimodules/ConverterAppIT.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/ear/src/test/java/it/io/openliberty/guides/multimodules/ConverterAppIT.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package it.io.openliberty.guides.multimodules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+public class ConverterAppIT {
+    String port = System.getProperty("default.http.port");
+    String war = "converter";
+    String urlBase = "http://localhost:" + port + "/" + war + "/";
+
+    @Test
+    public void testIndexPage() throws Exception {
+        String url = this.urlBase;
+        HttpURLConnection con = testRequestHelper(url, "GET");
+        assertEquals(200, con.getResponseCode(), "Incorrect response code from " + url);
+        assertTrue(testBufferHelper(con).contains("Enter the height in centimeters"),
+                        "Incorrect response from " + url);
+    }
+
+    @Test
+    public void testHeightsPage() throws Exception {
+        String url = this.urlBase + "heights.jsp?heightCm=10";
+        HttpURLConnection con = testRequestHelper(url, "POST");
+        assertTrue(testBufferHelper(con).contains("3        inches"),
+                        "Incorrect response from " + url);
+    }
+
+    private HttpURLConnection testRequestHelper(String url, String method)
+                    throws Exception {
+        URL obj = new URL(url);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        // optional default is GET
+        con.setRequestMethod(method);
+        return con;
+    }
+
+    private String testBufferHelper(HttpURLConnection con) throws Exception {
+        BufferedReader in = new BufferedReader(
+                        new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        return response.toString();
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/jar/pom.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.openliberty.guides</groupId>
+        <artifactId>guide-maven-multimodules</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>guide-maven-multimodules-jar</artifactId>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.lib;
+
+public class Converter {
+
+    public static int getFeet(int cm) {
+        int feet = (int) (cm / 30.48);
+        return feet;
+    }
+
+    public static int getInches(int cm) {
+        double feet = cm / 30.48;
+        int inches = (int) (cm / 2.54) - ((int) feet * 12);
+        return inches;
+    }
+
+    public static int sum(int a, int b) {
+        return a + b;
+    }
+
+    public static int diff(int a, int b) {
+        return a - b;
+    }
+
+    public static int product(int a, int b) {
+        return a * b;
+    }
+
+    public static int quotient(int a, int b) {
+        return a / b;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/jar/src/test/java/io/openliberty/guides/multimodules/lib/ConverterUnitTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/jar/src/test/java/io/openliberty/guides/multimodules/lib/ConverterUnitTest.java
@@ -1,0 +1,15 @@
+package io.openliberty.guides.multimodules.lib;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConverterUnitTest {
+
+    @Test
+    public void testHeightFeet() {
+        int feet = Converter.getFeet(61);
+        assertEquals(2, feet);
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/pom.xml
@@ -1,0 +1,48 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>jar</module>
+        <module>war</module>
+        <module>ear</module>
+    </modules>
+
+    <dependencies>
+        <!-- SUB JUNIT -->
+    </dependencies>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!-- Enable liberty-maven plugin -->
+                <plugin>
+                    <groupId>io.openliberty.tools</groupId>
+                    <artifactId>liberty-maven-plugin</artifactId>
+                    <version>3.4-SNAPSHOT</version>
+                </plugin>
+
+                <!-- Plugin to run integration tests -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.22.2</version>
+                </plugin>
+                <!-- Surefire plugin to run unit tests -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.2</version>
+                </plugin>
+            </plugins>
+
+        </pluginManagement>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/pom.xml
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.openliberty.guides</groupId>
+        <artifactId>guide-maven-multimodules</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>guide-maven-multimodules-war</artifactId>
+    <packaging>war</packaging>
+    <name>guide-maven-multimodules-war</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>9.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>3.3</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.web;
+
+public class HeightsBean implements java.io.Serializable {
+    private String heightCm = null;
+    private String heightFeet = null;
+    private String heightInches = null;
+    private int cm = 0;
+    private int feet = 0;
+    private int inches = 0;
+
+    public HeightsBean() {
+
+    }
+
+    // Capitalize the first letter of the name i.e. first letter after get
+    // If first letter is not capitalized, it must match the property name in
+    // index.jsp
+    public String getHeightCm() {
+        return heightCm;
+    }
+
+    public String getHeightFeet() {
+        return heightFeet;
+    }
+
+    public String getHeightInches() {
+        return heightInches;
+    }
+
+    public void setHeightCm(String heightcm) {
+        this.heightCm = heightcm;
+    }
+
+    // Need an input as placeholder, you can choose not to use the input
+    public void setHeightFeet(String heightfeet) {
+        this.cm = Integer.valueOf(heightCm);
+        this.feet = io.openliberty.guides.multimodules.lib.Converter.getFeet(cm);
+        String result = String.valueOf(feet);
+        this.heightFeet = result;
+    }
+
+    public void setHeightInches(String heightinches) {
+        this.cm = Integer.valueOf(heightCm);
+        this.inches = io.openliberty.guides.multimodules.lib.Converter.getInches(cm);
+        String result = String.valueOf(inches);
+        this.heightInches = result;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/src/main/resources/META-INF/MANIFEST.mf
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/src/main/resources/META-INF/MANIFEST.mf
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Ant-Version: Apache Ant 1.7.1
+Created-By: 2.6 (IBM Corporation)

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/src/main/webapp/WEB-INF/web.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE web-app PUBLIC
+ "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+ "http://java.sun.com/dtd/web-app_2_3.dtd" >
+
+<web-app>
+    <display-name>Archetype Created Web Application</display-name>
+</web-app>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/src/main/webapp/heights.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/src/main/webapp/heights.jsp
@@ -1,0 +1,42 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+
+    <jsp:useBean id="height" class="io.openliberty.guides.multimodules.web.HeightsBean"></jsp:useBean>
+    <jsp:setProperty name="height" property="heightCm" />
+    <jsp:setProperty name="height" property="heightFeet" value="0" />
+    <jsp:setProperty name="height" property="heightInches" value="0" />
+
+    <p>
+        Height in centimeters:
+        <jsp:getProperty name="height" property="heightCm" />
+        cm
+    </p>
+
+    <br>
+
+    <p>
+        Height in feet and inches:
+        <jsp:getProperty name="height" property="heightFeet" />
+        feet
+        <jsp:getProperty name="height" property="heightInches" />
+        inches
+    </p>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/src/main/webapp/index.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/src/main/webapp/index.jsp
@@ -1,0 +1,27 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+    <h2>Enter the height in centimeters</h2>
+
+    <form action="heights.jsp" method="post">
+        <input type="text" name="heightCm" /> cm <br> <input type="submit"
+            value="SUBMIT" />
+    </form>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/src/test/java/it/io/openliberty/guides/mutlimodules/web/HeightsBeanIT.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/src/test/java/it/io/openliberty/guides/mutlimodules/web/HeightsBeanIT.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package it.io.openliberty.guides.multimodules.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+public class HeightsBeanIT {
+    String war = "converter";
+    String urlBase = "http://localhost:" + "9080" + "/" + war + "/";
+
+    @Test
+    public void testIndexPage() throws Exception {
+        String url = this.urlBase;
+        HttpURLConnection con = testRequestHelper(url, "GET");
+        assertEquals(200, con.getResponseCode(), "Incorrect response code from " + url);
+        assertTrue(testBufferHelper(con).contains("Enter the height in centimeters"),
+                        "Incorrect response from " + url);
+    }
+
+    @Test
+    public void testHeightsPage() throws Exception {
+        String url = this.urlBase + "heights.jsp?heightCm=10";
+        HttpURLConnection con = testRequestHelper(url, "POST");
+        assertTrue(testBufferHelper(con).contains("3        inches"),
+                        "Incorrect response from " + url);
+    }
+
+    private HttpURLConnection testRequestHelper(String url, String method)
+                    throws Exception {
+        URL obj = new URL(url);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        // optional default is GET
+        con.setRequestMethod(method);
+        return con;
+    }
+
+    private String testBufferHelper(HttpURLConnection con) throws Exception {
+        BufferedReader in = new BufferedReader(
+                        new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        return response.toString();
+    }
+
+}
+

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/src/test/java/it/io/openliberty/guides/mutlimodules/web/HeightsBeanUnitTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/src/test/java/it/io/openliberty/guides/mutlimodules/web/HeightsBeanUnitTest.java
@@ -1,0 +1,16 @@
+package it.io.openliberty.guides.multimodules.web;
+
+import org.junit.jupiter.api.Test;
+import io.openliberty.guides.multimodules.web.HeightsBean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HeightsBeanUnitTest {
+
+    @Test
+    public void testGetHeightCm() {
+        HeightsBean heightBean = new HeightsBean();
+        heightBean.setHeightCm("2");
+        assertEquals("2", heightBean.getHeightCm());
+    }
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/ear/Dockerfile
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/ear/Dockerfile
@@ -1,0 +1,8 @@
+FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+
+# Add config
+COPY --chown=1001:0  target/liberty/wlp/usr/servers/defaultServer/server.xml /config/
+COPY --chown=1001:0  target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/liberty-plugin-variable-config.xml /config/configDropins/overrides/
+
+# Add application
+COPY --chown=1001:0  target/guide-maven-multimodules-ear.ear /config/apps/ 

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/ear/pom.xml
@@ -11,9 +11,9 @@
 
     <parent>
         <groupId>io.openliberty.guides</groupId>
-        <artifactId>guide-maven-multimodules-parent</artifactId>
+        <artifactId>guide-maven-multimodules-parent1</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../parent/pom.xml</relativePath>
+        <relativePath>../parent1/pom.xml</relativePath>
     </parent>
 
     <properties>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/ear/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/ear/src/main/liberty/config/server.xml
@@ -1,0 +1,16 @@
+<server description="Sample Liberty server">
+
+    <featureManager>
+        <feature>jsp-2.3</feature>
+    </featureManager>
+
+    <variable name="default.http.port" defaultValue="9080" />
+    <variable name="default.https.port" defaultValue="9443" />
+
+    <httpEndpoint host="*" httpPort="${default.http.port}"
+        httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+
+    <enterpriseApplication id="guide-maven-multimodules-ear"
+        location="guide-maven-multimodules-ear.ear"
+        name="guide-maven-multimodules-ear" />
+</server>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/ear/src/test/java/it/io/openliberty/guides/multimodules/IT.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/ear/src/test/java/it/io/openliberty/guides/multimodules/IT.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package it.io.openliberty.guides.multimodules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+public class IT {
+    String port = System.getProperty("default.http.port");
+    String war = "converter";
+    String urlBase = "http://localhost:" + port + "/" + war + "/";
+
+    @Test
+    public void testIndexPage() throws Exception {
+        String url = this.urlBase;
+        HttpURLConnection con = testRequestHelper(url, "GET");
+        assertEquals(200, con.getResponseCode(), "Incorrect response code from " + url);
+        assertTrue(testBufferHelper(con).contains("Enter the height in centimeters"),
+                        "Incorrect response from " + url);
+    }
+
+    @Test
+    public void testHeightsPage() throws Exception {
+        String url = this.urlBase + "heights.jsp?heightCm=10";
+        HttpURLConnection con = testRequestHelper(url, "POST");
+        assertTrue(testBufferHelper(con).contains("3        inches"),
+                        "Incorrect response from " + url);
+    }
+
+    private HttpURLConnection testRequestHelper(String url, String method)
+                    throws Exception {
+        URL obj = new URL(url);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        // optional default is GET
+        con.setRequestMethod(method);
+        return con;
+    }
+
+    private String testBufferHelper(HttpURLConnection con) throws Exception {
+        BufferedReader in = new BufferedReader(
+                        new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        return response.toString();
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/jar/pom.xml
@@ -7,21 +7,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.openliberty.guides</groupId>
-    <artifactId>guide-maven-multimodules-parent</artifactId>
+    <artifactId>guide-maven-multimodules-jar</artifactId>
     <version>1.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
-
-    <dependencies>
-        <!-- SUB JUNIT -->
-    </dependencies>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <!-- Liberty configuration: something child project will need -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
+
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.lib;
+
+public class Converter {
+
+    public static int getFeet(int cm) {
+        int feet = (int) (cm / 30.48);
+        return feet;
+    }
+
+    public static int getInches(int cm) {
+        double feet = cm / 30.48;
+        int inches = (int) (cm / 2.54) - ((int) feet * 12);
+        return inches;
+    }
+
+    public static int sum(int a, int b) {
+        return a + b;
+    }
+
+    public static int diff(int a, int b) {
+        return a - b;
+    }
+
+    public static int product(int a, int b) {
+        return a * b;
+    }
+
+    public static int quotient(int a, int b) {
+        return a / b;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent1/pom.xml
@@ -6,8 +6,14 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.openliberty.guides</groupId>
-    <artifactId>guide-maven-multimodules-parent</artifactId>
+    <parent>
+        <groupId>io.openliberty.guides</groupId>
+        <artifactId>guide-maven-multimodules-parent2</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../parent2/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>guide-maven-multimodules-parent1</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent2/pom.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-parent2</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <!-- Provided dependencies -->
+        <!-- SUB JAKARTAEE -->
+    </dependencies>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/pom.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>jar</module>
+        <module>war</module>
+        <module>ear</module>
+    </modules>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/war/pom.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.openliberty.guides</groupId>
+        <artifactId>guide-maven-multimodules-parent2</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../parent2/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>guide-maven-multimodules-war</artifactId>
+    <packaging>war</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>guide-maven-multimodules-war</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.web;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class HeightsBean implements java.io.Serializable {
+    private String heightCm = null;
+    private String heightFeet = null;
+    private String heightInches = null;
+    private int cm = 0;
+    private int feet = 0;
+    private int inches = 0;
+
+    public HeightsBean() {
+    }
+
+    // Capitalize the first letter of the name i.e. first letter after get
+    // If first letter is not capitalized, it must match the property name in
+    // index.jsp
+    public String getHeightCm() {
+        return heightCm;
+    }
+
+    public String getHeightFeet() {
+        return heightFeet;
+    }
+
+    public String getHeightInches() {
+        return heightInches;
+    }
+
+    public void setHeightCm(String heightcm) {
+        this.heightCm = heightcm;
+    }
+
+    // Need an input as placeholder, you can choose not to use the input
+    public void setHeightFeet(String heightfeet) {
+        this.cm = Integer.valueOf(heightCm);
+        this.feet = io.openliberty.guides.multimodules.lib.Converter.getFeet(cm);
+        String result = String.valueOf(feet);
+        this.heightFeet = result;
+    }
+
+    public void setHeightInches(String heightinches) {
+        this.cm = Integer.valueOf(heightCm);
+        this.inches = io.openliberty.guides.multimodules.lib.Converter.getInches(cm);
+        String result = String.valueOf(inches);
+        this.heightInches = result;
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/war/src/main/webapp/WEB-INF/web.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE web-app PUBLIC
+ "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+ "http://java.sun.com/dtd/web-app_2_3.dtd" >
+
+<web-app>
+    <display-name>Archetype Created Web Application</display-name>
+</web-app>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/war/src/main/webapp/heights.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/war/src/main/webapp/heights.jsp
@@ -1,0 +1,42 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+
+    <jsp:useBean id="height" class="io.openliberty.guides.multimodules.web.HeightsBean"></jsp:useBean>
+    <jsp:setProperty name="height" property="heightCm" />
+    <jsp:setProperty name="height" property="heightFeet" value="0" />
+    <jsp:setProperty name="height" property="heightInches" value="0" />
+
+    <p>
+        Height in centimeters:
+        <jsp:getProperty name="height" property="heightCm" />
+        cm
+    </p>
+
+    <br>
+
+    <p>
+        Height in feet and inches:
+        <jsp:getProperty name="height" property="heightFeet" />
+        feet
+        <jsp:getProperty name="height" property="heightInches" />
+        inches
+    </p>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/war/src/main/webapp/index.jsp
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/war/src/main/webapp/index.jsp
@@ -1,0 +1,27 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+    <h2>Enter the height in centimeters</h2>
+
+    <form action="heights.jsp" method="post">
+        <input type="text" name="heightCm" /> cm <br> <input type="submit"
+            value="SUBMIT" />
+    </form>
+
+</body>
+</html>

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
@@ -102,9 +102,7 @@ public class BaseMultiModuleTest extends BaseDevTest {
             assertTrue(getLogTail(), verifyLogMessageExists("Unit tests for " + moduleArtifactId + " finished.", 10000));
          }
          assertTrue(getLogTail(), verifyLogMessageExists("Integration tests for " + moduleArtifactId + " finished.", 10000));
-  
       }
-
       assertFalse("Found CWWKM2179W message indicating incorrect app deployment. " + getLogTail(), verifyLogMessageExists("CWWKM2179W", 2000));
    }
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRecompileDepsTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRecompileDepsTest.java
@@ -46,17 +46,18 @@ public class MultiModuleRecompileDepsTest extends BaseMultiModuleTest {
 
             // verify that when modifying a jar class, classes in dependent modules are
             // not recompiled as well
-            File targetWebClass = getTargetFileForModule(
+            File targetWarClass = getTargetFileForModule(
                         "war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java",
                         "war/target/classes/io/openliberty/guides/multimodules/web/HeightsBean.class");
-            long webLastModified = targetWebClass.lastModified();
+            long warLastModified = targetWarClass.lastModified();
             clearLogFile();
             testEndpointsAndUpstreamRecompile();
-            verifyTestsRan("guide-maven-multimodules-jar", "guide-maven-multimodules-war",
-            "guide-maven-multimodules-ear");
+            // verify jar unit tests failed
+            assertTrue(getLogTail(), verifyLogMessageExists("Unit tests failed: There are test failures.", 10000));
+            verifyTestsRan("guide-maven-multimodules-war", "guide-maven-multimodules-ear");
 
             // verify a source class in the war module was not compiled
-            assertTrue(targetWebClass.lastModified() == webLastModified);
+            assertTrue(targetWarClass.lastModified() == warLastModified);
 
             // Verify that with recompileDependencies=false, failing classes from upstream and downstream modules are still
             // re-tried for compilation on source file change

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRecompileDepsTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRecompileDepsTest.java
@@ -50,9 +50,10 @@ public class MultiModuleRecompileDepsTest extends BaseMultiModuleTest {
                         "war/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java",
                         "war/target/classes/io/openliberty/guides/multimodules/web/HeightsBean.class");
             long webLastModified = targetWebClass.lastModified();
+            clearLogFile();
             testEndpointsAndUpstreamRecompile();
-
-            // TODO verify that tests ran
+            verifyTestsRan("guide-maven-multimodules-jar", "guide-maven-multimodules-war",
+            "guide-maven-multimodules-ear");
 
             // verify a source class in the war module was not compiled
             assertTrue(targetWebClass.lastModified() == webLastModified);

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA3Test.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA3Test.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MultiModuleTypeA3Test extends BaseMultiModuleTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      setUpMultiModule("typeA3", "ear", null);
+      run();
+   }
+
+   @Test
+   public void runTest() throws Exception {
+       assertTrue(verifyLogMessageExists(
+               "The recompileDependencies parameter is set to \"true\". On a file change all dependent modules will be recompiled.",
+               20000));
+
+       File targetEarClass = new File(tempProj,
+               "ear/target/test-classes/it/io/openliberty/guides/multimodules/ConverterAppIT.class");
+       assertFalse(targetEarClass.exists());
+
+       // add a dependency to parent pom and check that it resolves compile errors in
+       // child modules
+       File parentPom = new File(tempProj, "pom.xml");
+       assertTrue(parentPom.exists());
+       replaceString("<!-- SUB JUNIT -->",
+               "<dependency> <groupId>org.junit.jupiter</groupId> <artifactId>junit-jupiter</artifactId> <version>5.6.2</version> <scope>test</scope> </dependency>",
+               parentPom);
+       Thread.sleep(5000); // wait for compilation
+       assertTrue(targetEarClass.exists());
+
+       super.manualTestsInvocation("guide-maven-multimodules-jar", "guide-maven-multimodules-war", "guide-maven-multimodules-ear");
+   }
+
+}
+

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA3Test.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA3Test.java
@@ -39,25 +39,26 @@ public class MultiModuleTypeA3Test extends BaseMultiModuleTest {
 
    @Test
    public void runTest() throws Exception {
-       assertTrue(verifyLogMessageExists(
-               "The recompileDependencies parameter is set to \"true\". On a file change all dependent modules will be recompiled.",
-               20000));
+           assertTrue(verifyLogMessageExists(
+                           "The recompileDependencies parameter is set to \"true\". On a file change all dependent modules will be recompiled.",
+                           20000));
+           // verify ear test class did not compile successfully
+           File targetEarClass = new File(tempProj,
+                           "ear/target/test-classes/it/io/openliberty/guides/multimodules/ConverterAppIT.class");
+           assertFalse(targetEarClass.exists());
 
-       File targetEarClass = new File(tempProj,
-               "ear/target/test-classes/it/io/openliberty/guides/multimodules/ConverterAppIT.class");
-       assertFalse(targetEarClass.exists());
+           // add a dependency to parent pom and check that it resolves compile errors in
+           // child modules
+           File parentPom = new File(tempProj, "pom.xml");
+           assertTrue(parentPom.exists());
+           replaceString("<!-- SUB JUNIT -->",
+                           "<dependency> <groupId>org.junit.jupiter</groupId> <artifactId>junit-jupiter</artifactId> <version>5.6.2</version> <scope>test</scope> </dependency>",
+                           parentPom);
+           Thread.sleep(5000); // wait for compilation
+           assertTrue(targetEarClass.exists());
 
-       // add a dependency to parent pom and check that it resolves compile errors in
-       // child modules
-       File parentPom = new File(tempProj, "pom.xml");
-       assertTrue(parentPom.exists());
-       replaceString("<!-- SUB JUNIT -->",
-               "<dependency> <groupId>org.junit.jupiter</groupId> <artifactId>junit-jupiter</artifactId> <version>5.6.2</version> <scope>test</scope> </dependency>",
-               parentPom);
-       Thread.sleep(5000); // wait for compilation
-       assertTrue(targetEarClass.exists());
-
-       super.manualTestsInvocation("guide-maven-multimodules-jar", "guide-maven-multimodules-war", "guide-maven-multimodules-ear");
+           super.manualTestsInvocation("guide-maven-multimodules-jar", "guide-maven-multimodules-war",
+                           "guide-maven-multimodules-ear");
    }
 
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeI2Test.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeI2Test.java
@@ -29,39 +29,58 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class MultiModuleTypeITest extends BaseMultiModuleTest {
+public class MultiModuleTypeI2Test extends BaseMultiModuleTest {
 
    @BeforeClass
    public static void setUpBeforeClass() throws Exception {
-      setUpMultiModule("typeI", "ear", null);
+      // project structure [parent, List of children]: [parent2: parent1, war], [parent1: ear]
+      setUpMultiModule("typeI2", "ear", null);
       run();
    }
 
    @Test
    public void runTest() throws Exception {
+      // start with missing dependencies in parent1 and parent2 pom.xml
       assertTrue(verifyLogMessageExists(
-            "The recompileDependencies parameter is set to \"true\". On a file change all dependent modules will be recompiled.",
-            20000));
-
+               "The recompileDependencies parameter is set to \"true\". On a file change all dependent modules will be recompiled.",
+               20000));
+      File targetJarClass = new File(tempProj, "jar/target/classes/io/openliberty/guides/multimodules/lib/Converter.class");
+      assertTrue(targetJarClass.exists());
+   
       // verify ear test class did not compile successfully
       File targetEarClass = new File(tempProj,
             "ear/target/test-classes/it/io/openliberty/guides/multimodules/IT.class");
       assertFalse(targetEarClass.exists());
 
+      // verify war source class did not compile successfully
+      File targetWarClass = new File(tempProj, "war/target/classes/io/openliberty/guides/multimodules/web/HeightsBean.class");
+      assertFalse(targetWarClass.exists());
+
+      clearLogFile();
+
       // add a dependency to parent pom and check that it resolves compile errors in
       // child modules
-      File parentPom = new File(tempProj, "parent/pom.xml");
-      assertTrue(parentPom.exists());
+      File parent2Pom = new File(tempProj, "parent2/pom.xml");
+      assertTrue(parent2Pom.exists());
+      replaceString("<!-- SUB JAKARTAEE -->",
+            "<dependency> <groupId>jakarta.platform</groupId> <artifactId>jakarta.jakartaee-api</artifactId> <version>8.0.0</version> <scope>provided</scope> </dependency>",
+            parent2Pom);
+      Thread.sleep(5000); // wait for compilation
+      assertTrue(targetWarClass.exists());
+      assertFalse(targetEarClass.exists()); // verify ear class is still failing to resolve
+      assertTrue(getLogTail(), verifyLogMessageExists("guide-maven-multimodules-war source compilation was successful.", 10000));
+      assertTrue(getLogTail(), verifyLogMessageExists("guide-maven-multimodules-ear tests compilation had errors.", 10000));
+
+      File parent1Pom = new File(tempProj, "parent1/pom.xml");
+      assertTrue(parent1Pom.exists());
       replaceString("<!-- SUB JUNIT -->",
             "<dependency> <groupId>org.junit.jupiter</groupId> <artifactId>junit-jupiter</artifactId> <version>5.6.2</version> <scope>test</scope> </dependency>",
-            parentPom);
+            parent1Pom);
       Thread.sleep(5000); // wait for compilation
       assertTrue(targetEarClass.exists());
-
-      super.manualTestsInvocation("guide-maven-multimodules-jar", "guide-maven-multimodules-war",
-            "guide-maven-multimodules-ear");
 
       testEndpointsAndUpstreamRecompile();
    }
 
 }
+

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeI2Test.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeI2Test.java
@@ -66,10 +66,10 @@ public class MultiModuleTypeI2Test extends BaseMultiModuleTest {
             "<dependency> <groupId>jakarta.platform</groupId> <artifactId>jakarta.jakartaee-api</artifactId> <version>8.0.0</version> <scope>provided</scope> </dependency>",
             parent2Pom);
       Thread.sleep(5000); // wait for compilation
-      assertTrue(targetWarClass.exists());
-      assertFalse(targetEarClass.exists()); // verify ear class is still failing to resolve
       assertTrue(getLogTail(), verifyLogMessageExists("guide-maven-multimodules-war source compilation was successful.", 10000));
       assertTrue(getLogTail(), verifyLogMessageExists("guide-maven-multimodules-ear tests compilation had errors.", 10000));
+      assertTrue(targetWarClass.exists());
+      assertFalse(targetEarClass.exists()); // verify ear class is still failing to resolve
 
       File parent1Pom = new File(tempProj, "parent1/pom.xml");
       assertTrue(parent1Pom.exists());

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -1330,7 +1330,7 @@ public class DevMojo extends StartDebugMojoSupport {
                     // assume this is the main module
                     testArtifacts = util.getTestArtifacts();
                 }
-                if (goal.equals("test") || goal.equals("integration-test") {
+                if (goal.equals("test") || goal.equals("integration-test")) {
                     injectClasspathElements(config, testArtifacts, project.getTestClasspathElements());
                 }
             } catch (IOException | DependencyResolutionRequiredException e) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -1203,26 +1203,32 @@ public class DevMojo extends StartDebugMojoSupport {
      * 
      * @param parentPoms Map of parent poms and subsequent child poms
      * @param proj       MavenProject
-     * @throws IOException
      */
-    private void updateParentPoms(Map<String, List<String>> parentPoms, MavenProject proj) throws IOException {
+    private void updateParentPoms(Map<String, List<String>> parentPoms, MavenProject proj) {
         MavenProject parentProject = proj.getParent();
-        if (parentProject != null) {
-            // append to existing list
-            List<String> childPoms = parentPoms.get(parentProject.getFile().getCanonicalPath());
-            if (childPoms == null) {
-                childPoms = new ArrayList<String>();
-                childPoms.add(proj.getFile().getCanonicalPath());
-                parentPoms.put(parentProject.getFile().getCanonicalPath(), childPoms);
-            } else {
-                if (!childPoms.contains(proj.getFile().getCanonicalPath())) {
-                    childPoms.add(proj.getFile().getCanonicalPath());
+        try {
+            if (parentProject != null) {
+                // append to existing list
+                if (parentProject.getFile() != null) {
+                    List<String> childPoms = parentPoms.get(parentProject.getFile().getCanonicalPath());
+                    if (childPoms == null) {
+                        childPoms = new ArrayList<String>();
+                        childPoms.add(proj.getFile().getCanonicalPath());
+                        parentPoms.put(parentProject.getFile().getCanonicalPath(), childPoms);
+                    } else {
+                        if (!childPoms.contains(proj.getFile().getCanonicalPath())) {
+                            childPoms.add(proj.getFile().getCanonicalPath());
+                        }
+                    }
+                    if (parentProject.getParent() != null) {
+                        // recursively search for top most parent project
+                        updateParentPoms(parentPoms, parentProject);
+                    }
                 }
             }
-            if (parentProject.getParent() != null) {
-                // recursively search for top most parent project
-                updateParentPoms(parentPoms, parentProject);
-            }
+        } catch (IOException e) {
+            log.error("An unexpected error occurred when trying to resolve " + proj.getFile() + ": " + e.getMessage());
+            log.debug(e);
         }
     }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -946,7 +946,7 @@ public class DevMojo extends StartDebugMojoSupport {
         // get all parent poms
         Map<String, List<String>> parentPoms = new HashMap<String, List<String>>();
         for (MavenProject proj : graph.getAllProjects()) {
-            getParentPoms(parentPoms, proj);
+            updateParentPoms(parentPoms, proj);
         }
 
         // default behavior of recompileDependencies
@@ -1198,8 +1198,14 @@ public class DevMojo extends StartDebugMojoSupport {
         return false;
     }
 
-    // update map with list of parent poms and their subsequent child poms
-    private void getParentPoms(Map<String, List<String>> parentPoms, MavenProject proj) throws IOException {
+    /**
+     * Update map with list of parent poms and their subsequent child poms
+     * 
+     * @param parentPoms Map of parent poms and subsequent child poms
+     * @param proj       MavenProject
+     * @throws IOException
+     */
+    private void updateParentPoms(Map<String, List<String>> parentPoms, MavenProject proj) throws IOException {
         MavenProject parentProject = proj.getParent();
         if (parentProject != null) {
             // append to existing list
@@ -1215,7 +1221,7 @@ public class DevMojo extends StartDebugMojoSupport {
             }
             if (parentProject.getParent() != null) {
                 // recursively search for top most parent project
-                getParentPoms(parentPoms, parentProject);
+                updateParentPoms(parentPoms, parentProject);
             }
         }
     }
@@ -1334,8 +1340,8 @@ public class DevMojo extends StartDebugMojoSupport {
                     injectClasspathElements(config, testArtifacts, project.getTestClasspathElements());
                 }
             } catch (IOException | DependencyResolutionRequiredException e) {
-                log.warn(
-                        "Unable to resolve test artifact paths, test compilation may not include parent dependencies. Restart dev mode to ensure classpaths are properly resolved.");
+                log.error(
+                        "Unable to resolve test artifact paths for " + project.getFile() + ". Restart dev mode to ensure classpaths are properly resolved.");
                 log.debug(e);
             }
         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -28,6 +28,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -270,14 +271,15 @@ public class DevMojo extends StartDebugMojoSupport {
         public DevMojoUtil(File installDir, File userDir, File serverDirectory, File sourceDirectory,
                 File testSourceDirectory, File configDirectory, File projectDirectory, File multiModuleProjectDirectory,
                 List<File> resourceDirs, JavaCompilerOptions compilerOptions, String mavenCacheLocation,
-                List<ProjectModule> upstreamProjects, List<MavenProject> upstreamMavenProjects,
-                boolean recompileDeps) throws IOException {
+                List<ProjectModule> upstreamProjects, List<MavenProject> upstreamMavenProjects, boolean recompileDeps,
+                File pom, Map<String, List<String>> parentPoms) throws IOException {
             super(new File(project.getBuild().getDirectory()), serverDirectory, sourceDirectory, testSourceDirectory,
                     configDirectory, projectDirectory, multiModuleProjectDirectory, resourceDirs, hotTests, skipTests,
                     skipUTs, skipITs, project.getArtifactId(), serverStartTimeout, verifyTimeout, verifyTimeout,
                     ((long) (compileWait * 1000L)), libertyDebug, false, false, pollingTest, container, dockerfile,
                     dockerBuildContext, dockerRunOpts, dockerBuildTimeout, skipDefaultPorts, compilerOptions,
-                    keepTempDockerfile, mavenCacheLocation, upstreamProjects, recompileDeps, project.getPackaging());
+                    keepTempDockerfile, mavenCacheLocation, upstreamProjects, recompileDeps, project.getPackaging(),
+                    pom, parentPoms);
 
             ServerFeature servUtil = getServerFeatureUtil();
             this.libertyDirPropertyFiles = BasicSupport.getLibertyDirectoryPropertyFiles(installDir, userDir,
@@ -508,14 +510,10 @@ public class DevMojo extends StartDebugMojoSupport {
         }
 
         @Override
-        public boolean updateArtifactPaths(File buildFile, List<String> compileArtifactPaths,
-                List<String> testArtifactPaths, boolean redeployCheck, ThreadPoolExecutor executor)
+        public boolean updateArtifactPaths(ProjectModule projectModule, boolean redeployCheck, ThreadPoolExecutor executor)
                 throws PluginExecutionException {
-            ProjectBuildingResult build;
             try {
-                build = mavenProjectBuilder.build(buildFile,
-                        session.getProjectBuildingRequest().setResolveDependencies(true));
-                MavenProject upstreamProject = build.getProject();
+                MavenProject upstreamProject = getMavenProject(projectModule.getBuildFile());
                 MavenProject backupUpstreamProject = upstreamProject;
                 for (MavenProject p : upstreamMavenProjects) {
                     if (buildFile != null && p.getFile().getCanonicalPath().equals(buildFile.getCanonicalPath())) {
@@ -531,10 +529,28 @@ public class DevMojo extends StartDebugMojoSupport {
                     util.getProjectModule(buildFile).setCompilerOptions(compilerOptions);
                 }
 
-                testArtifactPaths.clear();
+                Set<String> testArtifactPaths = projectModule.getTestArtifacts();
+                Set<String> compileArtifactPaths = projectModule.getCompileArtifacts();
+
+                if (this.parentBuildFiles.isEmpty()) {
+                    compileArtifactPaths.clear();
+                    testArtifactPaths.clear();
+                } else {
+                    // remove past artifacts and add the newest calculated (covers the case where a
+                    // dependency was deleted)
+                    // do not clear list as it may contain dependencies from parent projects
+                    // update classpath for dependencies changes
+                    testArtifactPaths.removeAll(backupUpstreamProject.getTestClasspathElements());
+                    compileArtifactPaths.removeAll(backupUpstreamProject.getCompileClasspathElements());
+                }
                 testArtifactPaths.addAll(upstreamProject.getTestClasspathElements());
-                compileArtifactPaths.clear();
                 compileArtifactPaths.addAll(upstreamProject.getCompileClasspathElements());
+
+                // check if project module is a parent project and update child modules' artifacts
+                if (!this.parentBuildFiles.isEmpty()
+                        && this.parentBuildFiles.containsKey(projectModule.getBuildFile().getCanonicalPath())) {
+                    updateArtifactPaths(projectModule.getBuildFile());
+                }
 
                 // check if compile dependencies have changed and redeploy if they have
                 if (redeployCheck) {
@@ -562,8 +578,73 @@ public class DevMojo extends StartDebugMojoSupport {
         }
 
         @Override
-        public boolean recompileBuildFile(File buildFile, List<String> compileArtifactPaths,
-                List<String> testArtifactPaths, ThreadPoolExecutor executor) throws PluginExecutionException {
+        public boolean updateArtifactPaths(File buildFile) {
+            try {
+                MavenProject parentProject = getMavenProject(buildFile);
+                updateChildProjectArtifactPaths(buildFile, parentProject.getCompileClasspathElements(),
+                        parentProject.getTestClasspathElements());
+            } catch (ProjectBuildingException | IOException | DependencyResolutionRequiredException e) {
+                log.error("An unexpected error occurred while processing changes in " + buildFile.getAbsolutePath()
+                        + ": " + e.getMessage());
+                log.debug(e);
+                return false;
+            }
+            return true;
+        }
+
+        private void updateChildProjectArtifactPaths(File parentBuildFile, List<String> compileClasspathElements,
+                List<String> testClasspathElements) throws IOException, ProjectBuildingException, DependencyResolutionRequiredException {
+            // search for child projects
+            List<String> childBuildFiles = this.parentBuildFiles.get(parentBuildFile.getCanonicalPath());
+            if (childBuildFiles != null) {
+                for (String childBuildPath : childBuildFiles) {
+                    if (this.parentBuildFiles.containsKey(childBuildPath)) {
+                        MavenProject project = getMavenProject(new File(childBuildPath));
+                        if (project != null) {
+                            compileClasspathElements.addAll(project.getCompileClasspathElements());
+                            testClasspathElements.addAll(project.getTestClasspathElements());
+                        }
+                        updateChildProjectArtifactPaths(new File(childBuildPath), compileClasspathElements,
+                                testClasspathElements);
+                    } else {
+                        // update artifacts on this project
+                        Set<String> compileArtifacts = null;
+                        Set<String> testArtifacts = null;
+                        MavenProject project = null;
+                        if (childBuildPath.equals(this.buildFile.getCanonicalPath())) {
+                            compileArtifacts = util.getCompileArtifacts();
+                            testArtifacts = util.getTestArtifacts();
+                            project = getMavenProject(this.buildFile);
+                        } else if (getProjectModule(new File(childBuildPath)) != null) {
+                            ProjectModule projectModule = getProjectModule(new File(childBuildPath));
+                            compileArtifacts = projectModule.getCompileArtifacts();
+                            testArtifacts = projectModule.getTestArtifacts();
+                            project = getMavenProject(projectModule.getBuildFile());
+                        }
+                        if (compileArtifacts != null && testArtifacts != null && project != null) {
+                            compileArtifacts.clear();
+                            testArtifacts.clear();
+                            // TODO if a dependency is deleted from a parent project, it will still be in
+                            // the child projects classpath elements
+                            compileClasspathElements.addAll(project.getCompileClasspathElements());
+                            testClasspathElements.addAll(project.getTestClasspathElements());
+                            compileArtifacts.addAll(compileClasspathElements);
+                            testArtifacts.addAll(testClasspathElements);
+                        }
+                    }
+                }
+            }
+        }
+
+        private MavenProject getMavenProject(File buildFile) throws ProjectBuildingException {
+            ProjectBuildingResult build = mavenProjectBuilder.build(buildFile,
+                        session.getProjectBuildingRequest().setResolveDependencies(true));
+            return build.getProject();
+        }
+
+        @Override
+        public boolean recompileBuildFile(File buildFile, Set<String> compileArtifactPaths,
+                Set<String> testArtifactPaths, ThreadPoolExecutor executor) throws PluginExecutionException {
             // monitoring project pom.xml file changes in dev mode:
             // - liberty.* properties in project properties section
             // - changes in liberty plugin configuration in the build plugin section
@@ -646,9 +727,18 @@ public class DevMojo extends StartDebugMojoSupport {
                     }
                 }
                 // update classpath for dependencies changes
-                compileArtifactPaths.clear();
+                if (this.parentBuildFiles.isEmpty()) {
+                    compileArtifactPaths.clear();
+                    testArtifactPaths.clear();
+                } else {
+                    // remove past artifacts and add the newest calculated (covers the case where a
+                    // dependency was deleted)
+                    // do not clear list as it may contain dependencies from parent projects
+                    testArtifactPaths.removeAll(backupProject.getTestClasspathElements());
+                    compileArtifactPaths.removeAll(backupProject.getCompileClasspathElements());
+                }
+
                 compileArtifactPaths.addAll(project.getCompileClasspathElements());
-                testArtifactPaths.clear();
                 testArtifactPaths.addAll(project.getTestClasspathElements());
 
                 if (restartServer) {
@@ -853,6 +943,12 @@ public class DevMojo extends StartDebugMojoSupport {
             }
         }
 
+        // get all parent poms
+        Map<String, List<String>> parentPoms = new HashMap<String, List<String>>();
+        for (MavenProject proj : graph.getAllProjects()) {
+            getParentPoms(parentPoms, proj);
+        }
+
         // default behavior of recompileDependencies
         if (recompileDependencies == null) {
             if (upstreamMavenProjects.isEmpty()) {
@@ -949,8 +1045,8 @@ public class DevMojo extends StartDebugMojoSupport {
                 // get compiler options for upstream project
                 JavaCompilerOptions upstreamCompilerOptions = getMavenCompilerOptions(p);
 
-                List<String> compileArtifacts = new ArrayList<String>();
-                List<String> testArtifacts = new ArrayList<String>();
+                Set<String> compileArtifacts = new HashSet<String>();
+                Set<String> testArtifacts = new HashSet<String>();
                 Build build = p.getBuild();
                 File upstreamSourceDir = new File(build.getSourceDirectory());
                 File upstreamOutputDir = new File(build.getOutputDirectory());
@@ -1000,17 +1096,18 @@ public class DevMojo extends StartDebugMojoSupport {
             skipUTs = true;
         }
 
+        // pom.xml
+        File pom = project.getFile();
+
         util = new DevMojoUtil(installDirectory, userDirectory, serverDirectory, sourceDirectory, testSourceDirectory,
                 configDirectory, project.getBasedir(), multiModuleProjectDirectory, resourceDirs, compilerOptions,
-                settings.getLocalRepository(), upstreamProjects, upstreamMavenProjects, recompileDeps);
+                settings.getLocalRepository(), upstreamProjects, upstreamMavenProjects, recompileDeps, pom, parentPoms);
         util.addShutdownHook(executor);
         util.startServer();
 
         // collect artifacts canonical paths in order to build classpath
-        List<String> compileArtifactPaths = project.getCompileClasspathElements();
-        List<String> testArtifactPaths = project.getTestClasspathElements();
-        // pom.xml
-        File pom = project.getFile();
+        Set<String> compileArtifactPaths = new HashSet<String>(project.getCompileClasspathElements());
+        Set<String> testArtifactPaths = new HashSet<String>(project.getTestClasspathElements());
 
         // start watching for keypresses immediately
         util.runHotkeyReaderThread(executor);
@@ -1022,10 +1119,10 @@ public class DevMojo extends StartDebugMojoSupport {
         try {
             if (!upstreamProjects.isEmpty()) {
                 // watch upstream projects for hot compilation if they exist
-                util.watchFiles(pom, outputDirectory, testOutputDirectory, executor, compileArtifactPaths,
+                util.watchFiles(outputDirectory, testOutputDirectory, executor, compileArtifactPaths,
                         testArtifactPaths, serverXmlFile, bootstrapPropertiesFile, jvmOptionsFile);
             } else {
-                util.watchFiles(pom, outputDirectory, testOutputDirectory, executor, compileArtifactPaths,
+                util.watchFiles(outputDirectory, testOutputDirectory, executor, compileArtifactPaths,
                         testArtifactPaths, serverXmlFile, bootstrapPropertiesFile, jvmOptionsFile);
             }
         } catch (PluginScenarioException e) {
@@ -1099,6 +1196,28 @@ public class DevMojo extends StartDebugMojoSupport {
             }
         }
         return false;
+    }
+
+    // update map with list of parent poms and their subsequent child poms
+    private void getParentPoms(Map<String, List<String>> parentPoms, MavenProject proj) throws IOException {
+        MavenProject parentProject = proj.getParent();
+        if (parentProject != null) {
+            // append to existing list
+            List<String> childPoms = parentPoms.get(parentProject.getFile().getCanonicalPath());
+            if (childPoms == null) {
+                childPoms = new ArrayList<String>();
+                childPoms.add(proj.getFile().getCanonicalPath());
+                parentPoms.put(parentProject.getFile().getCanonicalPath(), childPoms);
+            } else {
+                if (!childPoms.contains(proj.getFile().getCanonicalPath())) {
+                    childPoms.add(proj.getFile().getCanonicalPath());
+                }
+            }
+            if (parentProject.getParent() != null) {
+                // recursively search for top most parent project
+                getParentPoms(parentPoms, parentProject);
+            }
+        }
     }
 
     private JavaCompilerOptions getMavenCompilerOptions(MavenProject currentProject) {
@@ -1181,7 +1300,7 @@ public class DevMojo extends StartDebugMojoSupport {
             if (buildFile != null && !project.getFile().getCanonicalPath().equals(buildFile.getCanonicalPath())) {
                 build = mavenProjectBuilder.build(buildFile,
                         session.getProjectBuildingRequest().setResolveDependencies(true));
-                // if we can resolve the project associated with build file, run IT tests on
+                // if we can resolve the project associated with build file, run tests on
                 // corresponding project
                 if (build.getProject() != null) {
                     currentProject = build.getProject();
@@ -1195,9 +1314,31 @@ public class DevMojo extends StartDebugMojoSupport {
         return currentProject;
     }
 
-    private void runTestMojo(String groupId, String artifactId, String goal, MavenProject project) throws MojoExecutionException {
+    private void runTestMojo(String groupId, String artifactId, String goal, MavenProject project)
+            throws MojoExecutionException {
         Plugin plugin = getPluginForProject(groupId, artifactId, project);
         Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(plugin, goal, log);
+
+        // check if this is a project module or main module
+        if (util.isMultiModuleProject()) {
+            try {
+                Set<String> testArtifacts;
+                ProjectModule projectModule = util.getProjectModule(project.getFile());
+                if (projectModule != null) {
+                    testArtifacts = projectModule.getTestArtifacts();
+                } else {
+                    // assume this is the main module
+                    testArtifacts = util.getTestArtifacts();
+                }
+                if (goal.equals("test") || goal.equals("integration-test") {
+                    injectClasspathElements(config, testArtifacts, project.getTestClasspathElements());
+                }
+            } catch (IOException | DependencyResolutionRequiredException e) {
+                log.warn(
+                        "Unable to resolve test artifact paths, test compilation may not include parent dependencies. Restart dev mode to ensure classpaths are properly resolved.");
+                log.debug(e);
+            }
+        }
 
         if (goal.equals("test")) {
             injectTestId(config);
@@ -1266,6 +1407,35 @@ public class DevMojo extends StartDebugMojoSupport {
         MavenSession tempSession = session.clone();
         tempSession.setCurrentProject(project);
         executeMojo(plugin, goal(goal), config, executionEnvironment(project, tempSession, pluginManager));
+    }
+
+    /**
+     * Inject missing test artifacts (usually from upstream modules) for Maven
+     * surefire and failsafe plugins
+     * 
+     * @param config                The configuration element
+     * @param testArtifacts         The complete list of test artifacts resolved
+     *                              from the build file and upstream build files
+     * @param testClasspathElements The list of test artifacts resolved from the
+     *                              build file
+     */
+    private void injectClasspathElements(Xpp3Dom config, Set<String> testArtifacts,
+            List<String> testClasspathElements) {
+        if (testArtifacts.size() > testClasspathElements.size()) {
+            List<String> additionalClassPathElements = new ArrayList<String>();
+            additionalClassPathElements.addAll(testArtifacts);
+            additionalClassPathElements.removeAll(testClasspathElements);
+            Xpp3Dom classpathElement = config.getChild("additionalClasspathElements");
+            if (classpathElement == null) {
+                classpathElement = new Xpp3Dom("additionalClasspathElements");
+            }
+            for (String element : additionalClassPathElements) {
+                Xpp3Dom childElem = new Xpp3Dom("additionalClasspathElement");
+                childElem.setValue(element);
+                classpathElement.addChild(childElem);
+            }
+            config.addChild(classpathElement);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1226

When a dependency is added to a parent pom recalculate the compile and test artifacts for all child modules.

When running tests, the resolved dependencies of the `MavenProject` will not include any dependencies added to upstream projects after dev mode has started. Using the [Maven Surefire additional classpath element](https://maven.apache.org/surefire/maven-surefire-plugin/examples/configuring-classpath.html) and the [Maven Failsafe additional classpath element](https://maven.apache.org/surefire/maven-failsafe-plugin/examples/configuring-classpath.html) ensure that the complete list of artifacts are included when unit tests and integration tests run. See the added [injectClasspathElements](https://github.com/OpenLiberty/ci.maven/commit/7982c0c0c1f93c1ae76c2f397f3441ab9473c49f#diff-6e1b4178eafae85af99729483f003829d4a72a19d89a1f148bd98de4c51cb350R1257-R1285) method.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>