### PR TITLE
Common multi module logic to determine which module contains Lib server dir…

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/ServerFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/ServerFeatureSupport.java
@@ -15,6 +15,17 @@
  */
 package io.openliberty.tools.maven;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.execution.ProjectDependencyGraph;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+
 import io.openliberty.tools.common.plugins.util.ServerFeatureUtil;
 
 public class ServerFeatureSupport extends BasicSupport {
@@ -68,6 +79,129 @@ public class ServerFeatureSupport extends BasicSupport {
             createNewServerFeatureUtil();
         }
         return servUtil;
+    }
+
+    /**
+     * Check the Reactor build order for multi module conflicts. Multi module logic
+     * is utilized by DevMojo, RunMojo and GenerateFeaturesMojo.
+     * 
+     * A conflict is multiple modules that do not have downstream modules depending
+     * on them, and are not submodules of each other.
+     * For example, if the Reactor tree looks like:
+     * - ear
+     * - war
+     * - jar
+     * - jar2
+     * - pom (top level multi module pom.xml containing ear, war, jar, jar2 as
+     * modules)
+     * Then ear and jar2 conflict with each other, but pom does not conflict because
+     * ear and jar2 are sub-modules of it.
+     * 
+     * @param graph The project dependency graph
+     * 
+     * @throws MojoExecutionException If there are multiple modules that conflict
+     */
+    protected void checkMultiModuleConflicts(ProjectDependencyGraph graph) throws MojoExecutionException {
+        List<MavenProject> sortedReactorProjects = graph.getSortedProjects();
+        Set<MavenProject> conflicts = new LinkedHashSet<MavenProject>(); // keeps the order of items added in
+
+        // a leaf here is a module without any downstream modules depending on it
+        List<MavenProject> leaves = new ArrayList<MavenProject>();
+        for (MavenProject reactorProject : sortedReactorProjects) {
+            if (graph.getDownstreamProjects(reactorProject, true).isEmpty()) {
+                leaves.add(reactorProject);
+            }
+        }
+
+        for (MavenProject leaf1 : leaves) {
+            for (MavenProject leaf2 : leaves) {
+                if (leaf1 != leaf2 && !(isSubModule(leaf2, leaf1) || isSubModule(leaf1, leaf2))) {
+                    conflicts.add(leaf1);
+                    conflicts.add(leaf2);
+                }
+            }
+        }
+
+        List<String> conflictModuleRelativeDirs = new ArrayList<String>();
+        for (MavenProject conflict : conflicts) {
+            // make the module path relative to the multi module project directory
+            conflictModuleRelativeDirs.add(getModuleRelativePath(conflict));
+        }
+
+        boolean hasMultipleLibertyModules = !conflicts.isEmpty();
+
+        if (hasMultipleLibertyModules) {
+            throw new MojoExecutionException("Found multiple independent modules in the Reactor build order: "
+                    + conflictModuleRelativeDirs
+                    + ". Specify the module containing the Liberty configuration that you want to use for the server by including the following parameters in the Maven command: -pl <module-with-liberty-config> -am");
+        }
+    }
+
+    /**
+     * Returns whether potentialTopModule is a multi module project that has
+     * potentialSubModule as one of its sub-modules.
+     */
+    private static boolean isSubModule(MavenProject potentialTopModule, MavenProject potentialSubModule) {
+        List<String> multiModules = potentialTopModule.getModules();
+        if (multiModules != null) {
+            for (String module : multiModules) {
+                File subModuleDir = new File(potentialTopModule.getBasedir(), module);
+                try {
+                    if (subModuleDir.getCanonicalFile().equals(potentialSubModule.getBasedir().getCanonicalFile())) {
+                        return true;
+                    }
+                } catch (IOException e) {
+                    if (subModuleDir.getAbsoluteFile().equals(potentialSubModule.getBasedir().getAbsoluteFile())) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * If there was a previous module without downstream projects, assume Liberty
+     * already ran. Then if THIS module is a top-level multi module pom that
+     * includes that other module, skip THIS module.
+     * 
+     * @param graph The project dependency graph containing Reactor build order
+     * @return Whether this module should be skipped
+     */
+    protected boolean containsPreviousLibertyModule(ProjectDependencyGraph graph) {
+        List<MavenProject> sortedReactorProjects = graph.getSortedProjects();
+        MavenProject mostDownstreamModule = null;
+        for (MavenProject reactorProject : sortedReactorProjects) {
+            // Stop if reached the current module in Reactor build order
+            if (reactorProject.equals(project)) {
+                break;
+            }
+            if (graph.getDownstreamProjects(reactorProject, true).isEmpty()) {
+                mostDownstreamModule = reactorProject;
+                break;
+            }
+        }
+        if (mostDownstreamModule != null && !mostDownstreamModule.equals(project)) {
+            log.debug("Found a previous module in the Reactor build order that does not have downstream dependencies: "
+                    + mostDownstreamModule);
+            if (isSubModule(project, mostDownstreamModule)) {
+                log.debug(
+                        "Detected that this multi module pom contains another module that does not have downstream dependencies. Skipping goal on this module.");
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Gets the module's relative path (i.e. the module name) relative to the multi
+     * module project directory.
+     * 
+     * @param module The module for which you want to get the path
+     * @return The module path relative to the multi module project directory
+     */
+    protected String getModuleRelativePath(MavenProject module) {
+        return multiModuleProjectDirectory.toPath().relativize(module.getBasedir().toPath()).toString();
     }
 
 }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -912,67 +912,6 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
         return configFilesCopied;
     }
 
-    /*-
-     * Check the Reactor build order for multi module conflicts.
-     * 
-     * A conflict is multiple modules that do not have downstream modules depending on them, and are not submodules of each other.
-     * For example, if the Reactor tree looks like:
-     *   - ear
-     *     - war
-     *        - jar
-     *   - jar2
-     *   - pom (top level multi module pom.xml containing ear, war, jar, jar2 as modules)
-     * Then ear and jar2 conflict with each other, but pom does not conflict because ear and jar2 are sub-modules of it.
-     * 
-     * @param graph The project dependency graph
-     * @throws MojoExecutionException If there are multiple modules that conflict
-     */
-    protected void checkMultiModuleConflicts(ProjectDependencyGraph graph) throws MojoExecutionException {
-        List<MavenProject> sortedReactorProjects = graph.getSortedProjects();
-        Set<MavenProject> conflicts = new LinkedHashSet<MavenProject>(); // keeps the order of items added in
-
-        // a leaf here is a module without any downstream modules depending on it
-        List<MavenProject> leaves = new ArrayList<MavenProject>();
-        for (MavenProject reactorProject : sortedReactorProjects) {
-            if (graph.getDownstreamProjects(reactorProject, true).isEmpty()) {
-                leaves.add(reactorProject);
-            }
-        }
-
-        for (MavenProject leaf1 : leaves) {
-            for (MavenProject leaf2 : leaves) {
-                if (leaf1 != leaf2 && !(isSubModule(leaf2, leaf1) || isSubModule(leaf1, leaf2))) {
-                    conflicts.add(leaf1);
-                    conflicts.add(leaf2);
-                }
-            }
-        }
-
-        List<String> conflictModuleRelativeDirs = new ArrayList<String>();
-        for (MavenProject conflict : conflicts) {
-            // make the module path relative to the multi module project directory
-            conflictModuleRelativeDirs.add(getModuleRelativePath(conflict));
-        }
-
-        boolean hasMultipleLibertyModules = !conflicts.isEmpty();
-
-        if (hasMultipleLibertyModules) {
-            throw new MojoExecutionException("Found multiple independent modules in the Reactor build order: "
-                    + conflictModuleRelativeDirs
-                    + ". Specify the module containing the Liberty configuration that you want to use for the server by including the following parameters in the Maven command: -pl <module-with-liberty-config> -am");
-        }
-    }
-
-    /**
-     * Gets the module's relative path (i.e. the module name) relative to the multi module project directory.
-     * 
-     * @param module The module for which you want to get the path
-     * @return The module path relative to the multi module project directory
-     */
-    private String getModuleRelativePath(MavenProject module) {
-        return multiModuleProjectDirectory.toPath().relativize(module.getBasedir().toPath()).toString();
-    }
-
     /**
      * If the ear artifact is not in .m2, install an empty ear as a workaround so that downstream modules can build.
      * Only needed if using loose application.
@@ -1041,59 +980,5 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
         log.info("Running maven-dependency-plugin:" + goal);
         log.debug("configuration:\n" + config);
         executeMojo(plugin, goal(goal), config, executionEnvironment(project, session, pluginManager));
-    }
-
-    /**
-     * Returns whether potentialTopModule is a multi module project that has potentialSubModule as one of its sub-modules.
-     */
-    private static boolean isSubModule(MavenProject potentialTopModule, MavenProject potentialSubModule) {
-        List<String> multiModules = potentialTopModule.getModules();
-        if (multiModules != null) {
-            for (String module : multiModules) {
-                File subModuleDir = new File(potentialTopModule.getBasedir(), module);
-                try {
-                    if (subModuleDir.getCanonicalFile().equals(potentialSubModule.getBasedir().getCanonicalFile())) {
-                        return true;
-                    }    
-                } catch (IOException e) {
-                    if (subModuleDir.getAbsoluteFile().equals(potentialSubModule.getBasedir().getAbsoluteFile())) {
-                        return true;
-                    }   
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * If there was a previous module without downstream projects, assume Liberty
-     * already ran. Then if THIS module is a top-level multi module pom that
-     * includes that other module, skip THIS module.
-     * 
-     * @param graph The project dependency graph containing Reactor build order
-     * @return Whether this module should be skipped
-     */
-    protected boolean containsPreviousLibertyModule(ProjectDependencyGraph graph) {
-        List<MavenProject> sortedReactorProjects = graph.getSortedProjects();
-        MavenProject mostDownstreamModule = null;
-        for (MavenProject reactorProject : sortedReactorProjects) {
-            // Stop if reached the current module in Reactor build order
-            if (reactorProject.equals(project)) {
-                break;
-            }
-            if (graph.getDownstreamProjects(reactorProject, true).isEmpty()) {
-                mostDownstreamModule = reactorProject;
-                break;
-            }
-        }
-        if (mostDownstreamModule != null && !mostDownstreamModule.equals(project)) {
-            log.debug("Found a previous module in the Reactor build order that does not have downstream dependencies: " + mostDownstreamModule);
-            if (isSubModule(project, mostDownstreamModule)) {
-                log.debug(
-                        "Detected that this multi module pom contains another module that does not have downstream dependencies. Skipping goal on this module.");
-                return true;
-            }
-        }
-        return false;
     }
 }


### PR DESCRIPTION
`liberty:generate-features` was failing when running as a standalone goal on multi module Maven projects as it was running the goal on every module. Instead, we want to mimic the behaviour used by dev mode and `liberty:run` where the goal only runs on the module containing the Liberty configuration.

When `generate-features` runs on the module containing the Liberty configuration directory, it will get the classes directories of any downstream modules.