### PR TITLE
After writing server.xml ensure <server> element is on a new line.

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -21,8 +21,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -41,6 +39,7 @@ import org.apache.maven.project.MavenProject;
 import org.xml.sax.SAXException;
 
 import io.openliberty.tools.common.plugins.config.ServerConfigXmlDocument;
+import io.openliberty.tools.common.plugins.config.XmlDocument;
 import io.openliberty.tools.common.plugins.util.InstallFeatureUtil;
 import io.openliberty.tools.common.plugins.util.PluginExecutionException;
 import io.openliberty.tools.maven.BasicSupport;
@@ -277,11 +276,7 @@ public class GenerateFeaturesMojo extends InstallFeatureSupport {
         try {
             if (doc.createFMComment(FEATURES_FILE_MESSAGE)) {
                 doc.writeXMLDocument(serverXml);
-                // look for "<?xml version="1.0" ... ?><server .../>" and add a newline
-                byte[] contents = Files.readAllBytes(serverXml.toPath());
-                String xmlContents = new String(contents, StandardCharsets.UTF_8);
-                xmlContents = xmlContents.replace("?><", "?>"+System.getProperty("line.separator")+"<");
-                Files.write(serverXml.toPath(), xmlContents.getBytes());
+                XmlDocument.addNewlineBeforeFirstElement(serverXml);
             }
         } catch (IOException | TransformerException e) {
             log.debug("Exception adding comment to server.xml", e);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -21,6 +21,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -273,9 +275,13 @@ public class GenerateFeaturesMojo extends InstallFeatureSupport {
             return;
         }
         try {
-            if (doc.findFMComment(FEATURES_FILE_MESSAGE) == null) {
-                doc.createFMComment(FEATURES_FILE_MESSAGE);
-                doc.writeXMLDocument(serverXml);    
+            if (doc.createFMComment(FEATURES_FILE_MESSAGE)) {
+                doc.writeXMLDocument(serverXml);
+                // look for "<?xml version="1.0" ... ?><server .../>" and add a newline
+                byte[] contents = Files.readAllBytes(serverXml.toPath());
+                String xmlContents = new String(contents, StandardCharsets.UTF_8);
+                xmlContents = xmlContents.replace("?><", "?>"+System.getProperty("line.separator")+"<");
+                Files.write(serverXml.toPath(), xmlContents.getBytes());
             }
         } catch (IOException | TransformerException e) {
             log.debug("Exception adding comment to server.xml", e);


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/ci.maven/issues/1301

It would be more efficient to fix the file when it is written in the method in ci.common but I think this requirement could be more application specific and should be closer to where the file is used.