### PR TITLE
Add `:` prefix to artifactId in liberty:dev sample command

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -59,7 +59,7 @@ $ mvn liberty:dev
 ```
 
 Liberty server configuration files (such as `server.xml`) will be used from the module that does not have any other modules depending on it.  If there is more than one module without other modules depending on it, specify which module with Liberty configuration that you want to use by including the parameters `-pl :<module-with-liberty-config-artifact-id> -am`.  
-For example, to use Liberty configuration from a module named `ear`, run:
+For example, to use Liberty configuration from a module with artifact id `ear`, run:
 ```
 $ mvn liberty:dev -pl :ear -am
 ```

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -61,7 +61,7 @@ $ mvn liberty:dev
 Liberty server configuration files (such as `server.xml`) will be used from the module that does not have any other modules depending on it.  If there is more than one module without other modules depending on it, specify which module with Liberty configuration that you want to use by including the parameters `-pl <module-with-liberty-config> -am`.  
 For example, to use Liberty configuration from a module named `ear`, run:
 ```
-$ mvn liberty:dev -pl ear -am
+$ mvn liberty:dev -pl :ear -am
 ```
 
 ###### Examples

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -58,7 +58,7 @@ To start dev mode on a multi module project by using the short-form `liberty` na
 $ mvn liberty:dev
 ```
 
-Liberty server configuration files (such as `server.xml`) will be used from the module that does not have any other modules depending on it.  If there is more than one module without other modules depending on it, specify which module with Liberty configuration that you want to use by including the parameters `-pl <module-with-liberty-config> -am`.  
+Liberty server configuration files (such as `server.xml`) will be used from the module that does not have any other modules depending on it.  If there is more than one module without other modules depending on it, specify which module with Liberty configuration that you want to use by including the parameters `-pl :<module-with-liberty-config-artifact-id> -am`.  
 For example, to use Liberty configuration from a module named `ear`, run:
 ```
 $ mvn liberty:dev -pl :ear -am

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -64,6 +64,8 @@ For example, to use Liberty configuration from a module named `ear`, run:
 $ mvn liberty:dev -pl :ear -am
 ```
 
+More details on the `--projects` flag (`-pl` for short) can be found at https://maven.apache.org/guides/mini/guide-multiple-modules-4.html#inclusion-and-exclusion.
+
 ###### Examples
 
 The examples below apply regardless of whether you are using a single module or multi module project.  


### PR DESCRIPTION
I'm not certain that this is always needed, but it was needed in my case.