### PR TITLE
Work around server restart problem by changing dev-it

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/src/main/liberty/config/bootstrap.properties
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/src/main/liberty/config/bootstrap.properties
@@ -1,0 +1,1 @@
+com.ibm.ws.logging.trace.specification=config=all=enabled:*=info=enabled

--- a/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/GenerateFeaturesRestTest.java
+++ b/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/GenerateFeaturesRestTest.java
@@ -29,13 +29,6 @@ import org.junit.Test;
  * liberty:generate-features goal tests for various MicroProfile and Java EE versions
  * Test to ensure the binary scanner honours the version of MicroProfile and Java EE
  * specified in the pom.xml
- * When you use MicroProfile the binary scanner assumes you use the lastest subversion
- * in the version you specify:
- * You specify | binary scanner generates features in
- * MP 1.1-1.4  | MicroProfile 1.4
- * MP 2.0-2.2  | MicroProfile 2.2
- * MP 3.0-3.3  | MicroProfile 3.3
- * MP 4.0-4.1  | MicroProfile 4.1
  */
 public class GenerateFeaturesRestTest extends BaseGenerateFeaturesTest {
 
@@ -85,7 +78,7 @@ public class GenerateFeaturesRestTest extends BaseGenerateFeaturesTest {
     }
 
     @Test
-    public void mp2Test() throws Exception {
+    public void mp21Test() throws Exception {
         // Test Java EE 8.0 and MicroProfile 2.x
         // MicroProfile 2.1 uses cdi-2.0 so it requires EE8
         File pomFile = new File(tempProj, "pom.xml");
@@ -98,12 +91,12 @@ public class GenerateFeaturesRestTest extends BaseGenerateFeaturesTest {
 
         // verify that the correct features are in the generated-features.xml
         Set<String> features = readFeatures(newFeatureFile);
-        assertTrue(features.contains("mpRestClient-1.2"));
+        assertTrue(features.contains("mpRestClient-1.1"));
         assertTrue(features.contains("cdi-2.0"));
     }
 
     @Test
-    public void mp3Test() throws Exception {
+    public void mp30Test() throws Exception {
         // Test Java EE 8.0 and MicroProfile 3.x
         File pomFile = new File(tempProj, "pom.xml");
         replaceString("EE_VERSION", "8.0", pomFile);
@@ -115,12 +108,12 @@ public class GenerateFeaturesRestTest extends BaseGenerateFeaturesTest {
 
         // verify that the correct features are in the generated-features.xml
         Set<String> features = readFeatures(newFeatureFile);
-        assertTrue(features.contains("mpRestClient-1.4"));
+        assertTrue(features.contains("mpRestClient-1.3"));
         assertTrue(features.contains("cdi-2.0"));
     }
 
     @Test
-    public void mp4Test() throws Exception {
+    public void mp41Test() throws Exception {
         // Test Java EE 8.0 and MicroProfile 4.x
         File pomFile = new File(tempProj, "pom.xml");
         replaceString("EE_VERSION", "8.0", pomFile);

--- a/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/GenerateFeaturesTest.java
+++ b/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/GenerateFeaturesTest.java
@@ -232,26 +232,4 @@ public class GenerateFeaturesTest extends BaseGenerateFeaturesTest {
         }
         return str.toString();
     }
-
-    @Test
-    public void mpVersionTest() throws Exception {
-       assertEquals(GenerateFeaturesMojo.getMPVersion("mpHealth-2.0"), 3);
-       assertEquals(GenerateFeaturesMojo.getMPVersion("mpconfig-1.0"), 1);
-       assertEquals(GenerateFeaturesMojo.getMPVersion("mpconfig-1.3"), 2);
-       assertEquals(GenerateFeaturesMojo.getMPVersion("mpconfig-1.4"), 3);
-       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.0"), 1);
-       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.1"), 1);
-       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.2"), 2);
-       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.3"), 3);
-       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.4"), 3);
-       assertEquals(GenerateFeaturesMojo.getMPVersion("mpjwt-1.0"), 1);
-       assertEquals(GenerateFeaturesMojo.getMPVersion("mpjwt-1.1"), 3);
-       assertEquals(GenerateFeaturesMojo.getMPVersion("mpjwt-1.2"), 4);
-       // Error testing
-       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclientX-1.5"), 0);
-       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient1.5"), 0);
-       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-1.5a"), 0);
-       assertEquals(GenerateFeaturesMojo.getMPVersion("mprestclient-10"), 0);
-       assertEquals(GenerateFeaturesMojo.getMPVersion("Xmprestclient-1.0"), 0);
-    }
 }


### PR DESCRIPTION
We add the trace string in bootstrap.properties to allow the dev-it tests to run.

The changes to generate-features-it are essentially technical debt. 

With these changes dev-it was seen to pass in github actions and generate-features-it passes locally but there is one remaining issue affecting github actions.

Fixes #1461 