### PR TITLE
Update spring boot tests and temporarily disable

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,11 +20,11 @@ jobs:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         os: [ubuntu-18.04, windows-latest]
         RUNTIME: [ol, wlp]
-        RUNTIME_VERSION: [21.0.0.9, 21.0.0.12]
+        RUNTIME_VERSION: [22.0.0.3, 21.0.0.12]
         java: [11, 8]
         exclude:
         - java: 8
-          RUNTIME_VERSION: 21.0.0.9
+          RUNTIME_VERSION: 21.0.0.12
 
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, ${{ matrix.os }}
     steps:

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -298,6 +298,7 @@
                                 <pomExcludes>
                                     <pomExclude>dev-it/pom.xml</pomExclude>
                                     <pomExclude>generate-features-it/pom.xml</pomExclude>
+                                    <pomExclude>springboot-tests/pom.xml</pomExclude>
                                 </pomExcludes>
                             </configuration>
                         </plugin>
@@ -340,6 +341,7 @@
                                     <pomExclude>server-param-configdir-not-override-it/pom.xml</pomExclude>
                                     <pomExclude>install-features-it/pom.xml</pomExclude>
                                     <pomExclude>generate-features-it/pom.xml</pomExclude>
+                                    <pomExclude>springboot-tests/pom.xml</pomExclude>
                                 </pomExcludes>
                             </configuration>
                         </plugin>

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -214,6 +214,21 @@
                 <runtimeKernelId>wlp-kernel</runtimeKernelId>
                 <runtimeVersion>${runtimeVersion}</runtimeVersion>
             </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-invoker-plugin</artifactId>
+                            <configuration>
+                                <pomExcludes>
+                                    <pomExclude>springboot-tests/pom.xml</pomExclude>
+                                </pomExcludes>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
         <profile>
             <id>ol-its</id>
@@ -245,6 +260,7 @@
                                     <pomExclude>server-param-default-it/pom.xml</pomExclude>
                                     <pomExclude>server-param-configdir-not-override-it/pom.xml</pomExclude>
                                     <pomExclude>install-features-it/pom.xml</pomExclude>
+                                    <pomExclude>springboot-tests/pom.xml</pomExclude>
                                 </pomExcludes>
                             </configuration>
                         </plugin>

--- a/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-apps-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-apps-it/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.14.RELEASE</version>
+		<version>2.6.7</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
@@ -31,7 +31,13 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+                <dependency>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                    <version>4.13.2</version>
+                    <scope>test</scope>
+                </dependency>	
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-apps-it/src/test/java/application/InstallSpringBoot20AppIT.java
+++ b/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-apps-it/src/test/java/application/InstallSpringBoot20AppIT.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2018.
+ * (C) Copyright IBM Corporation 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import static org.junit.Assert.*;
 import java.io.File;
 import org.junit.Test;
 
-public class InstallSpringBoot15AppIT {
+public class InstallSpringBoot20AppIT {
 
     @Test
     public void testThinApplicationExistsInAppsDirectory() throws Exception {
@@ -32,6 +32,6 @@ public class InstallSpringBoot15AppIT {
     @Test
     public void testLibIndexCacheExists() throws Exception {
         File f = new File("target/liberty/wlp/usr/shared/resources/lib.index.cache");
-        assertTrue(f.getCanonicalFile() + " doesn't exist. Plugin failed to place the cache directory at right destination.", f.exists());
+        assertTrue(f.getCanonicalFile()+ " doesn't exist. Plugin failed to place the cache directory at right destination.", f.exists());
     }
 }

--- a/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-apps-it/src/test/java/application/SpringBoot20RestEndpointIT.java
+++ b/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-apps-it/src/test/java/application/SpringBoot20RestEndpointIT.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2018.
+ * (C) Copyright IBM Corporation 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,10 +24,11 @@ import java.net.URL;
 
 import org.junit.Test;
 
-public class SpringBoot15RestEndpointIT {
+public class SpringBoot20RestEndpointIT {
 
     @Test
     public void testSpringRestBootEndpoint() throws Exception {
+
         URL requestUrl = new URL("http://localhost:9080/spring/");
         HttpURLConnection conn = (HttpURLConnection) requestUrl.openConnection();
 

--- a/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-apps-it/src/test/resources/server.xml
+++ b/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-apps-it/src/test/resources/server.xml
@@ -3,8 +3,8 @@
 
 	<!-- Enable features -->
 	<featureManager>
-		<feature>springBoot-1.5</feature>
-		<feature>servlet-3.1</feature>
+		<feature>springBoot-2.0</feature>
+		<feature>servlet-4.0</feature>
 	</featureManager>
 
 	<!-- To access this server from a remote client add a host attribute to 

--- a/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-dropins-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-dropins-it/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.4.RELEASE</version>
+		<version>2.6.7</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	
@@ -32,6 +32,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+                <dependency>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                    <version>4.13.2</version>
+                    <scope>test</scope>
+                </dependency>	
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Part of #1495 

Updated all 2.x tests to latest spring boot version available. Also modified any 1.x test to use the latest 2.x since the 1.x stream is not receiving all the necessary fixes for vulnerabilities.

Will leave that open to reenable the tests once OL contains the fixes that Anjum is working on. Those will hopefully be in 22.0.0.6.