### PR TITLE
Add serverDir param to install-feature for dev mode

### DIFF
--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/base-install-feature-test/src/test/java/net/wasdev/wlp/test/feature/it/BaseInstallFeature.java
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/base-install-feature-test/src/test/java/net/wasdev/wlp/test/feature/it/BaseInstallFeature.java
@@ -19,7 +19,7 @@ import java.io.File;
 import java.io.FilenameFilter;
 import io.openliberty.tools.common.plugins.util.InstallFeatureUtil;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 
 public class BaseInstallFeature {

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-override-server-dir-it/pom.xml
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-override-server-dir-it/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.openliberty.tools.it</groupId>
+        <artifactId>kernel-install-feature-tests</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>install-features-override-server-dir-it</artifactId>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>@pom.version@</version>
+                <configuration>
+                    <assemblyArtifact>
+                        <groupId>${runtimeGroupId}</groupId>
+                        <artifactId>${runtimeKernelId}</artifactId>
+                        <version>${runtimeVersion}</version>
+                        <type>zip</type>
+                    </assemblyArtifact>
+                    <serverName>test</serverName>
+                    <serverDir>src/test/resources</serverDir>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>install-liberty-server</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>install-server</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>create-server</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>install-server-features</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>install-feature</goal>
+                        </goals>
+                        <configuration>
+                            <features>
+                                <acceptLicense>true</acceptLicense>
+                            </features>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-override-server-dir-it/pom.xml
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-override-server-dir-it/pom.xml
@@ -26,7 +26,6 @@
                         <type>zip</type>
                     </assemblyArtifact>
                     <serverName>test</serverName>
-                    <serverDir>src/test/resources</serverDir>
                 </configuration>
                 <executions>
                     <execution>
@@ -53,6 +52,7 @@
                             <features>
                                 <acceptLicense>true</acceptLicense>
                             </features>
+                            <serverDir>src/test/resources</serverDir>
                         </configuration>
                     </execution>
                 </executions>

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-override-server-dir-it/src/test/java/net/wasdev/wlp/test/features/it/InstallFeaturesOverrideServerDirTest.java
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-override-server-dir-it/src/test/java/net/wasdev/wlp/test/features/it/InstallFeaturesOverrideServerDirTest.java
@@ -22,8 +22,10 @@ public class InstallFeaturesOverrideServerDirTest extends BaseInstallFeature {
     @Test
     public void testInstalledFeatures() throws Exception {
         assertInstalled("jsp-2.3"); // specified in extra-features.xml
-        assertNotInstalled("servlet-3.1"); // specified in the server.xml
+        // ensure that the serverDir param is working as expected and 
+        // servlet-3.1 is not installed as servlet-4.0 is specified
+        assertNotInstalled("servlet-3.1");
         assertInstalled("appSecurityClient-1.0"); // specified in the server.xml
-        assertInstalled("servlet-4.0"); // not specified in server.xml
+        assertInstalled("servlet-4.0"); // specified in server.xml
     }
 }

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-override-server-dir-it/src/test/java/net/wasdev/wlp/test/features/it/InstallFeaturesOverrideServerDirTest.java
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-override-server-dir-it/src/test/java/net/wasdev/wlp/test/features/it/InstallFeaturesOverrideServerDirTest.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.feature.it;
+
+import org.junit.Test;
+
+public class InstallFeaturesOverrideServerDirTest extends BaseInstallFeature {
+    
+    @Test
+    public void testInstalledFeatures() throws Exception {
+        assertNotInstalled("servlet-4.0");
+        assertInstalled("jsp-2.3");
+        assertInstalled("servlet-3.1");
+    }
+}

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-override-server-dir-it/src/test/java/net/wasdev/wlp/test/features/it/InstallFeaturesOverrideServerDirTest.java
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-override-server-dir-it/src/test/java/net/wasdev/wlp/test/features/it/InstallFeaturesOverrideServerDirTest.java
@@ -21,8 +21,9 @@ public class InstallFeaturesOverrideServerDirTest extends BaseInstallFeature {
     
     @Test
     public void testInstalledFeatures() throws Exception {
-        assertNotInstalled("servlet-4.0");
-        assertInstalled("jsp-2.3");
-        assertInstalled("servlet-3.1");
+        assertInstalled("jsp-2.3"); // specified in extra-features.xml
+        assertNotInstalled("servlet-3.1"); // specified in the server.xml
+        assertInstalled("appSecurityClient-1.0"); // specified in the server.xml
+        assertInstalled("servlet-4.0"); // not specified in server.xml
     }
 }

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-override-server-dir-it/src/test/resources/extraFeatures.xml
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-override-server-dir-it/src/test/resources/extraFeatures.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="extra server features">
+	<featureManager>
+        <feature>jsp-2.3</feature>
+    </featureManager>
+</server>

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-override-server-dir-it/src/test/resources/server.xml
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-override-server-dir-it/src/test/resources/server.xml
@@ -1,0 +1,7 @@
+<server description="default server">
+    <featureManager>    
+        <feature>servlet-4.0</feature>
+    </featureManager> 
+
+    <include location="extraFeatures.xml"/>    
+</server>

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-override-server-dir-it/src/test/resources/server.xml
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-override-server-dir-it/src/test/resources/server.xml
@@ -1,6 +1,7 @@
 <server description="default server">
     <featureManager>    
         <feature>servlet-4.0</feature>
+        <feature>appSecurityClient-1.0</feature>
     </featureManager> 
 
     <include location="extraFeatures.xml"/>    

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/pom.xml
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/pom.xml
@@ -40,6 +40,7 @@
         <module>install-ol-features-no-accept-license-it</module> 
         <module>prepare-feature-it</module> 
         <module>install-usr-feature-ext-it</module>
+        <module>install-features-override-server-dir-it</module>
     </modules>
     
     <!-- Profiles for WLP vs OL -->

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -397,7 +397,7 @@ public class DevMojo extends LooseAppSupport {
         @Override
         public void libertyInstallFeature() throws PluginExecutionException {
             try {
-                runLibertyMojoInstallFeature(null, container ? super.getContainerName() : null);
+                runLibertyMojoInstallFeature(null, null, container ? super.getContainerName() : null);
             } catch (MojoExecutionException e) {
                 throw new PluginExecutionException(e);
             }
@@ -941,7 +941,7 @@ public class DevMojo extends LooseAppSupport {
                     	runLibertyMojoDeploy();
                     }
                     if (installFeature) {
-                        runLibertyMojoInstallFeature(null, super.getContainerName());
+                        runLibertyMojoInstallFeature(null, null, super.getContainerName());
                     }
                 }
                 if (!(restartServer || createServer || redeployApp || installFeature || runBoostPackage)) {
@@ -974,22 +974,24 @@ public class DevMojo extends LooseAppSupport {
                         Set<String> existingFeaturesCopy = new HashSet<String>(existingFeatures);
                         existingFeaturesCopy.removeAll(featuresCopy);
                         if (!existingFeaturesCopy.isEmpty()) {
-                            log.info("Configuration features have been removed");
+                            log.info("Configuration features have been removed: " + existingFeaturesCopy);
                             existingFeatures.removeAll(existingFeaturesCopy);
                         }
                     }
 
                     // check if features have been added and install new features
                     if (!features.isEmpty()) {
-                        log.info("Configuration features have been added");
+                        log.info("Configuration features have been added: " + features);
+                        // pass all features to install feature
+                        existingFeatures.addAll(features);
+
                         Element[] featureElems = new Element[features.size() + 1];
                         featureElems[0] = element(name("acceptLicense"), "true");
                         String[] values = features.toArray(new String[features.size()]);
                         for (int i = 0; i < features.size(); i++) {
                             featureElems[i + 1] = element(name("feature"), values[i]);
                         }
-                        runLibertyMojoInstallFeature(element(name("features"), featureElems), super.getContainerName());
-                        existingFeatures.addAll(features);
+                        runLibertyMojoInstallFeature(element(name("features"), featureElems), serverDir, super.getContainerName());
                     }
                 }
             } catch (MojoExecutionException e) {
@@ -1265,7 +1267,7 @@ public class DevMojo extends LooseAppSupport {
             // should have "RUN features.sh" in their Dockerfile if they want features to be
             // installed.
             if (!container) {
-                runLibertyMojoInstallFeature(null, null);
+                runLibertyMojoInstallFeature(null, null, null);
             }
             runLibertyMojoDeploy();
         }
@@ -1840,8 +1842,8 @@ public class DevMojo extends LooseAppSupport {
      * @throws MojoExecutionException
      */
     @Override
-    protected void runLibertyMojoInstallFeature(Element features, String containerName) throws MojoExecutionException {
-        super.runLibertyMojoInstallFeature(features, containerName);
+    protected void runLibertyMojoInstallFeature(Element features, File serverDir, String containerName) throws MojoExecutionException {
+        super.runLibertyMojoInstallFeature(features, serverDir, containerName);
     }
 
     /**

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -982,9 +982,8 @@ public class DevMojo extends LooseAppSupport {
                     // check if features have been added and install new features
                     if (!features.isEmpty()) {
                         log.info("Configuration features have been added: " + features);
-                        // pass all features to install feature
                         existingFeatures.addAll(features);
-
+                        // pass all new features to install-feature
                         Element[] featureElems = new Element[features.size() + 1];
                         featureElems[0] = element(name("acceptLicense"), "true");
                         String[] values = features.toArray(new String[features.size()]);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -983,7 +983,7 @@ public class DevMojo extends LooseAppSupport {
                     if (!features.isEmpty()) {
                         log.info("Configuration features have been added: " + features);
                         existingFeatures.addAll(features);
-                        // pass all new features to install-feature
+                        // pass all new features to install-feature as backup in case the serverDir cannot be accessed
                         Element[] featureElems = new Element[features.size() + 1];
                         featureElems[0] = element(name("acceptLicense"), "true");
                         String[] values = features.toArray(new String[features.size()]);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallFeatureMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallFeatureMojo.java
@@ -51,8 +51,8 @@ public class InstallFeatureMojo extends InstallFeatureSupport {
      * Dev mode uses this option to provide the location of the
      * temporary serverDir it uses after a change to the server.xml
      */
-    @Parameter(property = "serverDir")
-    private File serverDirectoryParam = null;
+    @Parameter(alias = "serverDir", property = "serverDir")
+    private File serverDirectoryParam;
 
     /*
      * (non-Javadoc)

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallFeatureMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallFeatureMojo.java
@@ -46,6 +46,14 @@ public class InstallFeatureMojo extends InstallFeatureSupport {
     @Parameter
     private String containerName;
 
+    /**
+     * (Optional) Server directory to get the features from.
+     * Dev mode uses this option to provide the location of the
+     * temporary serverDir it uses after a change to the server.xml
+     */
+    @Parameter(property = "serverDir")
+    private File serverDirectoryParam = null;
+
     /*
      * (non-Javadoc)
      * @see org.codehaus.mojo.pluginsupport.MojoSupport#doExecute()
@@ -54,6 +62,10 @@ public class InstallFeatureMojo extends InstallFeatureSupport {
     protected void doExecute() throws Exception {
         if(!initialize()) {
             return;
+        }
+        if (serverDirectoryParam != null) {
+            serverDirectory = serverDirectoryParam;
+            log.debug("Overriding the server directory with: " + serverDirectory);
         }
         installFeatures();
     }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -121,7 +121,7 @@ public class RunServerMojo extends PluginConfigSupport {
         }
         
         runLibertyMojoCreate();
-        runLibertyMojoInstallFeature(null, null);
+        runLibertyMojoInstallFeature(null, null, null);
         runLibertyMojoDeploy(false);
 
         ServerTask serverTask = initializeJava();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -328,7 +328,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
         runLibertyMojo("deploy", config);
     }
 
-    protected void runLibertyMojoInstallFeature(Element features, String containerName) throws MojoExecutionException {
+    protected void runLibertyMojoInstallFeature(Element features, File serverDir, String containerName) throws MojoExecutionException {
         Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(getLibertyPlugin(), "install-feature", log);
         if (features != null) {
             config = Xpp3Dom.mergeXpp3Dom(configuration(features), config);
@@ -336,7 +336,15 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
         if (containerName != null) {
             config.addChild(element(name("containerName"), containerName).toDom());
         }
-        runLibertyMojo("install-feature", config);   
+        if (serverDir != null) {
+            try {
+                config.addChild(element(name("serverDir"), serverDir.getCanonicalPath()).toDom());
+            } catch (IOException e) {
+                log.warn("Unable to pass 'serverDir' configuration parameter to liberty:install-feature: "
+                        + serverDir);
+            }
+        }
+        runLibertyMojo("install-feature", config);
     }
 
     protected void runLibertyMojoGenerateFeatures(Element classFiles, boolean optimize) throws MojoExecutionException {


### PR DESCRIPTION
Fixes  #1458 

Add `serverDir` param to `liberty:install-feature` for the dev mode flow. Dev mode now passes the temporary server directory it creates when installing features to install-feature so that install-feature only searches for features in that directory. 

This already exists in ci.gradle: https://github.com/OpenLiberty/ci.gradle/blob/7bbb55c54d3e0f430c12f19b4cd9394dfd3ac6d5/src/main/groovy/io/openliberty/tools/gradle/tasks/AbstractFeatureTask.groovy#L34-L50

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>