### PR TITLE
Compose parameters for binary scanner from umbrella version numbers in build file

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>io.openliberty.tools</groupId>
             <artifactId>ci.common</artifactId>
-            <version>1.8.21</version>
+            <version>1.8.22-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.twdata.maven</groupId>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
@@ -80,6 +80,8 @@
         <type>esa</type>
         <scope>provided</scope>
     </dependency>
+    <!-- Umbrella dependency replace 1 -->
+    <!-- Umbrella dependency replace 2 -->
     <!-- <dependency>
         <groupId>io.openliberty.features</groupId>
         <artifactId>mpHealth-1.0</artifactId>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/war/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>9.0.0</version>
+            <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/war/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>9.0.0</version>
+            <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>9.0.0</version>
+            <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>9.0.0</version>
+            <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
@@ -178,9 +178,10 @@ public class BaseDevTest {
          assertTrue(getLogTail(), verifyLogMessageExists("CWWKF0011I", 120000));
          if (isDevMode) {
             assertTrue(verifyLogMessageExists("Liberty is running in dev mode.", 60000));
-            // Can't start testing until compilation is complete if needed.
-            verifyLogMessageExists("Source compilation was successful.", 5000);
-            Thread.sleep(2000); // wait for dev mode to registere all directories
+            // TODO: Enable this code once issue 1554 is fixed
+            // // Can't start testing until compilation is complete if needed.
+            // verifyLogMessageExists("Source compilation was successful.", 5000);
+            // Thread.sleep(2000); // wait for dev mode to register all directories
          }
 
          // verify that the target directory was created

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
@@ -75,6 +75,8 @@ public class BaseDevTest {
    final static String SERVER_NOT_UPDATED = "CWWKG0018I: The server configuration was not updated.";
    final static String COMPILATION_SUCCESSFUL = "Source compilation was successful.";
    final static String COMPILATION_ERRORS = "Source compilation had errors.";
+   final static String INVALID_EE_VERSION_MSG = "The Java EE or Jakarta EE version number specified in the build file is not supported for feature generation";
+   final static String INVALID_MP_VERSION_MSG = "The MicroProfile version number specified in the build file is not supported for feature generation";
 
    protected static void setUpBeforeClass(String devModeParams) throws IOException, InterruptedException, FileNotFoundException {
    	setUpBeforeClass(devModeParams, "../resources/basic-dev-project");
@@ -176,6 +178,9 @@ public class BaseDevTest {
          assertTrue(getLogTail(), verifyLogMessageExists("CWWKF0011I", 120000));
          if (isDevMode) {
             assertTrue(verifyLogMessageExists("Liberty is running in dev mode.", 60000));
+            // Can't start testing until compilation is complete if needed.
+            verifyLogMessageExists("Source compilation was successful.", 5000);
+            Thread.sleep(2000); // wait for dev mode to registere all directories
          }
 
          // verify that the target directory was created

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
@@ -136,6 +136,7 @@ public class DevTest extends BaseDevTest {
    @Test
    public void testDirectoryTest() throws Exception {
       tagLog("##testDirectoryTest start");
+      Thread.sleep(500); // this test often fails, wait for dev mode
       // create the test directory
       File testDir = new File(tempProj, "src/test/java");
       assertTrue(testDir.mkdirs());
@@ -343,6 +344,59 @@ public class DevTest extends BaseDevTest {
       assertTrue(verifyLogMessageExists(SERVER_UPDATE_COMPLETE, 10000, serverUpdateCount+1));
       // Need to ensure server finished updating before the next test starts.
       tagLog("##generateFeatureTest end");
+   }
+
+   @Test
+   public void scannerInvalidEETest() throws Exception {
+      tagLog("##scannerInvalidEETest start");
+      String placeholder1 = "<!-- Umbrella dependency replace 1 -->";
+      String badDep = "<dependency>\n" +
+         "        <groupId>jakarta.platform</groupId>\n" +
+         "        <artifactId>jakarta.jakartaee-api</artifactId>\n" +
+         "        <version>99.0.0</version>\n" +
+         "        <scope>provided</scope>\n" +
+         "    </dependency>\n";
+
+      try {
+         int msgCount = countOccurrences(INVALID_EE_VERSION_MSG, logFile);
+         replaceString(placeholder1, badDep, pom);
+         assertTrue(verifyLogMessageExists(INVALID_EE_VERSION_MSG, 9000, logFile, ++msgCount));
+      } finally {
+         // restore pom
+         replaceString(badDep, placeholder1, pom);
+      }
+      int systemUpdateCount = countOccurrences(SERVER_CONFIG_SUCCESS, logFile);
+      replaceString(badDep, placeholder1, pom);
+      assertTrue(verifyLogMessageExists(SERVER_CONFIG_SUCCESS, 9000, logFile, ++systemUpdateCount));
+
+      tagLog("##scannerInvalidEETest end");
+   }
+
+   @Test
+   public void scannerInvalidMPTest() throws Exception {
+      tagLog("##scannerInvalidMPTest start");
+      String placeholder2 = "<!-- Umbrella dependency replace 2 -->";
+      String badDep = "<dependency>\n" +
+         "        <groupId>org.eclipse.microprofile</groupId>\n" +
+         "        <artifactId>microprofile</artifactId>\n" +
+         "        <version>99.0</version>\n" +
+         "        <scope>provided</scope>\n" +
+         "        <type>pom</type>\n" +
+         "    </dependency>\n";
+
+      try {
+         int msgCount = countOccurrences(INVALID_MP_VERSION_MSG, logFile);
+         replaceString(placeholder2, badDep, pom);
+         assertTrue(verifyLogMessageExists(INVALID_MP_VERSION_MSG, 9000, logFile, ++msgCount));
+      } finally {
+         // restore pom
+         replaceString(badDep, placeholder2, pom);
+      }
+      int systemUpdateCount = countOccurrences(SERVER_CONFIG_SUCCESS, logFile);
+      replaceString(badDep, placeholder2, pom);
+      assertTrue(verifyLogMessageExists(SERVER_CONFIG_SUCCESS, 9000, logFile, ++systemUpdateCount));
+
+      tagLog("##scannerInvalidMPTest end");
    }
 
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
@@ -349,6 +349,8 @@ public class DevTest extends BaseDevTest {
    @Test
    public void scannerInvalidEETest() throws Exception {
       tagLog("##scannerInvalidEETest start");
+      // TODO: Remove this code once issue 1554 is fixed
+      Thread.sleep(11500); // wait for devmode to complete start-up if this is the first test case
       String placeholder1 = "<!-- Umbrella dependency replace 1 -->";
       String badDep = "<dependency>\n" +
          "        <groupId>jakarta.platform</groupId>\n" +
@@ -375,6 +377,8 @@ public class DevTest extends BaseDevTest {
    @Test
    public void scannerInvalidMPTest() throws Exception {
       tagLog("##scannerInvalidMPTest start");
+      // TODO: Remove this code once issue 1554 is fixed
+      Thread.sleep(11500); // wait for devmode to complete start-up if this is the first test case
       String placeholder2 = "<!-- Umbrella dependency replace 2 -->";
       String badDep = "<dependency>\n" +
          "        <groupId>org.eclipse.microprofile</groupId>\n" +

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeITest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright IBM Corporation 2021.
+ * (c) Copyright IBM Corporation 2021, 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,16 +51,14 @@ public class MultiModuleTypeITest extends BaseMultiModuleTest {
 
       // add a dependency to parent pom and check that it resolves compile errors in
       // child modules
-      int appUpdatedCount = countOccurrences("CWWKZ0003I:", logFile);
       File parentPom = new File(tempProj, "parent/pom.xml");
       assertTrue(parentPom.exists());
       replaceString("<!-- SUB JUNIT -->",
             "<dependency> <groupId>org.junit.jupiter</groupId> <artifactId>junit-jupiter</artifactId> <version>5.6.2</version> <scope>test</scope> </dependency>",
             parentPom);
       // wait for compilation
-      assertTrue(getLogTail(), verifyLogMessageExists("CWWKZ0003I:", 6000, logFile, ++appUpdatedCount));
+      assertTrue(getLogTail(), verifyLogMessageExists("guide-maven-multimodules-ear tests compilation was successful.", 6000, logFile));
       assertTrue(getLogTail(), verifyFileExists(targetEarClass, 10000));
-
 
       super.manualTestsInvocation("guide-maven-multimodules-jar", "guide-maven-multimodules-war",
             "guide-maven-multimodules-ear");

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -461,7 +461,7 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
                     if (ver != null) {
                         eeVersionsDetected.add(ver);
                     } else {
-                        // EE version out of range, add max possible verison
+                        // EE version out of range, add max possible version
                         eeVersionsDetected.add(BINARY_SCANNER_UMBRELLA_DEP_MAXV);
                     }
                 } catch (NoUmbrellaDependencyException e) {
@@ -499,8 +499,7 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
      * will return the first EE umbrella dependency version detected.
      * 
      * @param project the MavenProject to search
-     * @return EE major version corresponding to the EE umbrella dependency, null if
-     *         an EE umbrella dependency is out of range
+     * @return EE major version corresponding to the EE umbrella dependency
      * @throws NoUmbrellaDependencyException indicates that the umbrella dependency was not found
      */
     private String getEEVersion(MavenProject project) throws NoUmbrellaDependencyException {
@@ -511,24 +510,13 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
                     continue;
                 }
                 if (d.getGroupId().equals("javax") && d.getArtifactId().equals("javaee-api")) {
-                    if (d.getVersion().startsWith("8.")) {
-                        return BINARY_SCANNER_EEV8;
-                    } else if (d.getVersion().startsWith("7.")) {
-                        return BINARY_SCANNER_EEV7;
-                    } else if (d.getVersion().startsWith("6.")) {
-                        return BINARY_SCANNER_EEV6;
-                    }
+                    return composeEEVersion(d.getVersion());
                 } else if (d.getGroupId().equals("jakarta.platform") &&
                         d.getArtifactId().equals("jakarta.jakartaee-api")) {
-                    if (d.getVersion().startsWith("8.")) {
-                        return BINARY_SCANNER_EEV8;
-                    } else {
-                        return null;
-                    }
+                    return composeEEVersion(d.getVersion());
                 }
             }
         }
-
         throw new NoUmbrellaDependencyException();
     }
 
@@ -583,14 +571,11 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
 
     /**
      * Returns the MicroProfile (MP) version detected for the given MavenProject
-     * First check for versions the binary scanner supports e.g. '3.3'.
-     * If a supported version is not found attempt to detect the major version digit.
      * To match the Maven "nearest in the dependency tree" strategy, this method
      * will return the first MP umbrella dependency version detected.
      * 
      * @param project the MavenProject to search
-     * @return MP exact version code or major version number code corresponding to
-     *         the MP umbrella dependency, null if the version number is out of range
+     * @return MP exact version code corresponding to the MP umbrella dependency
      * @throws NoUmbrellaDependencyException indicates that the umbrella dependency was not found
      */
     public String getMPVersion(MavenProject project) throws NoUmbrellaDependencyException { // figure out correct level of MP from declared dependencies
@@ -602,24 +587,7 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
                 }
                 if (d.getGroupId().equals("org.eclipse.microprofile") &&
                         d.getArtifactId().equals("microprofile")) {
-                    String version = d.getVersion();
-                    if (version.length() == 3) { // version is 'm.n'
-                        String mpVersion = BINARY_SCANNER_MP.get(version);
-                        if (mpVersion != null) {
-                            return mpVersion;
-                        }
-                    }
-                    // Specified version is not explicitly supported by the binary scanner
-                    if (version.startsWith("1")) {
-                        return BINARY_SCANNER_MPV1;
-                    } else if (version.startsWith("2")) {
-                        return BINARY_SCANNER_MPV2;
-                    } else if (version.startsWith("3")) {
-                        return BINARY_SCANNER_MPV3;
-                    } else if (version.startsWith("4")) {
-                        return BINARY_SCANNER_MPV4;
-                    }
-                    return null;
+                    return composeMPVersion(d.getVersion());
                 }
             }
         }


### PR DESCRIPTION
Use the facility added in BinaryScannerUtil to create a version number parameter from the value in the pom.xml build file. Add automated tests for the new message.

Also numerous fixes to the tests. Now that EE9 is accepted we need to ensure the value in the pom of a test matches the code. In one case we must wait for a different message.