### PR TITLE
Associate (possibly empty) build output dir (target/classes) with upstream projects rather than local m2 repository

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
@@ -48,7 +48,10 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 
 public class BaseDevTest {
 
@@ -501,4 +504,14 @@ public class BaseDevTest {
       writer.write(line + "\n");
       writer.flush();
    }
+
+    @Rule
+    public TestWatcher watchman = new TestWatcher() {
+        @Override
+        protected void failed(Throwable thr, Description description) {
+            try {
+                System.out.println("Failure log in " + logFile + ", tail of contents = " + getLogTail(logFile));
+            } catch (IOException e) {}
+        }
+    };
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleM2InstalledTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleM2InstalledTest.java
@@ -37,7 +37,7 @@ public class MultiModuleM2InstalledTest extends BaseMultiModuleTest {
    }
 
    @Test
-   public void purgeLocallyInstalledModule_DevMode_Test() throws Exception {
+   public void purgeUpstreamSourcePart_DevMode_Test() throws Exception {
 
       // install everything to m2
       runCommand("mvn install");
@@ -57,8 +57,7 @@ public class MultiModuleM2InstalledTest extends BaseMultiModuleTest {
       // i.e. it should not find the jar dependency from m2
       startProcess(null, true, "mvn io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":", false);
       
-      // TODO when https://github.com/OpenLiberty/ci.maven/issues/1203 is fixed, check for compilation error instead
-      assertTrue(getLogTail(logFile), verifyLogMessageExists("Could not resolve dependencies for project", 5000));
+      assertTrue(getLogTail(logFile), verifyLogMessageExists("package io.openliberty.guides.multimodules.lib does not exist", 25000));
       
       assertFalse(getLogTail(logFile), targetClass.exists());
    }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunM2InstalledTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunM2InstalledTest.java
@@ -37,7 +37,7 @@ public class MultiModuleRunM2InstalledTest extends BaseMultiModuleTest {
    }
 
    @Test
-   public void purgeLocallyInstalledModule_LibertyRun_Test() throws Exception {
+   public void purgeUpstreamSourcePart_LibertyRun_Test() throws Exception {
 
       // install everything to m2
       runCommand("mvn install");
@@ -57,8 +57,7 @@ public class MultiModuleRunM2InstalledTest extends BaseMultiModuleTest {
       // i.e. it should not find the jar dependency from m2
       startProcess(null, false, "mvn io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":", false);
       
-      // TODO when https://github.com/OpenLiberty/ci.maven/issues/1203 is fixed, check for compilation error instead
-      assertTrue(getLogTail(logFile), verifyLogMessageExists("Could not resolve dependencies for project", 5000));
+      assertTrue(getLogTail(logFile), verifyLogMessageExists("package io.openliberty.guides.multimodules.lib does not exist", 25000));
       
       assertFalse(getLogTail(logFile), targetClass.exists());
    }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -260,7 +260,7 @@ public class DevMojo extends LooseAppSupport {
     }
 
     protected List<File> getResourceDirectories(MavenProject project, File outputDir) {
-    	// Let's just add resources directories unconditionally, the dev util already checks the directories actually exist
+        // Let's just add resources directories unconditionally, the dev util already checks the directories actually exist
         // before adding them to the watch list.   If we avoid checking here we allow for creating them later on.
         List<File> resourceDirs = new ArrayList<File>();
         for (Resource resource : project.getResources()) {
@@ -740,39 +740,39 @@ public class DevMojo extends LooseAppSupport {
 
         @Override
         protected void updateLooseApp() throws PluginExecutionException {
-        	// Only perform operations if we are a war type application
-        	if (project.getPackaging().equals("war")) {
-		    	// Check if we are using an exploded loose app
-		    	if (LooseWarApplication.isExploded(project)) {
-		    		if (!isExplodedLooseWarApp) {
-		    			// The project was previously running with a "non-exploded" loose app.
-		    			// Update this flag and redeploy as an exploded loose app.
-		    			isExplodedLooseWarApp = true;
-		    			
-		    			// Validate maven-war-plugin version
-		    			Plugin warPlugin = getPlugin("org.apache.maven.plugins", "maven-war-plugin");
-		            	if (!validatePluginVersion(warPlugin.getVersion(), "3.3.1")) {
-		            		log.warn("Exploded WAR functionality is enabled. Please use maven-war-plugin version 3.3.1 or greater for best results.");
-		            	}
-		            	
-		    			redeployApp();
-		    		} else {
-		    			try {
-		    				runExplodedMojo();
-		    			} catch (MojoExecutionException e) {
-		    				log.error("Failed to run war:exploded goal", e);
-		    			}
-		    		}
-		    	} else {
-		    		if (isExplodedLooseWarApp) {
-		    			// Dev mode was previously running with an exploded loose war app. The app
-		    			// must have been updated to remove any exploded war capabilities 
-		    			// (filtering, overlay, etc). Update this flag and redeploy.
-		    			isExplodedLooseWarApp = false;
-		    			redeployApp();
-		    		}
-		    	}
-        	}
+            // Only perform operations if we are a war type application
+            if (project.getPackaging().equals("war")) {
+                // Check if we are using an exploded loose app
+                if (LooseWarApplication.isExploded(project)) {
+                    if (!isExplodedLooseWarApp) {
+                        // The project was previously running with a "non-exploded" loose app.
+                        // Update this flag and redeploy as an exploded loose app.
+                        isExplodedLooseWarApp = true;
+                        
+                        // Validate maven-war-plugin version
+                        Plugin warPlugin = getPlugin("org.apache.maven.plugins", "maven-war-plugin");
+                        if (!validatePluginVersion(warPlugin.getVersion(), "3.3.1")) {
+                            log.warn("Exploded WAR functionality is enabled. Please use maven-war-plugin version 3.3.1 or greater for best results.");
+                        }
+                        
+                        redeployApp();
+                    } else {
+                        try {
+                            runExplodedMojo();
+                        } catch (MojoExecutionException e) {
+                            log.error("Failed to run war:exploded goal", e);
+                        }
+                    }
+                } else {
+                    if (isExplodedLooseWarApp) {
+                        // Dev mode was previously running with an exploded loose war app. The app
+                        // must have been updated to remove any exploded war capabilities 
+                        // (filtering, overlay, etc). Update this flag and redeploy.
+                        isExplodedLooseWarApp = false;
+                        redeployApp();
+                    }
+                }
+            }
         }
 
         @Override
@@ -789,7 +789,7 @@ public class DevMojo extends LooseAppSupport {
 
         @Override
         protected void resourceModifiedOrCreated(File fileChanged, File resourceParent, File outputDirectory) throws IOException {
-        	if (project.getPackaging().equals("war") && LooseWarApplication.isExploded(project)) {
+            if (project.getPackaging().equals("war") && LooseWarApplication.isExploded(project)) {
                 try {
                     runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
                     runExplodedMojo();
@@ -1320,10 +1320,10 @@ public class DevMojo extends LooseAppSupport {
         
             // Validate maven-war-plugin version
             if (isExplodedLooseWarApp) {
-        	    Plugin warPlugin = getPlugin("org.apache.maven.plugins", "maven-war-plugin");
-        	    if (!validatePluginVersion(warPlugin.getVersion(), "3.3.2")) {
-        		    log.warn("Exploded WAR functionality is enabled. Please use maven-war-plugin version 3.3.2 or greater for best results.");
-        	    }
+                Plugin warPlugin = getPlugin("org.apache.maven.plugins", "maven-war-plugin");
+                if (!validatePluginVersion(warPlugin.getVersion(), "3.3.2")) {
+                    log.warn("Exploded WAR functionality is enabled. Please use maven-war-plugin version 3.3.2 or greater for best results.");
+                }
             }
         }
         

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -15,6 +15,8 @@
  */
 package io.openliberty.tools.maven.server;
 
+import java.io.File;
+import java.nio.file.Paths;
 import java.util.List;
 
 import org.apache.maven.execution.ProjectDependencyGraph;
@@ -77,17 +79,14 @@ public class RunServerMojo extends PluginConfigSupport {
             runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
 
             if (hasDownstreamProjects && looseApplication) {
-                installEmptyEarIfNotFound(project);
+                getOrCreateEarArtifact(project);
             }
         } else if (projectPackaging.equals("pom")) {
             log.debug("Skipping compile/resources on module with pom packaging type");
         } else {
-            if (hasDownstreamProjects && looseApplication) {
-                purgeLocalRepositoryArtifact();
-            }
-            
             runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
             runMojo("org.apache.maven.plugins", "maven-compiler-plugin", "compile");
+            updateArtifactPathToOutputDirectory(project);
         }
 
         if (!looseApplication) {


### PR DESCRIPTION
…ile because compilation wasn't done

Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Fixes #1569 (or at least starts the effort).

