### PR TITLE
Disable feature generation if the binary scanner jar cannot be resolved

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -59,6 +59,8 @@ import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingResult;
 import org.apache.maven.rtinfo.RuntimeInformation;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.resolution.VersionResolutionException;
 import org.twdata.maven.mojoexecutor.MojoExecutor.Element;
 
 import io.openliberty.tools.ant.ServerTask;
@@ -380,10 +382,16 @@ public class DevMojo extends LooseAppSupport {
                 }
                 return true; // successfully generated features
             } catch (MojoExecutionException e) {
-                // log as error instead of throwing an exception so we do not flood console with
+                // log errors instead of throwing an exception so we do not flood console with
                 // stacktrace
-                log.error(e.getMessage()
-                        + ".\n To disable the automatic generation of features, type 'g' and press Enter.");
+                if (e.getCause() != null && e.getCause() instanceof PluginExecutionException) {
+                    // PluginExecutionException indicates that the binary scanner jar could not be found
+                    log.error(e.getMessage() + ".\nDisabling the automatic generation of features.");
+                    setFeatureGeneration(false);
+                } else {
+                    log.error(e.getMessage()
+                    + ".\nTo disable the automatic generation of features, type 'g' and press Enter.");
+                }
                 return false;
             }
         }
@@ -1164,9 +1172,15 @@ public class DevMojo extends LooseAppSupport {
                 try {
                     runLibertyMojoGenerateFeatures(null, true);
                 } catch (MojoExecutionException e) {
-                    throw new MojoExecutionException(e.getMessage()
-                            + ". To disable the automatic generation of features, start dev mode with -DgenerateFeatures=false.",
-                            e);
+                    if (e.getCause() != null && e.getCause() instanceof PluginExecutionException) {
+                        // PluginExecutionException indicates that the binary scanner jar could not be found
+                        log.error(e.getMessage() + ".\nDisabling the automatic generation of features.");
+                        generateFeatures = false;
+                    } else {
+                        throw new MojoExecutionException(e.getMessage()
+                        + ". To disable the automatic generation of features, start dev mode with -DgenerateFeatures=false.",
+                        e);
+                    }
                 }
             }
             runLibertyMojoCreate();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -59,8 +59,6 @@ import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingResult;
 import org.apache.maven.rtinfo.RuntimeInformation;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
-import org.eclipse.aether.resolution.VersionRangeResolutionException;
-import org.eclipse.aether.resolution.VersionResolutionException;
 import org.twdata.maven.mojoexecutor.MojoExecutor.Element;
 
 import io.openliberty.tools.ant.ServerTask;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -21,7 +21,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -34,7 +33,6 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.eclipse.aether.resolution.VersionRangeResolutionException;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
@@ -64,7 +62,7 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
     protected static final String NO_NEW_FEATURES_COMMENT = "No additional features generated";
 
     private static final String BINARY_SCANNER_MAVEN_GROUP_ID = "com.ibm.websphere.appmod.tools";
-    private static final String BINARY_SCANNER_MAVEN_ARTIFACT_ID = "binary-app-scanner-test";
+    private static final String BINARY_SCANNER_MAVEN_ARTIFACT_ID = "binary-app-scanner";
     private static final String BINARY_SCANNER_MAVEN_TYPE = "jar";
     private static final String BINARY_SCANNER_MAVEN_VERSION = "[21.0.0.4-SNAPSHOT,)";
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -34,6 +34,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
@@ -63,7 +64,7 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
     protected static final String NO_NEW_FEATURES_COMMENT = "No additional features generated";
 
     private static final String BINARY_SCANNER_MAVEN_GROUP_ID = "com.ibm.websphere.appmod.tools";
-    private static final String BINARY_SCANNER_MAVEN_ARTIFACT_ID = "binary-app-scanner";
+    private static final String BINARY_SCANNER_MAVEN_ARTIFACT_ID = "binary-app-scanner-test";
     private static final String BINARY_SCANNER_MAVEN_TYPE = "jar";
     private static final String BINARY_SCANNER_MAVEN_VERSION = "[21.0.0.4-SNAPSHOT,)";
 
@@ -101,7 +102,15 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
         super.init();
     }
 
-    private void generateFeatures() throws PluginExecutionException, MojoExecutionException {
+    /**
+     * Generates features for the application given the API usage detected and
+     * taking any user specified features into account
+     * 
+     * @throws MojoExecutionException
+     * @throws PluginExecutionException indicates the binary-app-scanner.jar could
+     *                                  not be found
+     */
+    private void generateFeatures() throws MojoExecutionException, PluginExecutionException {
         binaryScanner = getBinaryScannerJarFromRepository();
         BinaryScannerHandler binaryScannerHandler = new BinaryScannerHandler(binaryScanner);
 
@@ -243,7 +252,12 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
         try {
             return getArtifact(BINARY_SCANNER_MAVEN_GROUP_ID, BINARY_SCANNER_MAVEN_ARTIFACT_ID, BINARY_SCANNER_MAVEN_TYPE, BINARY_SCANNER_MAVEN_VERSION).getFile();
         } catch (Exception e) {
-            throw new PluginExecutionException("Could not retrieve the binary scanner jar. Ensure you have a connection to Maven Central or another repository that contains the jar configured in your pom.xml", e);
+            throw new PluginExecutionException("Could not retrieve the artifact " + BINARY_SCANNER_MAVEN_GROUP_ID + "."
+                    + BINARY_SCANNER_MAVEN_ARTIFACT_ID
+                    + " needed for liberty:generate-features. Ensure you have a connection to Maven Central or another repository that contains the "
+                    + BINARY_SCANNER_MAVEN_GROUP_ID + "." + BINARY_SCANNER_MAVEN_ARTIFACT_ID
+                    + ".jar configured in your pom.xml",
+                    e);
         }
     }
 


### PR DESCRIPTION
Fixes #1291 

Do not fail dev mode if the binary-app-scanner.jar cannot be found in MavenCentral or the repositories specified in the pom.xml

Error message displayed if the binary-app-scanner.jar cannot be found on startup of dev mode:
```
[INFO] Running liberty:generate-features
[ERROR] Could not retrieve the artifact com.ibm.websphere.appmod.tools.binary-app-scanner-test needed for 
liberty:generate-features. Ensure you have a connection to Maven Central or another repository that contains 
the com.ibm.websphere.appmod.tools.binary-app-scanner-test.jar configured in your pom.xml.
Disabling the automatic generation of features.
[INFO] Running liberty:create
```

Error message displayed if the binary-app-scanner.jar cannot be found during the inner loop of dev mode:
```
[INFO] Running liberty:generate-features
[ERROR] Could not retrieve the artifact com.ibm.websphere.appmod.tools.binary-app-scanner-test needed for 
liberty:generate-features. Ensure you have a connection to Maven Central or another repository that contains 
the com.ibm.websphere.appmod.tools.binary-app-scanner-test.jar configured in your pom.xml.
Disabling the automatic generation of features.
[INFO] Setting automatic generation of features to: [ Off ]
```