### PR TITLE
Return correct EE and MP version from all project modules

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
@@ -29,8 +29,6 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import io.openliberty.tools.maven.server.GenerateFeaturesMojo;
-
 public class DevTest extends BaseDevTest {
 
    @BeforeClass
@@ -267,28 +265,6 @@ public class DevTest extends BaseDevTest {
       writer.write("o\n");
       writer.flush();
       assertTrue(verifyLogMessageExists("batch-1.0", 10000, newFeatureFile, 0)); // exist 0 times
-   }
-
-   @Test
-   public void mpVersionTest() throws Exception {
-      assertEquals(GenerateFeaturesMojo.getMPVersion("mpHealth-2.0"), 3);
-      assertEquals(GenerateFeaturesMojo.getMPVersion("mpconfig-1.0"), 1);
-      assertEquals(GenerateFeaturesMojo.getMPVersion("mpconfig-1.3"), 2);
-      assertEquals(GenerateFeaturesMojo.getMPVersion("mpconfig-1.4"), 3);
-      assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.0"), 1);
-      assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.1"), 1);
-      assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.2"), 2);
-      assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.3"), 3);
-      assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.4"), 3);
-      assertEquals(GenerateFeaturesMojo.getMPVersion("mpjwt-1.0"), 1);
-      assertEquals(GenerateFeaturesMojo.getMPVersion("mpjwt-1.1"), 3);
-      assertEquals(GenerateFeaturesMojo.getMPVersion("mpjwt-1.2"), 4);
-      // Error testing
-      assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclientX-1.5"), 0);
-      assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient1.5"), 0);
-      assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.5a"), 0);
-      assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-10"), 0);
-      assertEquals(GenerateFeaturesMojo.getMPVersion("Xmprestclient-1.0"), 0);
    }
 
 }

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/ear/pom.xml
@@ -30,6 +30,13 @@
             <version>1.0-SNAPSHOT</version>
             <type>war</type>
         </dependency>
+        <!-- Should be ignored as war module has EE8 dep, latest version found across multiple modules is used -->
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>7.0</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- For tests -->
         <dependency>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/war/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/war/pom.xml
@@ -35,10 +35,17 @@
             <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
+        <!-- Should be ignored as EE8 dep appears first, Maven "nearest in dependency tree" strategy -->
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>7.0</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>3.3</version>
+            <version>4.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/GenerateFeaturesTest.java
+++ b/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/GenerateFeaturesTest.java
@@ -233,4 +233,25 @@ public class GenerateFeaturesTest extends BaseGenerateFeaturesTest {
         return str.toString();
     }
 
+    @Test
+    public void mpVersionTest() throws Exception {
+       assertEquals(GenerateFeaturesMojo.getMPVersion("mpHealth-2.0"), 3);
+       assertEquals(GenerateFeaturesMojo.getMPVersion("mpconfig-1.0"), 1);
+       assertEquals(GenerateFeaturesMojo.getMPVersion("mpconfig-1.3"), 2);
+       assertEquals(GenerateFeaturesMojo.getMPVersion("mpconfig-1.4"), 3);
+       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.0"), 1);
+       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.1"), 1);
+       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.2"), 2);
+       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.3"), 3);
+       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.4"), 3);
+       assertEquals(GenerateFeaturesMojo.getMPVersion("mpjwt-1.0"), 1);
+       assertEquals(GenerateFeaturesMojo.getMPVersion("mpjwt-1.1"), 3);
+       assertEquals(GenerateFeaturesMojo.getMPVersion("mpjwt-1.2"), 4);
+       // Error testing
+       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclientX-1.5"), 0);
+       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient1.5"), 0);
+       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.5a"), 0);
+       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-10"), 0);
+       assertEquals(GenerateFeaturesMojo.getMPVersion("Xmprestclient-1.0"), 0);
+    }
 }

--- a/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleGenerateFeaturesTest.java
+++ b/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleGenerateFeaturesTest.java
@@ -71,7 +71,7 @@ public class MultiModuleGenerateFeaturesTest extends GenerateFeaturesTest {
     }
 
     @Override
-    @Ignore // TODO re-enable this test once https://github.com/OpenLiberty/ci.maven/issues/1429 is resolved
+    @Ignore // TODO re-enable this test oncehttps://github.com/OpenLiberty/ci.maven/issues/1356 is resolved
     @Test
     public void userAndGeneratedConflictTest() throws Exception {
     }

