### PR TITLE
Call install feature before deploying app on multi module compile dep…

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -655,6 +655,9 @@ public class DevMojo extends LooseAppSupport {
                             if (generateFeaturesSuccess) {
                                 util.getJavaSourceClassPaths().clear();
                             }
+                            // install new generated features, will not trigger install-feature if the feature list has not changed
+                            util.installFeaturesToTempDir(generatedFeaturesFile, configDirectory, null,
+                                generateFeaturesSuccess);
                         }
                         runLibertyMojoDeploy();
                     }


### PR DESCRIPTION
… change

Calls `install-feature` on build file change to an upstream module. Part of the fix for https://github.com/OpenLiberty/ci.maven/issues/1526

Also see https://github.com/OpenLiberty/ci.maven/pull/1531

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>