### PR TITLE
Call generate features on compile dependency changes in dev mode flow

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -641,20 +641,19 @@ public class DevMojo extends LooseAppSupport {
 
                     List<Dependency> deps = upstreamProject.getDependencies();
                     List<Dependency> oldDeps = backupUpstreamProject.getDependencies();
-                    if (!dependencyListsEquals(deps, oldDeps)) {
-                        // detect compile dependency changes
-                        if (!dependencyListsEquals(getCompileDependency(deps), getCompileDependency(oldDeps))) {
-                            // optimize generate features
-                            if (generateFeatures) {
-                                log.debug("Detected a change in the compile dependencies for "
-                                        + buildFile + " , regenerating features");
-                                boolean generateFeaturesSuccess = libertyGenerateFeatures(null, true);
-                                if (generateFeaturesSuccess) {
-                                    util.getJavaSourceClassPaths().clear();
-                                }
+
+                    // detect compile dependency changes
+                    if (!dependencyListsEquals(getCompileDependency(deps), getCompileDependency(oldDeps))) {
+                        // optimize generate features
+                        if (generateFeatures) {
+                            log.debug("Detected a change in the compile dependencies for "
+                                    + buildFile + " , regenerating features");
+                            boolean generateFeaturesSuccess = libertyGenerateFeatures(null, true);
+                            if (generateFeaturesSuccess) {
+                                util.getJavaSourceClassPaths().clear();
                             }
-                            runLibertyMojoDeploy();
                         }
+                        runLibertyMojoDeploy();
                     }
                 }
             } catch (ProjectBuildingException | DependencyResolutionRequiredException | IOException

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -119,14 +119,12 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
                 return;
             } else {
                 // get all upstream projects
-                // upstreamProjects.addAll(graph.getUpstreamProjects(project, true));
-
-                // when GenerateFeaturesMojo is called from dev mode on a multi module project,
-                // the upstream project umbrella dependencies may not be up to date. Call
-                // getMavenProject to rebuild the project with the current Maven session,
-                // ensuring that the latest umbrella dependencies are loaded
                 for (MavenProject upstreamProj : graph.getUpstreamProjects(project, true)) {
                     try {
+                        // when GenerateFeaturesMojo is called from dev mode on a multi module project,
+                        // the upstream project umbrella dependencies may not be up to date. Call
+                        // getMavenProject to rebuild the project with the current Maven session,
+                        // ensuring that the latest umbrella dependencies are loaded
                         upstreamProjects.add(getMavenProject(upstreamProj.getFile()));
                     } catch (ProjectBuildingException e) {
                         log.debug("Could not resolve the upstream project: " + upstreamProj.getFile()


### PR DESCRIPTION
Part of https://github.com/OpenLiberty/ci.maven/issues/1441

Call `liberty:generate-features` goal when compile dependencies have changed in a build file, covers single module and multi module scenarios.

Integration tests will be added as part of https://github.com/OpenLiberty/ci.maven/issues/1395

See https://github.com/OpenLiberty/ci.common/pull/349