### PR TITLE
Get existing features for feature generation from the source config dir

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/BasicSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/BasicSupport.java
@@ -59,6 +59,8 @@ public class BasicSupport extends AbstractLibertySupport {
 
     protected boolean defaultOutputDirSet = false;
 
+    protected boolean skipServerConfigSetup = false;
+
     /**
      * Skips the specific goal
      */
@@ -186,9 +188,12 @@ public class BasicSupport extends AbstractLibertySupport {
     protected void init() throws MojoExecutionException, MojoFailureException {
         if (skip) {
             return;
-        }        
+        }
         super.init();
 
+        if (skipServerConfigSetup) {
+            return;
+        }
         try {
             // First check if installDirectory is set, if it is, then we can skip this
             if (installDirectory != null) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/InstallFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/InstallFeatureSupport.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2020.
+ * (C) Copyright IBM Corporation 2020, 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import io.openliberty.tools.common.plugins.util.InstallFeatureUtil.ProductProper
 import io.openliberty.tools.maven.server.types.Features;
 
 
-public class InstallFeatureSupport extends BasicSupport {
+public class InstallFeatureSupport extends ServerFeatureSupport {
 
     /**
      * Define a set of features to install in the server and the configuration

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/ServerFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/ServerFeatureSupport.java
@@ -23,10 +23,6 @@ public class ServerFeatureSupport extends BasicSupport {
 
     protected class ServerFeatureMojoUtil extends ServerFeatureUtil {
 
-        public ServerFeatureMojoUtil() {
-            super();
-        }
-
         @Override
         public void debug(String msg) {
             log.debug(msg);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/ServerFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/ServerFeatureSupport.java
@@ -1,0 +1,77 @@
+/**
+ * (C) Copyright IBM Corporation 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.tools.maven;
+
+import io.openliberty.tools.common.plugins.util.ServerFeatureUtil;
+
+public class ServerFeatureSupport extends BasicSupport {
+
+    private ServerFeatureUtil servUtil;
+
+    protected class ServerFeatureMojoUtil extends ServerFeatureUtil {
+
+        public ServerFeatureMojoUtil() {
+            super();
+        }
+
+        @Override
+        public void debug(String msg) {
+            log.debug(msg);
+        }
+
+        @Override
+        public void debug(String msg, Throwable e) {
+            log.debug(msg, e);
+        }
+
+        @Override
+        public void debug(Throwable e) {
+            log.debug(e);
+        }
+
+        @Override
+        public void warn(String msg) {
+            log.warn(msg);
+        }
+
+        @Override
+        public void info(String msg) {
+            log.info(msg);
+        }
+
+        @Override
+        public void error(String msg, Throwable e) {
+            log.error(msg, e);
+        }
+    }
+
+    private void createNewServerFeatureUtil() {
+        servUtil = new ServerFeatureMojoUtil();
+    }
+
+    /**
+     * Get a new instance of ServerFeatureUtil
+     * 
+     * @return instance of ServerFeatureUtil
+     */
+    protected ServerFeatureUtil getServerFeatureUtil() {
+        if (servUtil == null) {
+            createNewServerFeatureUtil();
+        }
+        return servUtil;
+    }
+
+}

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -783,6 +783,9 @@ public class DevMojo extends StartDebugMojoSupport {
                     util.restartServer();
                     return true;
                 } else {
+                    if ((createServer || installFeature) && generateFeatures) {
+                        runLibertyMojoGenerateFeatures(null);
+                    }
                     if (isUsingBoost() && (createServer || runBoostPackage)) {
                         log.info("Running boost:package");
                         runBoostMojo("package");
@@ -790,9 +793,6 @@ public class DevMojo extends StartDebugMojoSupport {
                         runLibertyMojoCreate();
                     } else if (redeployApp) {
                         runLibertyMojoDeploy();
-                    }
-                    if ((createServer || installFeature) && generateFeatures) {
-                        runLibertyMojoGenerateFeatures(null);
                     }
                     if (installFeature) {
                         runLibertyMojoInstallFeature(null, super.getContainerName());
@@ -1090,10 +1090,10 @@ public class DevMojo extends StartDebugMojoSupport {
             log.info("Running boost:package");
             runBoostMojo("package");
         } else {
-            runLibertyMojoCreate();
             if (generateFeatures) {
                 runLibertyMojoGenerateFeatures(null);
             }
+            runLibertyMojoCreate();
             // If non-container, install features before starting server. Otherwise, user
             // should have "RUN features.sh" in their Dockerfile if they want features to be
             // installed.

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -285,7 +285,7 @@ public class DevMojo extends StartDebugMojoSupport {
                     keepTempDockerfile, mavenCacheLocation, upstreamProjects, recompileDeps, project.getPackaging(),
                     pom, parentPoms, generateFeatures, compileArtifactPaths, testArtifactPaths);
 
-            ServerFeature servUtil = getServerFeatureUtil();
+            ServerFeatureUtil servUtil = getServerFeatureUtil();
             this.libertyDirPropertyFiles = BasicSupport.getLibertyDirectoryPropertyFiles(installDir, userDir,
                     serverDirectory);
             this.existingFeatures = servUtil.getServerFeatures(serverDirectory, libertyDirPropertyFiles);
@@ -817,7 +817,7 @@ public class DevMojo extends StartDebugMojoSupport {
         @Override
         public void checkConfigFile(File configFile, File serverDir) {
             try {
-                ServerFeature servUtil = getServerFeatureUtil();
+                ServerFeatureUtil servUtil = getServerFeatureUtil();
                 Set<String> features = servUtil.getServerFeatures(serverDir, libertyDirPropertyFiles);
                 if (features != null) {
                     features.removeAll(existingFeatures);
@@ -1591,49 +1591,6 @@ public class DevMojo extends StartDebugMojoSupport {
                 }
             }
         }
-    }
-
-    private static ServerFeature serverFeatureUtil;
-
-    private ServerFeature getServerFeatureUtil() {
-        if (serverFeatureUtil == null) {
-            serverFeatureUtil = new ServerFeature();
-        }
-        return serverFeatureUtil;
-    }
-
-    private class ServerFeature extends ServerFeatureUtil {
-
-        @Override
-        public void debug(String msg) {
-            log.debug(msg);
-        }
-
-        @Override
-        public void debug(String msg, Throwable e) {
-            log.debug(msg, e);
-        }
-
-        @Override
-        public void debug(Throwable e) {
-            log.debug(e);
-        }
-
-        @Override
-        public void warn(String msg) {
-            log.warn(msg);
-        }
-
-        @Override
-        public void info(String msg) {
-            log.info(msg);
-        }
-
-        @Override
-        public void error(String msg, Throwable e) {
-            log.error(msg, e);
-        }
-
     }
 
     /**

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -100,6 +100,18 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
             log.debug("Generate features for all class files");
         }
 
+        // TODO add support for env variables
+        // commented out for now as the current logic depends on the server dir existing
+        // and specifying features with env variables is an edge case
+        /* Map<String, File> libertyDirPropertyFiles;
+        try {
+            libertyDirPropertyFiles = BasicSupport.getLibertyDirectoryPropertyFiles(installDirectory, userDirectory, serverDirectory);
+        } catch (IOException e) {
+            log.debug("Exception reading the server property files", e);
+            log.error("Error attempting to generate server feature list. Ensure your user account has read permission to the property files in the server installation directory.");
+            return;
+        } */
+
         // TODO: get user specified features that have not yet been installed in the
         // original case they appear in a server config xml document.
         // getSpecifiedFeatures may not return the features in the correct case
@@ -116,7 +128,7 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
         // if optimizing, ignore generated files when passing in existing features to
         // binary scanner
         Set<String> existingFeatures = servUtil.getServerFeatures(configDirectory, serverXmlFile,
-                new HashMap<String,File>() , optimize ? generatedFiles : null);
+                new HashMap<String, File>(), optimize ? generatedFiles : null);
         if (existingFeatures == null) {
             existingFeatures = new HashSet<String>();
         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -47,7 +47,6 @@ import java.util.regex.Pattern;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 
-import org.apache.maven.Maven;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.ProjectDependencyGraph;
@@ -67,13 +66,13 @@ import org.twdata.maven.mojoexecutor.MojoExecutor.Element;
 
 import io.openliberty.tools.ant.ServerTask;
 import io.openliberty.tools.common.plugins.config.ServerConfigXmlDocument;
-import io.openliberty.tools.maven.BasicSupport;
+import io.openliberty.tools.maven.ServerFeatureSupport;
 import io.openliberty.tools.maven.utils.ExecuteMojoUtil;
 
 /**
  * Start/Debug server support.
  */
-public class StartDebugMojoSupport extends BasicSupport {
+public class StartDebugMojoSupport extends ServerFeatureSupport {
 
     private static final String LIBERTY_MAVEN_PLUGIN_GROUP_ID = "io.openliberty.tools";
     private static final String LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID = "liberty-maven-plugin";


### PR DESCRIPTION
Fixes #1306 

Have generate features get existing user specified features from the source directory rather than the target directory.

On startup/restart dev mode now calls:
- compile
- generate features
- liberty create
- install features


Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>