### PR TITLE
Add exploded loose app support

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>io.openliberty.tools</groupId>
             <artifactId>ci.common</artifactId>
-            <version>1.8.18</version>
+            <version>1.8.19-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.twdata.maven</groupId>

--- a/liberty-maven-plugin/src/it/dev-it/resources/exploded-war-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/exploded-war-project/pom.xml
@@ -1,0 +1,251 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>dev-it-tests</groupId>
+	<artifactId>exploded-war-proj</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>war</packaging>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
+		<app.name>LibertyProject</app.name>
+		<!-- tag::ports[] -->
+		<testServerHttpPort>9080</testServerHttpPort>
+		<testServerHttpsPort>9443</testServerHttpsPort>
+		<!-- end::ports[] -->
+		<packaging.type>usr</packaging.type>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.openliberty.features</groupId>
+				<artifactId>features-bom</artifactId>
+				<version>RUNTIME_VERSION</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<!-- Open Liberty features -->
+		<dependency>
+			<groupId>io.openliberty.features</groupId>
+			<artifactId>jaxrs-2.1</artifactId>
+			<type>esa</type>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.openliberty.features</groupId>
+			<artifactId>jsonp-1.1</artifactId>
+			<type>esa</type>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.openliberty.features</groupId>
+			<artifactId>cdi-2.0</artifactId>
+			<type>esa</type>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.openliberty.features</groupId>
+			<artifactId>mpConfig-1.3</artifactId>
+			<type>esa</type>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.openliberty.features</groupId>
+			<artifactId>mpRestClient-1.2</artifactId>
+			<type>esa</type>
+			<scope>provided</scope>
+		</dependency>
+		<!-- For tests -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-rt-rs-client</artifactId>
+			<version>3.2.6</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-rt-rs-extension-providers</artifactId>
+			<version>3.2.6</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.json</artifactId>
+			<version>1.0.4</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- Java utility classes -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.0</version>
+		</dependency>
+		<!-- Support for JDK 9 and above -->
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-core</artifactId>
+			<version>2.3.0.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<version>2.3.2</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>activation</artifactId>
+			<version>1.1.1</version>
+		</dependency>
+		<!-- Test runtime dependency for run goal -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.25</version>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.2.3</version>
+			<scope>runtime</scope>
+		</dependency>
+		<!-- ADDITIONAL_DEPENDENCIES -->
+		
+		<!-- Overlay dependency
+        <dependency>
+      		<groupId>com.example.projects</groupId>
+      		<artifactId>documentedprojectdependency</artifactId>
+      		<version>1.0-SNAPSHOT</version>
+      		<type>war</type>
+      		<scope>runtime</scope>
+    	</dependency>
+    	-->
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-war-plugin</artifactId>
+				<version>3.2.2</version>
+				<configuration>
+					<failOnMissingWebXml>false</failOnMissingWebXml>
+					<packagingExcludes>pom.xml</packagingExcludes>
+					<!-- Overlay configuration start
+					<overlays> 
+						<overlay> 
+						</overlay> 
+					</overlays> 
+					Overlay configuration end -->
+
+					<!-- Filtered directory start
+					<webResources> 
+						<resource> 
+							<directory>resource2</directory> 
+						</resource> 
+					</webResources> 
+					Filtered directory end -->
+
+					<filteringDeploymentDescriptors>false</filteringDeploymentDescriptors>
+				</configuration>
+			</plugin>
+			<!-- Plugin to run unit tests -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0-M1</version>
+				<executions>
+					<execution>
+						<phase>test</phase>
+						<id>default-test</id>
+						<configuration>
+							<excludes>
+								<exclude>**/it/**</exclude>
+							</excludes>
+							<reportsDirectory>${project.build.directory}/test-reports/unit</reportsDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- Enable liberty-maven plugin -->
+			<plugin>
+				<groupId>io.openliberty.tools</groupId>
+				<artifactId>liberty-maven-plugin</artifactId>
+				<version>SUB_VERSION</version>
+				<configuration>
+					<assemblyArtifact>
+						<groupId>io.openliberty</groupId>
+						<artifactId>openliberty-kernel</artifactId>
+						<version>RUNTIME_VERSION</version>
+						<type>zip</type>
+					</assemblyArtifact>
+					<packageName>${app.name}</packageName>
+					<include>${packaging.type}</include>
+					<bootstrapProperties>
+						<default.http.port>${testServerHttpPort}</default.http.port>
+						<default.https.port>${testServerHttpsPort}</default.https.port>
+						<com.ibm.ws.logging.message.format>json</com.ibm.ws.logging.message.format>
+					</bootstrapProperties>
+					<!-- ADDITIONAL_CONFIGURATION -->
+				</configuration>
+			</plugin>
+			<!-- Plugin to run functional tests -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>3.0.0-M1</version>
+				<executions>
+					<execution>
+						<phase>integration-test</phase>
+						<id>integration-test</id>
+						<goals>
+							<goal>integration-test</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>**/it/**/*.java</include>
+							</includes>
+							<!-- tag::system-props[] -->
+							<systemPropertyVariables>
+								<liberty.test.port>${testServerHttpPort}</liberty.test.port>
+							</systemPropertyVariables>
+							<!-- end::system-props[] -->
+						</configuration>
+					</execution>
+					<execution>
+						<id>verify-results</id>
+						<goals>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<summaryFile>${project.build.directory}/test-reports/it/failsafe-summary.xml</summaryFile>
+					<reportsDirectory>${project.build.directory}/test-reports/it</reportsDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/exploded-war-project/src/main/java/com/demo/HelloLogger.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/exploded-war-project/src/main/java/com/demo/HelloLogger.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.demo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+@Path("/show-log")
+public class HelloLogger {
+    private static final Logger log = LoggerFactory.getLogger(HelloLogger.class);
+
+    @GET
+    @Produces(TEXT_PLAIN)
+    public String showLog() {
+        log.info("Here is the Log");
+        return "Log has been shown";
+    }
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/exploded-war-project/src/main/java/com/demo/HelloServlet.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/exploded-war-project/src/main/java/com/demo/HelloServlet.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.demo;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(urlPatterns="/servlet")
+public class HelloServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger log = LoggerFactory.getLogger(HelloLogger.class);
+
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        log.info("SLF4J Logger is ready for messages.");
+        response.getWriter().append("hello world");
+    }
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/exploded-war-project/src/main/java/com/demo/HelloWorld.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/exploded-war-project/src/main/java/com/demo/HelloWorld.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.demo;
+
+public class HelloWorld {
+
+	public String helloWorld() {
+		return "helloWorld";
+	}
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/exploded-war-project/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/exploded-war-project/src/main/liberty/config/server.xml
@@ -1,0 +1,9 @@
+<server description="Sample Liberty server">
+
+  <featureManager>
+    <feature>jaxrs-2.1</feature>
+  </featureManager>
+
+  <httpEndpoint host="*" httpPort="${default.http.port}"
+    httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+</server>

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/ExplodedLooseWarAppTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/ExplodedLooseWarAppTest.java
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.file.Files;
+import java.util.Scanner;
+
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ExplodedLooseWarAppTest extends BaseDevTest {
+       private final String projectArtifact = "exploded-war-proj-1.0-SNAPSHOT";
+       private final String appsDir = "target/liberty/wlp/usr/servers/defaultServer/dropins/";
+
+	   @BeforeClass
+	   public static void setUpBeforeClass() throws Exception {
+	      setUpBeforeClass(null, "../resources/exploded-war-project");
+	   }
+	
+	   @AfterClass
+	   public static void cleanUpAfterClass() throws Exception {
+	      BaseDevTest.cleanUpAfterClass();
+	   }
+	
+	   @Test
+	   public void configureWebXmlFiltering() throws Exception {
+	      // Add deployment descriptor filtering config to pom war plugin
+		  replaceString("<filteringDeploymentDescriptors>false</filteringDeploymentDescriptors>", 
+				  "<filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>", pom);
+		  
+		  // Verify exploded goal running and redeploy
+		  verifyLogMessageExists("Running liberty:deploy", 2000);
+		  verifyLogMessageExists("Running maven-war-plugin:exploded", 2000);
+		  
+		  // Verify loose app xml is correct
+		  verifyExplodedLooseApp();
+		   
+		  // Remove filtering config
+		  replaceString("<filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>", 
+				  "<filteringDeploymentDescriptors>false</filteringDeploymentDescriptors>", pom);	  
+		  
+		  // Verify redeploy
+		  verifyLogMessageExists("Running liberty:deploy", 2000);
+		  
+		  // Verify loose app xml is back to how it was
+		  verifyNonExplodedLooseApp();
+	   }
+	   
+	   @Test
+	   public void configureFilteredResource() throws Exception {
+		   // Add filtering config to pom war plugin (directory)
+		   replaceString("<!-- Filtered directory start", 
+					  "<!-- Filtered directory start -->", pom);
+		   
+		   replaceString("Filtered directory end -->", 
+					  "<!-- Filtered directory end -->", pom);
+		   
+		   // Verify exploded goal running and redeploy
+		   verifyLogMessageExists("Running liberty:deploy", 2000);
+		   verifyLogMessageExists("Running maven-war-plugin:exploded", 2000);
+		   
+		   // Verify loose app xml is correct
+		   verifyExplodedLooseApp();   
+		   
+		   // Remove filtering config
+		   replaceString("<!-- Filtered directory start -->", 
+					  "<!-- Filtered directory start ", pom);
+		   
+		   replaceString("<!-- Filtered directory end -->", 
+					  "Filtered directory end -->", pom);
+		   
+		   // Verify redeploy
+		   verifyLogMessageExists("Running liberty:deploy", 2000);
+		   
+		   // Verify loose app xml is back to how it was
+		   verifyNonExplodedLooseApp();
+	   }
+	   
+	   @Test
+	   public void configureWarOverlay() throws Exception {
+		   // Add filtering config to pom war plugin (directory)
+		   replaceString("<!-- Overlay configuration start", 
+					  "<!-- Overlay configuration start -->", pom);
+		   
+		   replaceString("Overlay configuration end -->", 
+					  "<!-- Overlay configuration end -->", pom);
+		   
+		   // Verify exploded goal running and redeploy
+		   verifyLogMessageExists("Running liberty:deploy", 2000);
+		   verifyLogMessageExists("Running maven-war-plugin:exploded", 2000);
+		   
+		   // Verify loose app xml is correct
+		   verifyExplodedLooseApp();   
+		   
+		   // Remove filtering config
+		   replaceString("<!-- Overlay configuration start -->", 
+					  "<!-- Overlay configuration start", pom);
+		   
+		   replaceString("<!-- Overlay configuration end -->", 
+					  "Overlay configuration end -->", pom);
+		   
+		   // Verify redeploy
+		   verifyLogMessageExists("Running liberty:deploy", 2000);
+		   
+		   // Verify loose app xml is back to how it was
+		   verifyNonExplodedLooseApp();
+	   }
+	   
+	   private void verifyExplodedLooseApp() throws Exception {
+		   String looseAppXml = tempProj.getAbsolutePath() + "/" + appsDir + projectArtifact + ".war.xml";
+		   
+		   // Verify the target/<projectArtifact> entry
+		   String explodedWar = basicDevProj.getAbsolutePath() + "/target/" + projectArtifact;
+		   verifyLogMessageExists("<dir sourceOnDisk=\"" + explodedWar + "\" targetInArchive=\"/\"/>", 2000, new File(looseAppXml));
+	   }
+	   
+	   private void verifyNonExplodedLooseApp() throws Exception {
+		   String looseAppXml = tempProj.getAbsolutePath() + "/" + appsDir + projectArtifact + ".war.xml";
+		   
+		   // Verify the src/main/webapp entry
+		   String srcMain = basicDevProj.getAbsolutePath() + "/src/main/webapp";
+		   verifyLogMessageExists("<dir sourceOnDisk=\"" + srcMain + "\" targetInArchive=\"/\"/>", 2000, new File(looseAppXml));
+	       
+		   // Verify the target/classes entry
+		   String targetClasses = basicDevProj.getAbsolutePath() + "/target/classes";
+		   verifyLogMessageExists("<dir sourceOnDisk=\"" + targetClasses + "\" targetInArchive=\"/WEB-INF/classes\"/>", 2000, new File(looseAppXml));
+	   }
+}

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/LooseEarApplication.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/LooseEarApplication.java
@@ -16,6 +16,7 @@
 package io.openliberty.tools.maven.applications;
 
 import java.io.File;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -94,12 +95,12 @@ public class LooseEarApplication extends LooseApplication {
         
         
         // retrieve the directories defined as resources in the maven war plugin
-        Map<String,String> webResources = MavenProjectUtil.getWebResourcesConfiguration(proj);
-        if (webResources != null) {
-            for (String directory : webResources.keySet()) {
-                String targetPath = webResources.get(directory)==null ? "/" : "/"+webResources.get(directory);
-                config.addDir(warArchive, new File(proj.getBasedir().getAbsolutePath(), directory), targetPath);
-            }
+        List<Xpp3Dom> webResources = LooseWarApplication.getWebResourcesConfigurations(proj);
+    	for (Xpp3Dom resource : webResources) {
+            Xpp3Dom dir = resource.getChild("directory");
+            Xpp3Dom target = resource.getChild("targetPath");
+            String targetPath = target==null ? "/" : "/"+target.getValue();
+            config.addDir(warArchive, new File(proj.getBasedir().getAbsolutePath(), dir.getValue()), targetPath);
         }
 
         // add Manifest file

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/LooseWarApplication.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/LooseWarApplication.java
@@ -1,8 +1,34 @@
+/**
+ * (C) Copyright IBM Corporation 2019, 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.openliberty.tools.maven.applications;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.w3c.dom.DOMException;
 
 import io.openliberty.tools.maven.utils.MavenProjectUtil;
 import io.openliberty.tools.common.plugins.config.LooseApplication;
@@ -12,17 +38,243 @@ public class LooseWarApplication extends LooseApplication {
     
     protected final MavenProject project;
     
-    public LooseWarApplication(MavenProject project, LooseConfigData config) {
+    protected final Log log;
+
+    public LooseWarApplication(MavenProject project, LooseConfigData config, Log log) {
         super(project.getBuild().getDirectory(), config);
         this.project = project;
+        this.log = log;
     }
     
-    public void addSourceDir(MavenProject proj) throws Exception {
-        File sourceDir = new File(proj.getBasedir().getAbsolutePath(), "src/main/webapp");
-        String path = MavenProjectUtil.getPluginConfiguration(proj, "org.apache.maven.plugins", "maven-war-plugin", "warSourceDirectory");
-        if (path != null) {
-            sourceDir = new File(proj.getBasedir().getAbsolutePath(), path);
-        } 
-        config.addDir(sourceDir, "/");
+    public static boolean isExploded(MavenProject project) {
+    	boolean isExplodedWar = false;
+    	
+    	// Check if filtering is enabled
+    	List<Path> dynamicWebResources = getFilteredWebSourceDirectories(project);
+    	
+    	if (!dynamicWebResources.isEmpty() || isUsingOverlays(project)) {
+    		isExplodedWar = true;
+    	}
+    	
+    	// TODO: Check additional filtering options (properties?)
+    	
+    	return isExplodedWar;
+    }
+    
+    
+    public boolean isExploded() {
+    	return isExploded(project);
+    }
+    
+    public void addSourceDir() throws Exception {
+        Path warSourceDir = getWarSourceDirectory();
+        config.addDir(warSourceDir.toFile(), "/");
+    }
+
+    public Path getWarSourceDirectory() {
+        return getWarSourceDirectory(project);
+    }
+
+    private static Path getWarSourceDirectory(MavenProject project) {
+        Path baseDir = Paths.get(project.getBasedir().getAbsolutePath());
+        String warSourceDir = MavenProjectUtil.getPluginConfiguration(project, "org.apache.maven.plugins", "maven-war-plugin", "warSourceDirectory");
+        if (warSourceDir == null) {
+            warSourceDir = "src/main/webapp";
+        }  
+        // Use java.nio Paths to fix issue with absolute paths on Windows
+        return baseDir.resolve(warSourceDir);
+    }
+
+    private Path getWebAppDirectory(MavenProject project) {
+        Xpp3Dom dom = project.getGoalConfiguration("org.apache.maven.plugins", "maven-war-plugin", null, null);
+        String webAppDirStr = null;
+        if (dom != null) {
+            Xpp3Dom webAppDirConfig = dom.getChild("webappDirectory");
+            if (webAppDirConfig != null) {
+                webAppDirStr = webAppDirConfig.getValue();
+            }
+        }
+
+        if (webAppDirStr != null) {
+            return Paths.get(webAppDirStr);
+        } else {
+            // Match plugin default (we could get the default programmatically via webAppDirConfig.getAttribute("default-value") but don't
+            return Paths.get(project.getBuild().getDirectory(), project.getBuild().getFinalName());
+        }
+    }
+
+    public static List<Path> getFilteredWebSourceDirectories(MavenProject project) {
+
+        List<Path> retVal = new ArrayList<Path>();
+
+        Path baseDirPath = Paths.get(project.getBasedir().getAbsolutePath());
+
+        for (Xpp3Dom resource : getWebResourcesConfigurations(project)) {
+            Xpp3Dom dir = resource.getChild("directory");
+            Xpp3Dom filtering = resource.getChild("filtering");
+            if (dir != null && filtering != null) {
+                boolean filtered = Boolean.parseBoolean(filtering.getValue());
+                if (filtered) {
+                    retVal.add(baseDirPath.resolve(dir.getValue()));
+                }
+            }
+        }
+
+        // Now add warSourceDir
+        if (isFilteringDeploymentDescriptors(project)) {
+            retVal.add(getWarSourceDirectory(project));
+        }
+
+        return retVal;
+    }
+    
+    public List<Path> getFilteredWebSourceDirectories() {
+    	return getFilteredWebSourceDirectories(project);
+    }
+    
+    private static boolean isFilteringDeploymentDescriptors(MavenProject project) {
+        Boolean retVal = false;
+        Xpp3Dom dom = project.getGoalConfiguration("org.apache.maven.plugins", "maven-war-plugin", null, null);
+        if (dom != null) {
+            Xpp3Dom fdd = dom.getChild("filteringDeploymentDescriptors");
+            if (fdd != null) {
+                retVal = Boolean.parseBoolean(fdd.getValue());
+            }
+        }
+        return retVal;
+    }
+
+    public boolean isFilteringDeploymentDescriptors() {
+        return isFilteringDeploymentDescriptors(project);
+    }
+    
+    public static boolean isUsingOverlays(MavenProject project) {
+    	boolean overlaysEnabled = false;
+    	
+    	// Get overlay dependencies
+    	List<Dependency> overlayDependencies = getWarDependencies(project);
+    	
+    	// Get overlays configured in the Maven WAR plugin
+    	List<Xpp3Dom> overlayConfigurations = getOverlayConfigurations(project);
+    	
+    	if (!overlayDependencies.isEmpty() || !overlayConfigurations.isEmpty()) {
+    		overlaysEnabled = true;
+    	}
+    	
+    	return overlaysEnabled;
+    }
+    
+    /**
+     * Get overlay configuration values from the Maven WAR plugin
+     * @param proj the Maven project
+     * @return ALLOWS DUPS
+     * @return a List of war plugin overlay elements
+     */
+    private static List<Xpp3Dom> getOverlayConfigurations(MavenProject project) {
+        List<Xpp3Dom> retVal = new ArrayList<Xpp3Dom>();
+        Xpp3Dom dom = project.getGoalConfiguration("org.apache.maven.plugins", "maven-war-plugin", null, null);
+        if (dom != null) {
+            Xpp3Dom overlays = dom.getChild("overlays");
+            if (overlays != null) {
+                Xpp3Dom overlayList[] = overlays.getChildren("overlay");
+                if (overlayList != null) {
+                    for (int i = 0; i < overlayList.length; i++) {
+                        retVal.add(overlayList[i]);
+                    }
+                }
+            }
+        }
+        return retVal;
+    }
+    
+    /**
+     * Get overlay dependencies
+     * @param proj the Maven project
+     * @return ALLOWS DUPS
+     * @return a List of war plugin overlay dependencies
+     */
+    private static List<Dependency> getWarDependencies(MavenProject project) {
+    	List<Dependency> overlayDependencies = new ArrayList<Dependency>();
+    	
+    	List<Dependency> deps = project.getDependencies();
+    	for (Dependency dep : deps) {
+    		if (dep.getType().equals("war")) {
+    			overlayDependencies.add(dep);
+    		}
+    	}
+    	
+    	return overlayDependencies;
+    }
+
+
+    /**
+     * Get resource configuration values that have "directory" children elements from the Maven WAR plugin
+     * @param proj the Maven project
+     * @return a List of war plugin resource elements that contain a "directory" child element or empty list if none are found
+     */
+    public static List<Xpp3Dom> getWebResourcesConfigurations(MavenProject project) {
+        List<Xpp3Dom> retVal = new ArrayList<Xpp3Dom>();
+        Xpp3Dom dom = project.getGoalConfiguration("org.apache.maven.plugins", "maven-war-plugin", null, null);
+        if (dom != null) {
+            Xpp3Dom web = dom.getChild("webResources");
+            if (web != null) {
+                Xpp3Dom resources[] = web.getChildren("resource");
+                if (resources != null) {
+                    for (int i = 0; i < resources.length; i++) {
+                        Xpp3Dom dir = resources[i].getChild("directory");
+                        // put dir in List
+                        if (dir != null) {
+                            retVal.add(resources[i]);
+                        }
+                    }
+                }
+            }
+        }
+        return retVal;
+    }
+
+    private void addWebResourcesConfigurationPaths(boolean onlyUnfiltered) throws DOMException, IOException {
+        Set<Path> handled = new HashSet<Path>();
+
+        Path baseDirPath = Paths.get(project.getBasedir().getAbsolutePath());
+
+        for (Xpp3Dom resource : getWebResourcesConfigurations(project)) {
+            Xpp3Dom dir = resource.getChild("directory");
+            Xpp3Dom target = resource.getChild("targetPath");
+            Xpp3Dom filtering = resource.getChild("filtering");
+            Path resolvedDir = baseDirPath.resolve(dir.getValue());
+            if (handled.contains(resolvedDir)) {
+                log.warn("Ignoring webResources dir: " + dir.getValue() + ", already have entry for path: " + resolvedDir);
+            } else {
+                if (onlyUnfiltered && filtering != null && Boolean.parseBoolean(filtering.getValue())) {
+                    continue;
+                } else {
+                    String targetPath = "/";
+                    if (target != null) {
+                        targetPath = "/" + target.getValue();
+                    } 
+                    addOutputDir(getDocumentRoot(), resolvedDir.toFile(), targetPath);
+                    handled.add(resolvedDir);
+                }
+            }
+        }
+    }
+
+    /*
+     * @return
+     * @throws IOException 
+     * @throws DOMException 
+     */
+
+    public void addAllWebResourcesConfigurationPaths() throws DOMException, IOException {
+        addWebResourcesConfigurationPaths(false);
+    }
+
+    public void addNonFilteredWebResourcesConfigurationPaths() throws DOMException, IOException {
+        addWebResourcesConfigurationPaths(true);
+    }
+
+    public Path getWebAppDirectory() {
+    	return getWebAppDirectory(project);
     }
 }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -24,6 +24,7 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.name;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -69,6 +70,7 @@ import io.openliberty.tools.common.plugins.util.ServerStatusUtil;
 import io.openliberty.tools.common.plugins.util.ProjectModule;
 import io.openliberty.tools.maven.BasicSupport;
 import io.openliberty.tools.maven.applications.DeployMojoSupport;
+import io.openliberty.tools.maven.applications.LooseWarApplication;
 import io.openliberty.tools.maven.utils.ExecuteMojoUtil;
 
 /**
@@ -232,6 +234,8 @@ public class DevMojo extends LooseAppSupport {
      */
     @Parameter(property = "keepTempDockerfile", defaultValue = "false")
     private boolean keepTempDockerfile;
+    
+    private boolean isExplodedLooseWarApp = false;
 
     /**
      * Set the container option.
@@ -247,16 +251,12 @@ public class DevMojo extends LooseAppSupport {
     }
 
     protected List<File> getResourceDirectories(MavenProject project, File outputDir) {
-        // resource directories
+    	// Let's just add resources directories unconditionally, the dev util already checks the directories actually exist
+        // before adding them to the watch list.   If we avoid checking here we allow for creating them later on.
         List<File> resourceDirs = new ArrayList<File>();
-        if (outputDir.exists()) {
-            List<Resource> resources = project.getResources();
-            for (Resource resource : resources) {
-                File resourceFile = new File(resource.getDirectory());
-                if (resourceFile.exists()) {
-                    resourceDirs.add(resourceFile);
-                }
-            }
+        for (Resource resource : project.getResources()) {
+            File resourceFile = new File(resource.getDirectory());
+            resourceDirs.add(resourceFile);
         }
         if (resourceDirs.isEmpty()) {
             File defaultResourceDir = new File(project.getBasedir(), "src/main/resources");
@@ -276,14 +276,16 @@ public class DevMojo extends LooseAppSupport {
                 File testSourceDirectory, File configDirectory, File projectDirectory, File multiModuleProjectDirectory,
                 List<File> resourceDirs, JavaCompilerOptions compilerOptions, String mavenCacheLocation,
                 List<ProjectModule> upstreamProjects, List<MavenProject> upstreamMavenProjects, boolean recompileDeps,
-                File pom, Map<String, List<String>> parentPoms, Set<String> compileArtifactPaths, Set<String> testArtifactPaths) throws IOException {
+                File pom, Map<String, List<String>> parentPoms, Set<String> compileArtifactPaths, Set<String> testArtifactPaths, 
+                List<Path> webResourceDirs) throws IOException {
+        	
             super(new File(project.getBuild().getDirectory()), serverDirectory, sourceDirectory, testSourceDirectory,
                     configDirectory, projectDirectory, multiModuleProjectDirectory, resourceDirs, hotTests, skipTests,
                     skipUTs, skipITs, project.getArtifactId(), serverStartTimeout, verifyTimeout, verifyTimeout,
                     ((long) (compileWait * 1000L)), libertyDebug, false, false, pollingTest, container, dockerfile,
                     dockerBuildContext, dockerRunOpts, dockerBuildTimeout, skipDefaultPorts, compilerOptions,
                     keepTempDockerfile, mavenCacheLocation, upstreamProjects, recompileDeps, project.getPackaging(),
-                    pom, parentPoms, compileArtifactPaths, testArtifactPaths);
+                    pom, parentPoms, compileArtifactPaths, testArtifactPaths, webResourceDirs);
 
             ServerFeature servUtil = getServerFeatureUtil();
             this.libertyDirPropertyFiles = BasicSupport.getLibertyDirectoryPropertyFiles(installDir, userDir,
@@ -645,6 +647,81 @@ public class DevMojo extends LooseAppSupport {
                         session.getProjectBuildingRequest().setResolveDependencies(true));
             return build.getProject();
         }
+        
+        @Override
+        protected void updateLooseApp() throws PluginExecutionException {
+        	// Only perform operations if we are a war type application
+        	if (project.getPackaging().equals("war")) {
+		    	// Check if we are using an exploded loose app
+		    	if (LooseWarApplication.isExploded(project)) {
+		    		if (!isExplodedLooseWarApp) {
+		    			// The project was previously running with a "non-exploded" loose app.
+		    			// Update this flag and redeploy as an exploded loose app.
+		    			isExplodedLooseWarApp = true;
+		    			
+		    			// Validate maven-war-plugin version
+		    			Plugin warPlugin = getPlugin("org.apache.maven.plugins", "maven-war-plugin");
+		            	if (!validatePluginVersion(warPlugin.getVersion(), "3.3.1")) {
+		            		log.warn("Exploded WAR functionality is enabled. Please use maven-war-plugin version 3.3.1 or greater for best results.");
+		            	}
+		            	
+		    			redeployApp();
+		    		} else {
+		    			try {
+		    				runExplodedMojo();
+		    			} catch (MojoExecutionException e) {
+		    				log.error("Failed to run war:exploded goal", e);
+		    			}
+		    		}
+		    	} else {
+		    		if (isExplodedLooseWarApp) {
+		    			// Dev mode was previously running with an exploded loose war app. The app
+		    			// must have been updated to remove any exploded war capabilities 
+		    			// (filtering, overlay, etc). Update this flag and redeploy.
+		    			isExplodedLooseWarApp = false;
+		    			redeployApp();
+		    		}
+		    	}
+        	}
+        }
+
+        @Override
+        protected void resourceDirectoryCreated() throws IOException {
+            if (project.getPackaging().equals("war") && LooseWarApplication.isExploded(project)) {
+                try {
+                    runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
+                    runExplodedMojo();
+                } catch (MojoExecutionException e) {
+                    log.error("Failed to run goal(s)", e);
+                }
+            } 
+        }
+
+        @Override
+        protected void resourceModifiedOrCreated(File fileChanged, File resourceParent, File outputDirectory) throws IOException {
+        	if (project.getPackaging().equals("war") && LooseWarApplication.isExploded(project)) {
+                try {
+                    runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
+                    runExplodedMojo();
+                } catch (MojoExecutionException e) {
+                    log.error("Failed to run goal(s)", e);
+                }
+            } else {
+                copyFile(fileChanged, resourceParent, outputDirectory, null);
+            }
+        }
+
+        @Override
+        protected void resourceDeleted(File fileChanged, File resourceParent, File outputDirectory) throws IOException {
+            deleteFile(fileChanged, resourceParent, outputDirectory, null);
+            if (project.getPackaging().equals("war") && LooseWarApplication.isExploded(project)) {
+                try {
+                    runExplodedMojo();
+                } catch (MojoExecutionException e) {
+                    log.error("Failed to run goal(s)", e);
+                }
+            } 
+        }
 
         @Override
         public boolean recompileBuildFile(File buildFile, Set<String> compileArtifactPaths,
@@ -760,7 +837,7 @@ public class DevMojo extends LooseAppSupport {
                     } else if (createServer) {
                         runLibertyMojoCreate();
                     } else if (redeployApp) {
-                        runLibertyMojoDeploy();
+                    	runLibertyMojoDeploy();
                     }
                     if (installFeature) {
                         runLibertyMojoInstallFeature(null, super.getContainerName());
@@ -1051,8 +1128,24 @@ public class DevMojo extends LooseAppSupport {
             }
             runLibertyMojoDeploy();
         }
+        
+        if (project.getPackaging().equals("war")) {
+            // Check if we are using the exploded loose app functionality and save for checking later on. 
+            isExplodedLooseWarApp = LooseWarApplication.isExploded(project);
+        
+            // Validate maven-war-plugin version
+            if (isExplodedLooseWarApp) {
+        	    Plugin warPlugin = getPlugin("org.apache.maven.plugins", "maven-war-plugin");
+        	    if (!validatePluginVersion(warPlugin.getVersion(), "3.3.1")) {
+        		    log.warn("Exploded WAR functionality is enabled. Please use maven-war-plugin version 3.3.1 or greater for best results.");
+        	    }
+            }
+        }
+        
         // resource directories
         List<File> resourceDirs = getResourceDirectories(project, outputDirectory);
+        
+        List<Path> webResourceDirs = LooseWarApplication.getFilteredWebSourceDirectories(project);
 
         JavaCompilerOptions compilerOptions = getMavenCompilerOptions(project);
 
@@ -1123,7 +1216,8 @@ public class DevMojo extends LooseAppSupport {
 
         util = new DevMojoUtil(installDirectory, userDirectory, serverDirectory, sourceDirectory, testSourceDirectory,
                 configDirectory, project.getBasedir(), multiModuleProjectDirectory, resourceDirs, compilerOptions,
-                settings.getLocalRepository(), upstreamProjects, upstreamMavenProjects, recompileDeps, pom, parentPoms, compileArtifactPaths, testArtifactPaths);
+                settings.getLocalRepository(), upstreamProjects, upstreamMavenProjects, recompileDeps, pom, parentPoms, 
+                compileArtifactPaths, testArtifactPaths, webResourceDirs);
         util.addShutdownHook(executor);
         util.startServer();
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
@@ -17,6 +17,9 @@ package io.openliberty.tools.maven.utils;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.element;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.executeMojo;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.executionEnvironment;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.goal;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.name;
 
 import java.util.ArrayList;
@@ -137,6 +140,12 @@ public class ExecuteMojoUtil {
 
     // https://maven.apache.org/surefire/maven-surefire-report-plugin/failsafe-report-only-mojo.html
     private static final ArrayList<String> FAILSAFE_REPORT_ONLY_PARAMS = REPORT_ONLY_PARAMS;
+    
+    // https://maven.apache.org/plugins/maven-war-plugin/exploded-mojo.html
+    private static final ArrayList<String> EXPLODED_PARAMS = new ArrayList<>(Arrays.asList(
+            "filteringDeploymentDescriptors", "warSourceDirectory", "webappDirectory", "workDirectory", "filters",
+            "overlays", "webResources"
+            ));
 
     // https://maven.apache.org/plugins/maven-ear-plugin/ear-mojo.html
     private static final ArrayList<String> EAR_PARAMS = new ArrayList<>(
@@ -321,6 +330,9 @@ public class ExecuteMojoUtil {
             break;
         case "maven-surefire-report-plugin:failsafe-report-only":
             goalConfig = stripConfigElements(config, FAILSAFE_REPORT_ONLY_PARAMS);
+            break;
+        case "maven-war-plugin:exploded":
+            goalConfig = stripConfigElements(config, EXPLODED_PARAMS);
             break;
         case "maven-ear-plugin:generate-application-xml":
             goalConfig = stripConfigElements(config, EAR_GENERATE_APPLICATION_XML_PARAMS);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/MavenProjectUtil.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/MavenProjectUtil.java
@@ -61,40 +61,6 @@ public class MavenProjectUtil {
         }
         return null;
     }
-
-    /**
-     * Get directory and targetPath configuration values from the Maven WAR plugin
-     * @param proj the Maven project
-     * @return a Map of source and target directories corresponding to the configuration keys
-     * or null if the war plugin or its webResources or resource elements are not used. 
-     * The map will be empty if the directory element is not used. The value field of the 
-     * map is null when the targetPath element is not used.
-     */
-    public static Map<String,String> getWebResourcesConfiguration(MavenProject proj) {
-        Xpp3Dom dom = proj.getGoalConfiguration("org.apache.maven.plugins", "maven-war-plugin", null, null);
-        if (dom != null) {
-            Xpp3Dom web = dom.getChild("webResources");
-            if (web != null) {
-                Xpp3Dom resources[] = web.getChildren("resource");
-                if (resources != null) {
-                    Map<String, String> result = new HashMap<String, String>();
-                    for (int i = 0; i < resources.length; i++) {
-                        Xpp3Dom dir = resources[i].getChild("directory");
-                        if (dir != null) {
-                            Xpp3Dom target = resources[i].getChild("targetPath");
-                            if (target != null) {
-                                result.put(dir.getValue(), target.getValue());
-                            } else {
-                                result.put(dir.getValue(), null);
-                            }
-                        }
-                    }
-                    return result;
-                }
-            }
-        }
-        return null;
-    }
     
     public static String getAppNameClassifier(MavenProject proj) {
         String pluginName = null;


### PR DESCRIPTION
Signed-off-by: Adam Wisniewski <awisniew@us.ibm.com>

Add support for "exploded" loose war applications. 

This will:

1. Auto-detect if the exploded function is needed (checking if WAR overlays and/or resource filtering is configured)
2. Tailor the loose app xml to use the "filtered" web resources location 
3. Run the war plugin's "exploded" goal on changes
4. Dynamically switch between "exploded" and "non-exploded" (default) mode in dev mode as filtering/overlays are added/removed.