### PR TITLE
Block tests from running when Maven thread classpath error is detected

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.twdata.maven</groupId>
             <artifactId>mojo-executor</artifactId>
-            <version>2.3.0</version>
+            <version>2.3.2</version>
         </dependency>
         <dependency>
             <groupId>xmlunit</groupId>

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -272,14 +272,14 @@ public class DevMojo extends StartDebugMojoSupport {
                 File testSourceDirectory, File configDirectory, File projectDirectory, File multiModuleProjectDirectory,
                 List<File> resourceDirs, JavaCompilerOptions compilerOptions, String mavenCacheLocation,
                 List<ProjectModule> upstreamProjects, List<MavenProject> upstreamMavenProjects, boolean recompileDeps,
-                File pom, Map<String, List<String>> parentPoms) throws IOException {
+                File pom, Map<String, List<String>> parentPoms, Set<String> compileArtifactPaths, Set<String> testArtifactPaths) throws IOException {
             super(new File(project.getBuild().getDirectory()), serverDirectory, sourceDirectory, testSourceDirectory,
                     configDirectory, projectDirectory, multiModuleProjectDirectory, resourceDirs, hotTests, skipTests,
                     skipUTs, skipITs, project.getArtifactId(), serverStartTimeout, verifyTimeout, verifyTimeout,
                     ((long) (compileWait * 1000L)), libertyDebug, false, false, pollingTest, container, dockerfile,
                     dockerBuildContext, dockerRunOpts, dockerBuildTimeout, skipDefaultPorts, compilerOptions,
                     keepTempDockerfile, mavenCacheLocation, upstreamProjects, recompileDeps, project.getPackaging(),
-                    pom, parentPoms);
+                    pom, parentPoms, compileArtifactPaths, testArtifactPaths);
 
             ServerFeature servUtil = getServerFeatureUtil();
             this.libertyDirPropertyFiles = BasicSupport.getLibertyDirectoryPropertyFiles(installDir, userDir,
@@ -889,6 +889,37 @@ public class DevMojo extends StartDebugMojoSupport {
             return DeployMojoSupport.isSupportedLooseAppType(project.getPackaging());
         }
 
+        @Override
+        public boolean isClasspathResolved(File buildFile) {
+            MavenProject currentProject = resolveMavenProject(buildFile);
+            Set<String> testArtifacts;
+            try {
+                if (util.isMultiModuleProject()) {
+                    ProjectModule projectModule = util.getProjectModule(currentProject.getFile());
+                    if (projectModule != null) {
+                        testArtifacts = projectModule.getTestArtifacts();
+                    } else {
+                        // assume this is the main module
+                        testArtifacts = util.getTestArtifacts();
+                    }
+                } else {
+                    testArtifacts = util.getTestArtifacts();
+                }
+                // if project.getArtifacts() is empty but our tracked list of of testArtifacts
+                // is not empty, this is a Maven thread error and block tests from running
+                // see https://issues.apache.org/jira/browse/MNG-7285
+                if (currentProject.getArtifacts().isEmpty() && !testArtifacts.isEmpty()) {
+                    return false;
+                }
+            } catch (IOException e) {
+                log.error("Unable to resolve test artifact paths for " + currentProject.getFile()
+                        + ". Restart dev mode to ensure classpaths are properly resolved.");
+                log.debug(e);
+                return false;
+            }
+            return true;
+        }
+
     }
 
     private boolean isUsingBoost() {
@@ -1099,15 +1130,15 @@ public class DevMojo extends StartDebugMojoSupport {
         // pom.xml
         File pom = project.getFile();
 
-        util = new DevMojoUtil(installDirectory, userDirectory, serverDirectory, sourceDirectory, testSourceDirectory,
-                configDirectory, project.getBasedir(), multiModuleProjectDirectory, resourceDirs, compilerOptions,
-                settings.getLocalRepository(), upstreamProjects, upstreamMavenProjects, recompileDeps, pom, parentPoms);
-        util.addShutdownHook(executor);
-        util.startServer();
-
         // collect artifacts canonical paths in order to build classpath
         Set<String> compileArtifactPaths = new HashSet<String>(project.getCompileClasspathElements());
         Set<String> testArtifactPaths = new HashSet<String>(project.getTestClasspathElements());
+
+        util = new DevMojoUtil(installDirectory, userDirectory, serverDirectory, sourceDirectory, testSourceDirectory,
+                configDirectory, project.getBasedir(), multiModuleProjectDirectory, resourceDirs, compilerOptions,
+                settings.getLocalRepository(), upstreamProjects, upstreamMavenProjects, recompileDeps, pom, parentPoms, compileArtifactPaths, testArtifactPaths);
+        util.addShutdownHook(executor);
+        util.startServer();
 
         // start watching for keypresses immediately
         util.runHotkeyReaderThread(executor);
@@ -1117,14 +1148,8 @@ public class DevMojo extends StartDebugMojoSupport {
         // which is where the server.xml is located if a specific serverXmlFile
         // configuration parameter is not specified.
         try {
-            if (!upstreamProjects.isEmpty()) {
-                // watch upstream projects for hot compilation if they exist
-                util.watchFiles(outputDirectory, testOutputDirectory, executor, compileArtifactPaths,
-                        testArtifactPaths, serverXmlFile, bootstrapPropertiesFile, jvmOptionsFile);
-            } else {
-                util.watchFiles(outputDirectory, testOutputDirectory, executor, compileArtifactPaths,
-                        testArtifactPaths, serverXmlFile, bootstrapPropertiesFile, jvmOptionsFile);
-            }
+            util.watchFiles(outputDirectory, testOutputDirectory, executor, serverXmlFile, bootstrapPropertiesFile,
+                    jvmOptionsFile);
         } catch (PluginScenarioException e) {
             if (e.getMessage() != null) {
                 // a proper message is included in the exception if the server has been stopped
@@ -1357,6 +1382,7 @@ public class DevMojo extends StartDebugMojoSupport {
         } else if (goal.equals("integration-test")) {
             injectTestId(config);
             injectLibertyProperties(config);
+
             // clean up previous summary file
             File summaryFile = null;
             Xpp3Dom summaryFileElement = config.getChild("summaryFile");


### PR DESCRIPTION
Closes #1255 

This is a [known issue](https://issues.apache.org/jira/browse/MNG-7285) with Maven 3.8.2 and 3.8.3. `project.getArtifacts()` is returning an empty list when called from a separate thread. In order to ensure tests are running with the correct resolved classpath, users will have to run tests outside outside of dev mode. 

Tests are blocked when this error is detected, and the following startup messages have been added:
```
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        A classpath error with Maven has been detected. Tests will not run in dev mode on this project.
[INFO] *        Run tests outside of dev mode with `mvn verify` or `mvn failsafe:integration-test`.
[INFO] *        To restart the server, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *        
[INFO] *    Liberty server port information:
[INFO] *        Liberty server HTTP port: [ 9080 ]
[INFO] *        Liberty debug port: [ 7777 ]
[INFO] ************************************************************************
[ERROR] A classpath error with Maven has been detected. Tests will not run in dev mode on this project. Run tests outside of dev mode with `mvn verify` or `mvn failsafe:integration-test`.
[INFO] Source compilation was successful.
[INFO] Tests compilation was successful.

```

If users press "Enter" to trigger tests, they will see the same error message. If `hotTests=true`, the error message will appear on every source file change.
```
[ERROR] A classpath error with Maven has been detected. Tests will not run in dev mode on this project. Run tests outside of dev mode with `mvn verify` or `mvn failsafe:integration-test`.
```

This applies to dev, devc and dev mode with multimodules.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>