### PR TITLE
Dev mode get loose application configuration file

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>io.openliberty.tools</groupId>
             <artifactId>ci.common</artifactId>
-            <version>1.8.17</version>
+            <version>1.8.18-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.twdata.maven</groupId>

--- a/liberty-maven-plugin/src/it/server-config-props-it/src/test/java/net/wasdev/wlp/test/servlet/it/ServerConfigPropertiesTest.java
+++ b/liberty-maven-plugin/src/it/server-config-props-it/src/test/java/net/wasdev/wlp/test/servlet/it/ServerConfigPropertiesTest.java
@@ -116,11 +116,9 @@ public class ServerConfigPropertiesTest {
             Pattern pattern1 = Pattern.compile(DUPLICATE_APP_MESSAGE);
             Pattern pattern2 = Pattern.compile(APPS_DIR_MESSAGE);
             Pattern pattern3 = Pattern.compile(APP_INSTALLED_MESSAGE);
-            
 
             while (s.hasNextLine()) {
                 String line = s.nextLine();
-                sb.append(line + "\n");
                 if (pattern1.matcher(line).find()) {
                     duplicateMatches.add(line);
                 } else if (pattern2.matcher(line).find()) {
@@ -135,8 +133,6 @@ public class ServerConfigPropertiesTest {
         in.close();
         serverOutput.close();
 
-
-        Assert.assertTrue("Log file: " + sb, sb.indexOf("CWWKM2185I") != -1);
         //Check app name/appsDir resolved correctly during create, deploy, and start
         Assert.assertTrue("Found duplicate application message in console output", duplicateMatches.size() == 0);
         Assert.assertTrue("Did not find appsDirectory message in console output", appDirMatches.size() == 1);

--- a/liberty-maven-plugin/src/it/server-config-props-it/src/test/java/net/wasdev/wlp/test/servlet/it/ServerConfigPropertiesTest.java
+++ b/liberty-maven-plugin/src/it/server-config-props-it/src/test/java/net/wasdev/wlp/test/servlet/it/ServerConfigPropertiesTest.java
@@ -116,9 +116,11 @@ public class ServerConfigPropertiesTest {
             Pattern pattern1 = Pattern.compile(DUPLICATE_APP_MESSAGE);
             Pattern pattern2 = Pattern.compile(APPS_DIR_MESSAGE);
             Pattern pattern3 = Pattern.compile(APP_INSTALLED_MESSAGE);
+            
 
             while (s.hasNextLine()) {
                 String line = s.nextLine();
+                sb.append(line + "\n");
                 if (pattern1.matcher(line).find()) {
                     duplicateMatches.add(line);
                 } else if (pattern2.matcher(line).find()) {
@@ -133,6 +135,8 @@ public class ServerConfigPropertiesTest {
         in.close();
         serverOutput.close();
 
+
+        Assert.assertTrue("Log file: " + sb, sb.indexOf("CWWKM2185I") != -1);
         //Check app name/appsDir resolved correctly during create, deploy, and start
         Assert.assertTrue("Found duplicate application message in console output", duplicateMatches.size() == 0);
         Assert.assertTrue("Did not find appsDirectory message in console output", appDirMatches.size() == 1);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
@@ -343,45 +343,6 @@ public class DeployMojoSupport extends PluginConfigSupport {
         return false;
     }
 
-    // get loose application configuration file name for project artifact
-    protected String getLooseConfigFileName(MavenProject project) {
-        return getPostDeployAppFileName(project) + ".xml";
-    }
-
-    // get loose application file name for project artifact
-    protected String getPostDeployAppFileName(MavenProject project) {
-        return getAppFileName(project, true);
-    }
-    
-    // target ear/war produced by war:war, ear:ear, haven't stripped version yet
-    protected String getPreDeployAppFileName(MavenProject project) {
-        return getAppFileName(project, false);
-    }
-    
-    protected String getAppFileName(MavenProject project, boolean stripVersionIfConfigured) {
-
-        String name = project.getBuild().getFinalName();
-
-        if (stripVersionIfConfigured &&  stripVersion) {
-            name = stripVersionFromName(name, project.getVersion());
-        }
-
-        String classifier = MavenProjectUtil.getAppNameClassifier(project);
-        if (classifier != null) {
-            name += "-" + classifier;
-        } 
-
-        if (project.getPackaging().equals("liberty-assembly")) {
-            name += ".war";
-        } else if (project.getPackaging().equals("ejb")) {
-            name += ".jar";
-        } else {
-            name += "." + project.getPackaging();
-        }
-
-        return name;
-    }
-
     protected void validateAppConfig(String fileName, String artifactId) throws Exception {
         validateAppConfig(fileName, artifactId, false);
     }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
@@ -33,7 +33,7 @@ import org.w3c.dom.Element;
 
 import io.openliberty.tools.ant.ServerTask;
 import io.openliberty.tools.ant.SpringBootUtilTask;
-import io.openliberty.tools.maven.server.PluginConfigSupport;
+import io.openliberty.tools.maven.server.LooseAppSupport;
 import io.openliberty.tools.maven.utils.CommonLogger;
 import io.openliberty.tools.maven.utils.MavenProjectUtil;
 import io.openliberty.tools.common.plugins.config.ApplicationXmlDocument;
@@ -45,7 +45,7 @@ import io.openliberty.tools.common.plugins.util.DevUtil;
 /**
  * Support for installing and deploying applications to a Liberty server.
  */
-public class DeployMojoSupport extends PluginConfigSupport {
+public class DeployMojoSupport extends LooseAppSupport {
 
     private final String PROJECT_ROOT_TARGET_LIBS = "target/libs";
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -75,7 +75,7 @@ import io.openliberty.tools.maven.utils.ExecuteMojoUtil;
  * it helps build full transitive dependency classpath
  */
 @Mojo(name = "dev", requiresDependencyCollection = ResolutionScope.TEST, requiresDependencyResolution = ResolutionScope.TEST)
-public class DevMojo extends PluginConfigSupport {
+public class DevMojo extends LooseAppSupport {
 
     private static final String TEST_RUN_ID_PROPERTY_NAME = "liberty.dev.test.run.id";
     private static final String LIBERTY_HOSTNAME = "liberty.hostname";
@@ -891,7 +891,6 @@ public class DevMojo extends PluginConfigSupport {
 
         @Override
         public File getLooseApplicationFile() {
-            log.warn("loose config file: " + getLooseAppConfigFile(project, container));
             return getLooseAppConfigFile(project, container);
         }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -75,7 +75,7 @@ import io.openliberty.tools.maven.utils.ExecuteMojoUtil;
  * it helps build full transitive dependency classpath
  */
 @Mojo(name = "dev", requiresDependencyCollection = ResolutionScope.TEST, requiresDependencyResolution = ResolutionScope.TEST)
-public class DevMojo extends StartDebugMojoSupport {
+public class DevMojo extends PluginConfigSupport {
 
     private static final String TEST_RUN_ID_PROPERTY_NAME = "liberty.dev.test.run.id";
     private static final String LIBERTY_HOSTNAME = "liberty.hostname";
@@ -887,6 +887,12 @@ public class DevMojo extends StartDebugMojoSupport {
             // dev mode forces deploy with looseApplication=true, but it only takes effect
             // if packaging is one of the supported loose app types
             return DeployMojoSupport.isSupportedLooseAppType(project.getPackaging());
+        }
+
+        @Override
+        public File getLooseApplicationFile() {
+            log.warn("loose config file: " + getLooseAppConfigFile(project, container));
+            return getLooseAppConfigFile(project, container);
         }
 
         @Override

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/LooseAppSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/LooseAppSupport.java
@@ -1,0 +1,91 @@
+/**
+ * (C) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.openliberty.tools.maven.server;
+
+import java.io.File;
+
+import org.apache.maven.project.MavenProject;
+
+import io.openliberty.tools.common.plugins.util.DevUtil;
+import io.openliberty.tools.maven.utils.MavenProjectUtil;
+
+/**
+ * Loose application Liberty server support.
+ */
+public class LooseAppSupport extends PluginConfigSupport {
+
+    // get loose application configuration file name for project artifact
+    public String getLooseConfigFileName(MavenProject project) {
+        return getPostDeployAppFileName(project) + ".xml";
+    }
+
+    // get loose application file name for project artifact
+    protected String getPostDeployAppFileName(MavenProject project) {
+        return getAppFileName(project, true);
+    }
+
+    // target ear/war produced by war:war, ear:ear, haven't stripped version yet
+    protected String getPreDeployAppFileName(MavenProject project) {
+        return getAppFileName(project, false);
+    }
+
+    protected String getAppFileName(MavenProject project, boolean stripVersionIfConfigured) {
+
+        String name = project.getBuild().getFinalName();
+
+        if (stripVersionIfConfigured && stripVersion) { // TODO stripVersion is set to false when called from dev mojo
+            name = stripVersionFromName(name, project.getVersion());
+        }
+
+        String classifier = MavenProjectUtil.getAppNameClassifier(project);
+        if (classifier != null) {
+            name += "-" + classifier;
+        }
+
+        if (project.getPackaging().equals("liberty-assembly")) {
+            name += ".war";
+        } else if (project.getPackaging().equals("ejb")) {
+            name += ".jar";
+        } else {
+            name += "." + project.getPackaging();
+        }
+
+        return name;
+    }
+
+    /**
+     * Gets the loose application configuration xml file
+     * 
+     * @param proj      MavenProject
+     * @param container whether the app is running in a container
+     * @return File the loose application configuration xml file
+     */
+    public File getLooseAppConfigFile(MavenProject proj, boolean container) {
+        String looseConfigFileName = getLooseConfigFileName(proj);
+        if (container) {
+            File devcDestDir = new File(new File(project.getBuild().getDirectory(), DevUtil.DEVC_HIDDEN_FOLDER),
+                    getAppsDirectory());
+            File devcLooseConfigFile = new File(devcDestDir, looseConfigFileName);
+            return devcLooseConfigFile;
+        } else {
+            File destDir = new File(serverDirectory, getAppsDirectory());
+            File looseConfigFile = new File(destDir, looseConfigFileName);
+            return looseConfigFile;
+        }
+    }
+    
+}

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/LooseAppSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/LooseAppSupport.java
@@ -78,11 +78,11 @@ public class LooseAppSupport extends PluginConfigSupport {
         String looseConfigFileName = getLooseConfigFileName(proj);
         if (container) {
             File devcDestDir = new File(new File(project.getBuild().getDirectory(), DevUtil.DEVC_HIDDEN_FOLDER),
-                    getAppsDirectory());
+                    getAppsDirectory(false));
             File devcLooseConfigFile = new File(devcDestDir, looseConfigFileName);
             return devcLooseConfigFile;
         } else {
-            File destDir = new File(serverDirectory, getAppsDirectory());
+            File destDir = new File(serverDirectory, getAppsDirectory(false));
             File looseConfigFile = new File(destDir, looseConfigFileName);
             return looseConfigFile;
         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PluginConfigSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PluginConfigSupport.java
@@ -321,6 +321,10 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
     }
 
     protected String getAppsDirectory() {
+        return getAppsDirectory(true);
+    }
+
+    protected String getAppsDirectory(boolean logDirectory) {
         if (appsDirectory != null && !appsDirectory.isEmpty()) {
             if ("dropins".equals(appsDirectory) || "apps".equals(appsDirectory)) {
                 return appsDirectory;
@@ -337,7 +341,9 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
             // found.
             appsDirectory = "apps";
         }
-        log.info(MessageFormat.format(messages.getString("info.default.app.directory"), appsDirectory));
+        if (logDirectory) {
+            log.info(MessageFormat.format(messages.getString("info.default.app.directory"), appsDirectory));
+        }
         return appsDirectory;
     }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PluginConfigSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PluginConfigSupport.java
@@ -31,10 +31,8 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 
 import io.openliberty.tools.maven.PluginConfigXmlDocument;
 import io.openliberty.tools.maven.utils.CommonLogger;
-import io.openliberty.tools.maven.utils.MavenProjectUtil;
 import io.openliberty.tools.common.plugins.config.ApplicationXmlDocument;
 import io.openliberty.tools.common.plugins.config.ServerConfigDocument;
-import io.openliberty.tools.common.plugins.util.DevUtil;
 
 /**
  * Basic Liberty Mojo Support
@@ -383,66 +381,5 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
             }
         }
         return null;
-    }
-
-    // get loose application configuration file name for project artifact
-    public String getLooseConfigFileName(MavenProject project) {
-        return getPostDeployAppFileName(project) + ".xml";
-    }
-
-    // get loose application file name for project artifact
-    protected String getPostDeployAppFileName(MavenProject project) {
-        return getAppFileName(project, true);
-    }
-
-    // target ear/war produced by war:war, ear:ear, haven't stripped version yet
-    protected String getPreDeployAppFileName(MavenProject project) {
-        return getAppFileName(project, false);
-    }
-
-    protected String getAppFileName(MavenProject project, boolean stripVersionIfConfigured) {
-
-        String name = project.getBuild().getFinalName();
-
-        if (stripVersionIfConfigured && stripVersion) { // TODO stripVersion is set to false when called from dev mojo
-            name = stripVersionFromName(name, project.getVersion());
-        }
-
-        String classifier = MavenProjectUtil.getAppNameClassifier(project);
-        if (classifier != null) {
-            name += "-" + classifier;
-        }
-
-        if (project.getPackaging().equals("liberty-assembly")) {
-            name += ".war";
-        } else if (project.getPackaging().equals("ejb")) {
-            name += ".jar";
-        } else {
-            name += "." + project.getPackaging();
-        }
-
-        return name;
-    }
-
-    /**
-     * Gets the loose application configuration xml file
-     * 
-     * @param proj      MavenProject
-     * @param container whether the app is running in a container
-     * @return the loose application configuration xml file or null if it does not
-     *         exist
-     */
-    public File getLooseAppConfigFile(MavenProject proj, boolean container) {
-        String looseConfigFileName = getLooseConfigFileName(proj);
-        if (container) {
-            File devcDestDir = new File(new File(project.getBuild().getDirectory(), DevUtil.DEVC_HIDDEN_FOLDER),
-                    getAppsDirectory());
-            File devcLooseConfigFile = new File(devcDestDir, looseConfigFileName);
-            return devcLooseConfigFile;
-        } else {
-            File destDir = new File(serverDirectory, getAppsDirectory());
-            File looseConfigFile = new File(destDir, looseConfigFileName);
-            return looseConfigFile;
-        }
     }
 }


### PR DESCRIPTION
Add logic for dev mode to retrieve the loose application configuration file. This change involves `DevMojo` extending `PluginConfigSupport` (which extends `StartDebugMojoSupport`) and moves logic to determine the loose application configuration file from `DeployMojoSupport` to `PluginConfigSupport`.

Fixes #1285 

See https://github.com/OpenLiberty/ci.common/pull/311
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>