### PR TITLE
Remove null check for install-feature

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallFeatureMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallFeatureMojo.java
@@ -85,10 +85,7 @@ public class InstallFeatureMojo extends InstallFeatureSupport {
         }
         else if(util != null) {
             util.installFeatures(features.isAcceptLicense(), new ArrayList<String>(featuresToInstall));
-        }else if(util == null) {
-        	throw new IllegalStateException(MessageFormat.format("Could not install feature", "install-feature"));
         }
-        
        
     }
 


### PR DESCRIPTION
Fixes #1303
Removing the null check for `util` which was recently added to throw an exception (as part of the user feature implementation)

TODO:
-Should investigate further for the case where`util = null`. From the error.log, this happened when trying to resolve the features that are not released yet. Not sure if this should be a passing scenario. 

`Cannot find json for productId io.openliberty, productVersion 21.0.0.12`