### PR TITLE
Simply serverDir param for dev mode in install-feature

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallFeatureMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallFeatureMojo.java
@@ -51,8 +51,8 @@ public class InstallFeatureMojo extends InstallFeatureSupport {
      * Dev mode uses this option to provide the location of the
      * temporary serverDir it uses after a change to the server.xml
      */
-    @Parameter(alias = "serverDir", property = "serverDir")
-    private File serverDirectoryParam;
+    @Parameter
+    private File serverDir;
 
     /*
      * (non-Javadoc)
@@ -63,8 +63,8 @@ public class InstallFeatureMojo extends InstallFeatureSupport {
         if(!initialize()) {
             return;
         }
-        if (serverDirectoryParam != null) {
-            serverDirectory = serverDirectoryParam;
+        if (serverDir != null) {
+            serverDirectory = serverDir;
             log.debug("Overriding the server directory with: " + serverDirectory);
         }
         installFeatures();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -336,7 +336,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
         if (containerName != null) {
             config.addChild(element(name("containerName"), containerName).toDom());
         }
-        if (serverDir != null) {
+        if (serverDir != null && serverDir.exists()) {
             try {
                 config.addChild(element(name("serverDir"), serverDir.getCanonicalPath()).toDom());
             } catch (IOException e) {


### PR DESCRIPTION
Simplify `serverDir` install-feature param that dev mode uses for readability and maintainability.

Fixes a bug where instead of `<serverDir>` install-feature expects `<serverDirectoryParam>` to be passed via config from dev mode.
```
Caused by: org.apache.maven.plugin.PluginConfigurationException: Unable to parse configuration of mojo io.openliberty.tools:liberty-maven-plugin:3.6-SNAPSHOT:install-feature for parameter serverDir: Cannot find 'serverDir' in class io.openliberty.tools.maven.server.InstallFeatureMojo
```

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>