### PR TITLE
Suppress logs from ServerFeatureUtil so that dev console is not flooded

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/ServerFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/ServerFeatureSupport.java
@@ -53,6 +53,8 @@ public class ServerFeatureSupport extends BasicSupport {
         public void warn(String msg) {
             if (!suppressLogs) {
                 log.warn(msg);
+            } else {
+                log.debug(msg);
             }
         }
 
@@ -60,6 +62,8 @@ public class ServerFeatureSupport extends BasicSupport {
         public void info(String msg) {
             if (!suppressLogs) {
                 log.info(msg);
+            } else {
+                log.debug(msg);
             }
         }
 
@@ -76,11 +80,17 @@ public class ServerFeatureSupport extends BasicSupport {
     /**
      * Get a new instance of ServerFeatureUtil
      * 
+     * @param suppressLogs if true info and warning will be logged as debug
      * @return instance of ServerFeatureUtil
      */
-    protected ServerFeatureUtil getServerFeatureUtil() {
+    protected ServerFeatureUtil getServerFeatureUtil(boolean suppressLogs) {
         if (servUtil == null) {
             createNewServerFeatureUtil();
+        }
+        if (suppressLogs) {
+            servUtil.setSuppressLogs(true);
+        } else {
+            servUtil.setSuppressLogs(false);
         }
         return servUtil;
     }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -290,7 +290,7 @@ public class DevMojo extends LooseAppSupport {
                     keepTempDockerfile, mavenCacheLocation, upstreamProjects, recompileDeps, project.getPackaging(),
                     pom, parentPoms, generateFeatures, compileArtifactPaths, testArtifactPaths, webResourceDirs);
 
-            ServerFeatureUtil servUtil = getServerFeatureUtil();
+            ServerFeatureUtil servUtil = getServerFeatureUtil(true);
             this.libertyDirPropertyFiles = BasicSupport.getLibertyDirectoryPropertyFiles(installDir, userDir,
                     serverDirectory);
             this.existingFeatures = servUtil.getServerFeatures(serverDirectory, libertyDirPropertyFiles);
@@ -963,7 +963,7 @@ public class DevMojo extends LooseAppSupport {
         @Override
         public void installFeatures(File configFile, File serverDir) {
             try {
-                ServerFeatureUtil servUtil = getServerFeatureUtil();
+                ServerFeatureUtil servUtil = getServerFeatureUtil(true);
                 Set<String> features = servUtil.getServerFeatures(serverDir, libertyDirPropertyFiles);
                 if (features != null) {
                     Set<String> featuresCopy = new HashSet<String>(features);
@@ -999,7 +999,8 @@ public class DevMojo extends LooseAppSupport {
 
         @Override
         public ServerFeatureUtil getServerFeatureUtilObj() {
-            return getServerFeatureUtil();
+            // suppress logs from ServerFeatureUtil so that dev console is not flooded
+            return getServerFeatureUtil(true);
         }
 
         @Override

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -168,7 +168,7 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
         // Set<String> featuresToInstall = getSpecifiedFeatures(null); 
 
         // get existing server features from source directory
-        ServerFeatureUtil servUtil = getServerFeatureUtil();
+        ServerFeatureUtil servUtil = getServerFeatureUtil(true);
 
         Set<String> generatedFiles = new HashSet<String>();
         generatedFiles.add(GENERATED_FEATURES_FILE_NAME);


### PR DESCRIPTION
Partial fix for #1369 

Output when running the `generate-features` goal standalone:
```
kathrynkodama@MacBook-Pro demo-devmode % mvn liberty:generate-features
[INFO] Scanning for projects...
[INFO] 
[INFO] -----------------< io.openliberty:demo-devmode-maven >------------------
[INFO] Building demo-devmode-maven 1.0-SNAPSHOT
[INFO] --------------------------------[ war ]---------------------------------
[INFO] 
[INFO] --- liberty-maven-plugin:3.6-SNAPSHOT:generate-features (default-cli) @ demo-devmode-maven ---
[INFO] Generated the following features: [cdi-2.0, jaxrs-2.1]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.321 s
[INFO] Finished at: 2022-04-07T12:06:07-04:00
[INFO] ------------------------------------------------------------------------
```

Ouptut when triggering generate-features in dev mode on source file change (but no new API usage):
```
[INFO] Source compilation was successful.
[INFO] Generating feature list from incremental changes...
[INFO] Running liberty:generate-features
[INFO] [AUDIT   ] CWWKZ0009I: The application demo-devmode-maven has stopped successfully.
[INFO] Generated the following features: [cdi-2.0, mpHealth-3.1, jaxrs-2.1]
[INFO] Copied file: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/src/main/liberty/config/configDropins/overrides/generated-features.xml to: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/generated-features.xml
[INFO] [AUDIT   ] CWWKZ0003I: The application demo-devmode-maven updated in 0.187 seconds.
[INFO] [AUDIT   ] CWWKG0016I: Starting server configuration update.
[INFO] [AUDIT   ] CWWKG0093A: Processing configuration drop-ins resource: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/configDropins/defaults/install_apps_configuration_1491924271.xml
[INFO] [AUDIT   ] CWWKG0028A: Processing included configuration resource: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/extraFeatures1.xml
[INFO] [AUDIT   ] CWWKG0028A: Processing included configuration resource: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/extraServerConfig1.xml
[INFO] [AUDIT   ] CWWKG0093A: Processing configuration drop-ins resource: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/generated-features.xml
[INFO] [AUDIT   ] CWWKG0093A: Processing configuration drop-ins resource: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/liberty-plugin-variable-config.xml
[INFO] [AUDIT   ] CWWKG0018I: The server configuration was not updated. No functional changes were detected.
```

Output when triggering generate-features in dev mode on new API usage:
```
[INFO] Source compilation was successful.
[INFO] Generating feature list from incremental changes...
[INFO] Running liberty:generate-features
[INFO] [AUDIT   ] CWWKZ0009I: The application demo-devmode-maven has stopped successfully.
[INFO] Generated the following features: [cdi-2.0, mpHealth-3.1, jaxrs-2.1]
[INFO] [AUDIT   ] CWWKZ0003I: The application demo-devmode-maven updated in 0.246 seconds.
[INFO] Copied file: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/src/main/liberty/config/configDropins/overrides/generated-features.xml to: /private/var/folders/gr/3p093xzj0f9fj9psx80z_zw00000gn/T/tempConfig11005644340673091909/configDropins/overrides/generated-features.xml
[INFO] Configuration features have been added
[INFO] Running liberty:install-feature
[INFO] CWWKM2102I: Using artifact based assembly archive : io.openliberty:openliberty-kernel:null:22.0.0.2:zip.
[INFO] CWWKM2102I: Using installDirectory : /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp.
[INFO] CWWKM2102I: Using serverName : defaultServer.
[INFO] CWWKM2102I: Using serverDirectory : /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer.
[INFO] Parsing the server file /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/configDropins/defaults/install_apps_configuration_1491924271.xml for features and includes.
[INFO] Parsing the server file /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/server.xml for features and includes.
[INFO] Parsing the server file /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/extraFeatures1.xml for features and includes.
[INFO] Parsing the server file /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/extraServerConfig1.xml for features and includes.
[INFO] Parsing the server file /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/generated-features.xml for features and includes.
[INFO] Parsing the server file /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/liberty-plugin-variable-config.xml for features and includes.
[INFO] Installing features: [mphealth-3.1, cdi-2.0, jaxrs-2.1]

[INFO] Product validation completed successfully.
[INFO] The following features have been installed: json-1.0 mpConfig-2.0 mpHealth-3.1 
[INFO] Copied file: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/src/main/liberty/config/configDropins/overrides/generated-features.xml to: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/generated-features.xml
[INFO] [AUDIT   ] CWWKG0016I: Starting server configuration update.
[INFO] [AUDIT   ] CWWKG0093A: Processing configuration drop-ins resource: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/configDropins/defaults/install_apps_configuration_1491924271.xml
[INFO] [AUDIT   ] CWWKG0028A: Processing included configuration resource: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/extraFeatures1.xml
[INFO] [AUDIT   ] CWWKG0028A: Processing included configuration resource: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/extraServerConfig1.xml
[INFO] [AUDIT   ] CWWKG0093A: Processing configuration drop-ins resource: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/generated-features.xml
[INFO] [AUDIT   ] CWWKG0093A: Processing configuration drop-ins resource: /Users/kathrynkodama/devex/featureGeneration/snapshot-testing/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/liberty-plugin-variable-config.xml
[INFO] [AUDIT   ] CWWKZ0009I: The application demo-devmode-maven has stopped successfully.
[INFO] [AUDIT   ] CWWKG0017I: The server configuration was successfully updated in 0.593 seconds.
[INFO] [AUDIT   ] CWWKF0012I: The server installed the following features: [json-1.0, mpConfig-2.0, mpHealth-3.1].
[INFO] [AUDIT   ] CWWKF0008I: Feature update completed in 0.627 seconds.
[INFO] [AUDIT   ] CWWKZ0003I: The application demo-devmode-maven updated in 0.528 seconds.

```


If users want to see which config file(s) generate-features gathers existing features from they can use the `-X` debug flag. 



Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>