### PR TITLE
Move binary scanner maven artifact constants to ci.common

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -60,11 +60,6 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
     protected static final String GENERATED_FEATURES_COMMENT = "The following features were generated based on API usage detected in your application";
     protected static final String NO_NEW_FEATURES_COMMENT = "No additional features generated";
 
-    private static final String BINARY_SCANNER_MAVEN_GROUP_ID = "com.ibm.websphere.appmod.tools";
-    private static final String BINARY_SCANNER_MAVEN_ARTIFACT_ID = "binary-app-scanner";
-    private static final String BINARY_SCANNER_MAVEN_TYPE = "jar";
-    private static final String BINARY_SCANNER_MAVEN_VERSION = "[21.0.0.4-SNAPSHOT,)";
-
     private File binaryScanner;
 
     @Parameter(property = "classFiles")


### PR DESCRIPTION
See https://github.com/OpenLiberty/ci.common/pull/343

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>