### PR TITLE
Add doc for calculating liberty runtime version via deps/depMgmt

### DIFF
--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -45,7 +45,7 @@ Example for using the `runtimeArtifact` parameter:
 </plugin>
 ```
 
-The coordinates for `runtimeArtifact` can be overridden using `libertyRuntimeGroupId`, `libertyRuntimeArtifactId`, and `libertyRuntimeVersion`. These can be set using command line properties, pom.xml properties, or additional plugin configuration. Empty or `null` values will result in a default value overriding the respective `runtimeArtifact` coordinate value. More information on these properties can be found in [common parameters](docs/common-parameters.md#common-parameters).
+The coordinates for `runtimeArtifact` can be overridden using `libertyRuntimeGroupId`, `libertyRuntimeArtifactId`, and `libertyRuntimeVersion`. These can be set using command line properties, pom.xml properties, or additional plugin configuration. Empty or `null` values will result in a default value overriding the respective `runtimeArtifact` coordinate value. More information on these properties can be found in [common parameters](common-parameters.md#common-parameters).
 
 Example of overriding the `runtimeArtifact` parameter through the command line:
 
@@ -94,6 +94,43 @@ Example of overriding the `runtimeArtifact` parameter with plugin configuration:
         </runtimeArtifact>
     </configuration>
 </plugin>
+```
+
+#### Calculating the runtime artifact version
+
+If a version is provided in the `runtimeArtifact` parameter configuration it will be used as the version of the runtime artifact used for the Liberty installation unless it is overridden by the `libertyRuntimeVersion` property.
+
+If a version is not provided with the `runtimeArtifact` parameter configuration or `libertyRuntimeVersion` property then, first, the runtime artifact groupId and artifactId will be calculated (via parameter config, properties, or default values).   If this runtime artifact groupId and artifactId matches those of a project dependency then the version of this dependency will be set as the version of the runtime artifact used for Liberty installation.   If there is no matching project dependency than the project's dependencyManagement is checked for a dependency matching the runtime artifact groupId and artifactId and if such a dependency is found, this version will be set as the version of the runtime artifact used for Liberty installation.
+
+If a version is not provided with the `runtimeArtifact` parameter configuration or `libertyRuntimeVersion` property and also there is no matching dependency listed as a project dependency or in the project's dependency management, then a default version value is chosen, generally the most recent available version of Liberty.
+
+##### Example
+
+Example "resolving" the `runtimeArtifact` version from matching `dependencyManagement` configuration:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.openliberty</groupId>
+        <artifactId>openliberty-runtime</artifactId>
+        <version>22.0.0.2</version>
+        <type>zip</type>
+      </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<plugins>  
+   <plugin>
+    <groupId>io.openliberty.tools</groupId>
+    <artifactId>liberty-maven-plugin</artifactId>
+    <configuration>
+        <runtimeArtifact>
+            <groupId>io.openliberty</groupId>
+            <artifactId>openliberty-runtime</artifactId>
+        </runtimeArtifact>
+    </configuration>
+  </plugin>
 ```
 
 ### Using an existing installation

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/AbstractLibertySupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/AbstractLibertySupport.java
@@ -153,22 +153,29 @@ public abstract class AbstractLibertySupport extends MojoSupport {
      */
     @Override
     protected Artifact getArtifact(final ArtifactItem item) throws MojoExecutionException {
-        return getArtifact(item, false);
+        Artifact artifact = getResolvedArtifact(item);
+
+        if (artifact == null) {
+            throw new MojoExecutionException(
+                "Unable to find artifact version of " + item.getGroupId() + ":" + item.getArtifactId()
+                        + " in either project dependencies or in project dependencyManagement.");
+         }
+
+         return artifact;
     }
     
     /**
      * Resolves the Artifact from the remote repository if necessary. If no version is specified, it will
-     * be retrieved from the dependency list or from the DependencyManagement section of the pom.
+     * be retrieved from the dependency list or from the DependencyManagement section of the pom.  If no
+     * dependency or dependencyManagement artifact is found for the given item a 'null' will be returned.
      *
      *
      * @param item  The item to create an artifact for; must not be null
-     * @param useDefaultVersion Flag indicating whether or not to default the version for the artifact (only
-     *                          used for defaulting the Liberty runtime version)
      * @return      The artifact for the given item
      *
      * @throws MojoExecutionException   Failed to create artifact
      */
-    protected Artifact getArtifact(final ArtifactItem item, boolean useDefaultVersion) throws MojoExecutionException {
+    protected Artifact getResolvedArtifact(final ArtifactItem item) throws MojoExecutionException {
         assert item != null;
         Artifact artifact = null;
         
@@ -191,14 +198,6 @@ public abstract class AbstractLibertySupport extends MojoSupport {
                 // get version from dependencyManagement
                 item.setVersion(resolveFromProjectDepMgmt(item).getVersion());
                 artifact = createArtifact(item);
-            } else if (useDefaultVersion) {
-                log.debug("Defaulting runtimeArtifact version to '[22.0.0.3,)'");
-                item.setVersion("[22.0.0.3,)");
-                artifact = createArtifact(item);
-            } else {
-                    throw new MojoExecutionException(
-                            "Unable to find artifact version of " + item.getGroupId() + ":" + item.getArtifactId()
-                                    + " in either project dependencies or in project dependencyManagement.");
             }
         }
         

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/BasicSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/BasicSupport.java
@@ -264,7 +264,7 @@ public class BasicSupport extends AbstractLibertySupport {
                 }
                 
                 // check for liberty.runtime.version property which overrides any version set in the assemblyArtifact
-                boolean useDefaultVersion = false;
+
                 if (libertyRuntimeVersion != null && !libertyRuntimeVersion.isEmpty()) {
                     if (assemblyArtifact.getVersion() != null) {
                         log.info("The runtimeArtifact version " + assemblyArtifact.getVersion() + " is overwritten by the liberty.runtime.version value "+ libertyRuntimeVersion +".");
@@ -272,13 +272,15 @@ public class BasicSupport extends AbstractLibertySupport {
                         log.info("The liberty.runtime.version property value "+ libertyRuntimeVersion +" is used for the runtimeArtifact version.");
                     }
                     assemblyArtifact.setVersion(libertyRuntimeVersion);
-                } else {
-                    if(assemblyArtifact.getVersion() == null) {
-                        useDefaultVersion = true;
-                    }
                 }
-                
-                Artifact artifact = getArtifact(assemblyArtifact, useDefaultVersion);                
+
+                Artifact artifact = getResolvedArtifact(assemblyArtifact);
+
+                if (artifact == null) {
+                    log.debug("Defaulting runtimeArtifact version to '[22.0.0.3,)'");
+                    assemblyArtifact.setVersion("[22.0.0.3,)");
+                    artifact = createArtifact(assemblyArtifact);
+                }
                 
                 assemblyArchive = artifact.getFile();
                 if (assemblyArchive == null) {


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Follow-up to https://github.com/OpenLiberty/ci.maven/pull/1361

Thought I'd add some doc here.  (I don't see it already?)

A bit wordy and maybe could be condensed but could we start by seeing if it looks basically correct?

For the code... it doesn't seem like the default version for a generic artifact should be set to a liberty thing so I refactored a bit.

@cherylking please take a look...thank you

**UPDATE (3/29):**  A few of the test runs seemed to complete OK.  Guessing the others may be intermittent failures (haven't been paying attention)?    I re-pushed just one more doc update today so the tests will rerun now.
