### PR TITLE
Revert generate-features-it from pomExclude and ignore all generate-features-it

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -129,9 +129,6 @@
                         <artifactId>maven-invoker-plugin</artifactId>
                         <version>3.2.2</version>
                         <configuration>
-                            <pomExcludes>
-                                <pomExclude>generate-features-it/pom.xml</pomExclude>
-                            </pomExcludes>
                             <debug>false</debug>
                             <goals>
                                 <goal>install</goal>
@@ -168,9 +165,6 @@
                         <artifactId>maven-invoker-plugin</artifactId>
                         <version>3.1.0</version>
                         <configuration>
-                            <pomExcludes>
-                                <pomExclude>generate-features-it/pom.xml</pomExclude>
-                            </pomExcludes>
                             <debug>false</debug>
                             <goals>
                                 <goal>install</goal>
@@ -251,7 +245,6 @@
                                     <pomExclude>server-param-default-it/pom.xml</pomExclude>
                                     <pomExclude>server-param-configdir-not-override-it/pom.xml</pomExclude>
                                     <pomExclude>install-features-it/pom.xml</pomExclude>
-                                    <pomExclude>generate-features-it/pom.xml</pomExclude>
                                 </pomExcludes>
                             </configuration>
                         </plugin>

--- a/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/GenerateFeaturesRestTest.java
+++ b/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/GenerateFeaturesRestTest.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -30,6 +31,8 @@ import org.junit.Test;
  * Test to ensure the binary scanner honours the version of MicroProfile and Java EE
  * specified in the pom.xml
  */
+// TODO enable when feature generation is re-enabled
+@Ignore
 public class GenerateFeaturesRestTest extends BaseGenerateFeaturesTest {
 
     @Before

--- a/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/GenerateFeaturesTest.java
+++ b/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/GenerateFeaturesTest.java
@@ -31,6 +31,7 @@ import java.util.Set;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import io.openliberty.tools.maven.server.GenerateFeaturesMojo;
@@ -38,6 +39,8 @@ import io.openliberty.tools.maven.server.GenerateFeaturesMojo;
 /**
  * liberty:generate-features goal tests
  */
+// TODO enable when feature generation is re-enabled
+@Ignore
 public class GenerateFeaturesTest extends BaseGenerateFeaturesTest {
 
     @Before

--- a/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleGenerateFeaturesTest.java
+++ b/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleGenerateFeaturesTest.java
@@ -30,6 +30,8 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+// TODO enable when feature generation is re-enabled
+@Ignore
 public class MultiModuleGenerateFeaturesTest extends GenerateFeaturesTest {
 
     @Override


### PR DESCRIPTION
Reverts the `<pomExclude>` elements for generate-features-it and instead ignore all generate-features-it tests. Fixes the recent failures seen in the GitHub actions and the `<pomExclude>` elements seemingly being ignored.