--- a/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleGenerateFeaturesTest.java
+++ b/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleGenerateFeaturesTest.java
@@ -71,7 +71,7 @@ public class MultiModuleGenerateFeaturesTest extends GenerateFeaturesTest {
     }
 
     @Override
-    @Ignore // TODO re-enable this test oncehttps://github.com/OpenLiberty/ci.maven/issues/1356 is resolved
+    @Ignore // TODO re-enable this test once https://github.com/OpenLiberty/ci.maven/issues/1356 is resolved
     @Test
     public void userAndGeneratedConflictTest() throws Exception {
     }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -427,7 +427,6 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
             // if multiple EE versions are found across multiple modules, return the latest
             // version
             for (String ver : eeVersionsDetected) {
-                log.warn(ver);
                 if (Integer.parseInt(ver.substring(ver.lastIndexOf("ee") + 2)) > Integer
                         .parseInt(eeVersion.substring(eeVersion.lastIndexOf("ee") + 2))) {
                     eeVersion = ver;
@@ -496,7 +495,6 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
             // if multiple MP versions are found across multiple modules, return the latest
             // version
             for (String ver : mpVersionsDetected) {
-                log.warn(ver);
                 if (Integer.parseInt(ver.substring(ver.lastIndexOf("mp") + 2)) > Integer
                         .parseInt(mpVersion.substring(mpVersion.lastIndexOf("mp") + 2))) {
                     mpVersion = ver;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -409,34 +409,36 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
     /**
      * Returns the EE major version detected for the given MavenProjects
      * 
-     * @param mavenProjects project modules, null if a single module project
+     * @param mavenProjects project modules, for single module projects list of size 1
      * @return the latest version of EE detected across multiple project modules,
      *         null if an EE version is not found
      */
     public String getEEVersion(List<MavenProject> mavenProjects) {
         String eeVersion = null;
-        Set<String> eeVersionsDetected = new HashSet<String>();
-        for (MavenProject mavenProject : mavenProjects) {
-            String ver = getEEVersion(mavenProject);
-            if (ver != null) {
-                eeVersionsDetected.add(ver);
-            }
-        }
-        if (!eeVersionsDetected.isEmpty()) {
-            eeVersion = eeVersionsDetected.iterator().next();
-            // if multiple EE versions are found across multiple modules, return the latest
-            // version
-            for (String ver : eeVersionsDetected) {
-                if (Integer.parseInt(ver.substring(ver.lastIndexOf("ee") + 2)) > Integer
-                        .parseInt(eeVersion.substring(eeVersion.lastIndexOf("ee") + 2))) {
-                    eeVersion = ver;
+        if (mavenProjects != null) {
+            Set<String> eeVersionsDetected = new HashSet<String>();
+            for (MavenProject mavenProject : mavenProjects) {
+                String ver = getEEVersion(mavenProject);
+                if (ver != null) {
+                    eeVersionsDetected.add(ver);
                 }
             }
-        }
-        if (eeVersionsDetected.size() > 1) {
-            log.debug(
-                    "Multiple Java and/or Jakarta EE versions found across multiple project modules, using the latest version ("
-                            + eeVersion + ") found to generate Liberty features.");
+            if (!eeVersionsDetected.isEmpty()) {
+                eeVersion = eeVersionsDetected.iterator().next();
+                // if multiple EE versions are found across multiple modules, return the latest
+                // version
+                for (String ver : eeVersionsDetected) {
+                    if (Integer.parseInt(ver.substring(ver.lastIndexOf("ee") + 2)) > Integer
+                            .parseInt(eeVersion.substring(eeVersion.lastIndexOf("ee") + 2))) {
+                        eeVersion = ver;
+                    }
+                }
+            }
+            if (eeVersionsDetected.size() > 1) {
+                log.debug(
+                        "Multiple Java and/or Jakarta EE versions found across multiple project modules, using the latest version ("
+                                + eeVersion + ") found to generate Liberty features.");
+            }
         }
         return eeVersion;
     }
@@ -451,24 +453,26 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
      *         an EE umbrella dependency is not found
      */
     private String getEEVersion(MavenProject project) {
-        List<Dependency> dependencies = project.getDependencies();
-        for (Dependency d : dependencies) {
-            if (!d.getScope().equals("provided")) {
-                continue;
-            }
-            log.debug("getEEVersion, dep=" + d.getGroupId() + ":" + d.getArtifactId() + ":" + d.getVersion());
-            if (d.getGroupId().equals("javax") && d.getArtifactId().equals("javaee-api")) {
-                if (d.getVersion().startsWith("8.")) {
-                    return BINARY_SCANNER_EEV8;
-                } else if (d.getVersion().startsWith("7.")) {
-                    return BINARY_SCANNER_EEV7;
-                } else if (d.getVersion().startsWith("6.")) {
-                    return BINARY_SCANNER_EEV6;
+        if (project != null) {
+            List<Dependency> dependencies = project.getDependencies();
+            for (Dependency d : dependencies) {
+                if (!d.getScope().equals("provided")) {
+                    continue;
                 }
-            } else if (d.getGroupId().equals("jakarta.platform") &&
-                    d.getArtifactId().equals("jakarta.jakartaee-api") &&
-                    d.getVersion().startsWith("8.")) {
-                return BINARY_SCANNER_EEV8;
+                log.debug("getEEVersion, dep=" + d.getGroupId() + ":" + d.getArtifactId() + ":" + d.getVersion());
+                if (d.getGroupId().equals("javax") && d.getArtifactId().equals("javaee-api")) {
+                    if (d.getVersion().startsWith("8.")) {
+                        return BINARY_SCANNER_EEV8;
+                    } else if (d.getVersion().startsWith("7.")) {
+                        return BINARY_SCANNER_EEV7;
+                    } else if (d.getVersion().startsWith("6.")) {
+                        return BINARY_SCANNER_EEV6;
+                    }
+                } else if (d.getGroupId().equals("jakarta.platform") &&
+                        d.getArtifactId().equals("jakarta.jakartaee-api") &&
+                        d.getVersion().startsWith("8.")) {
+                    return BINARY_SCANNER_EEV8;
+                }
             }
         }
         return null;
@@ -477,34 +481,36 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
     /**
      * Returns the MicroProfile major version detected for the given MavenProjects
      * 
-     * @param mavenProjects project modules, null if a single module project
+     * @param mavenProjects project modules, for single module projects list of size 1
      * @return the latest version of MP detected across multiple project modules,
      *         null if an MP version is not found
      */
     public String getMPVersion(List<MavenProject> mavenProjects) {
         String mpVersion = null;
-        Set<String> mpVersionsDetected = new HashSet<String>();
-        for (MavenProject mavenProject : mavenProjects) {
-            String ver = getMPVersion(mavenProject);
-            if (ver != null) {
-                mpVersionsDetected.add(ver);
-            }
-        }
-        if (!mpVersionsDetected.isEmpty()) {
-            mpVersion = mpVersionsDetected.iterator().next();
-            // if multiple MP versions are found across multiple modules, return the latest
-            // version
-            for (String ver : mpVersionsDetected) {
-                if (Integer.parseInt(ver.substring(ver.lastIndexOf("mp") + 2)) > Integer
-                        .parseInt(mpVersion.substring(mpVersion.lastIndexOf("mp") + 2))) {
-                    mpVersion = ver;
+        if (mavenProjects != null) {
+            Set<String> mpVersionsDetected = new HashSet<String>();
+            for (MavenProject mavenProject : mavenProjects) {
+                String ver = getMPVersion(mavenProject);
+                if (ver != null) {
+                    mpVersionsDetected.add(ver);
                 }
             }
-        }
-        if (mpVersionsDetected.size() > 1) {
-            log.debug(
-                    "Multiple MicroProfile versions found across multiple project modules, using the latest version ("
-                            + mpVersion + ") found to generate Liberty features.");
+            if (!mpVersionsDetected.isEmpty()) {
+                mpVersion = mpVersionsDetected.iterator().next();
+                // if multiple MP versions are found across multiple modules, return the latest
+                // version
+                for (String ver : mpVersionsDetected) {
+                    if (Integer.parseInt(ver.substring(ver.lastIndexOf("mp") + 2)) > Integer
+                            .parseInt(mpVersion.substring(mpVersion.lastIndexOf("mp") + 2))) {
+                        mpVersion = ver;
+                    }
+                }
+            }
+            if (mpVersionsDetected.size() > 1) {
+                log.debug(
+                        "Multiple MicroProfile versions found across multiple project modules, using the latest version ("
+                                + mpVersion + ") found to generate Liberty features.");
+            }
         }
         return mpVersion;
     }
@@ -518,29 +524,32 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
      * @return MP major version corresponding to the MP umbrella dependency, null if
      *         an MP umbrella dependency is not found
      */
-    public String getMPVersion(MavenProject project) {  // figure out correct level of mp from declared dependencies
-        List<Dependency> dependencies = project.getDependencies();
-        for (Dependency d : dependencies) {
-            if (!d.getScope().equals("provided")) {
-                continue;
-            }
-            if (d.getGroupId().equals("org.eclipse.microprofile") &&
-                d.getArtifactId().equals("microprofile")) {
-                String version = d.getVersion();
-                log.debug("dep=org.eclipse.microprofile:microprofile version="+version);
-                if (version.startsWith("1")) {
-                    return BINARY_SCANNER_MPV1;
-                } else if (version.startsWith("2")) {
-                    return BINARY_SCANNER_MPV2;
-                } else if (version.startsWith("3")) {
-                    return BINARY_SCANNER_MPV3;
+    public String getMPVersion(MavenProject project) { // figure out correct level of MP from declared dependencies
+        if (project != null) {
+            List<Dependency> dependencies = project.getDependencies();
+            for (Dependency d : dependencies) {
+                if (!d.getScope().equals("provided")) {
+                    continue;
                 }
-                return BINARY_SCANNER_MPV4; // add support for future versions of MicroProfile here
+                if (d.getGroupId().equals("org.eclipse.microprofile") &&
+                        d.getArtifactId().equals("microprofile")) {
+                    String version = d.getVersion();
+                    log.debug("dep=org.eclipse.microprofile:microprofile version=" + version);
+                    if (version.startsWith("1")) {
+                        return BINARY_SCANNER_MPV1;
+                    } else if (version.startsWith("2")) {
+                        return BINARY_SCANNER_MPV2;
+                    } else if (version.startsWith("3")) {
+                        return BINARY_SCANNER_MPV3;
+                    }
+                    return BINARY_SCANNER_MPV4; // add support for future versions of MicroProfile here
+                }
+                // if (d.getGroupId().equals("io.openliberty.features")) {
+                // mpVersion = Math.max(mpVersion, getMPVersion(d.getArtifactId()));
+                // log.debug("dep=io.openliberty.features:"+d.getArtifactId()+"
+                // mpVersion="+mpVersion);
+                // }
             }
-            // if (d.getGroupId().equals("io.openliberty.features")) {
-            //     mpVersion = Math.max(mpVersion, getMPVersion(d.getArtifactId()));
-            //     log.debug("dep=io.openliberty.features:"+d.getArtifactId()+" mpVersion="+mpVersion);
-            // }
         }
         return null;
     }


### PR DESCRIPTION
Fixes #1429 

If multiple EE or MP umbrella dependencies are found within the same pom.xml file, follow Maven "nearest in dependency tree" strategy, returns the first dependency found.

If multiple EE or MP umbrella dependencies are found across multiple project modules, return the latest umbrella dependency found.
 
Modified tests so that there are multiple EE and MP umbrella dependencies specified and they continue to behave as expected. Encountered https://github.com/OpenLiberty/ci.maven/issues/1356 when enabling `MultiModuleGenerateFeaturesTest.userAndGeneratedConflictTest`:
```
[INFO] [WARNING] Calling binary-app-scanner-21.0.0.5-SNAPSHOT.jar with the following inputs...
[DEBUG]   binaryInputs: [/private/var/folders/gr/3p093xzj0f9fj9psx80z_zw00000gn/T/temp16442316120028812028/war/target/classes, /private/var/folders/gr/3p093xzj0f9fj9psx80z_zw00000gn/T/temp16442316120028812028/jar/target/classes]
[INFO]   eeVersion: ee8
[INFO]   mpVersion: null
[INFO]   currentFeatures: [cdi-1.2]
[INFO]   locale: en_CA
[INFO] [INFO] Generated the following features: [cdi-2.0, mpMetrics-3.0, jaxrs-2.1]
```
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>