### PR TITLE
dev-it fix with some dependency upgrades

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -71,10 +71,6 @@ jobs:
     # Run tests
     - name: Run tests
       run: mvn verify -Ponline-its -D"invoker.streamLogs"=true -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
-    # Additionally run dev-it if not Java 17
-    - name: Run dev-it tests
-      if: ${{ matrix.java != 17 }}
-      run: mvn verify -Ponline-its -Dinvoker.test="dev-it" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
 
 # WINDOWS BUILD
   build-windows:
@@ -129,8 +125,3 @@ jobs:
     - name: Run tests
       working-directory: C:/ci.maven
       run: mvn verify -Ponline-its -D"invoker.streamLogs"=true -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
-    # Additionally run dev-it if not Java 17
-    # - name: Run dev-it tests
-    #   working-directory: C:/ci.maven
-    #   if: ${{ matrix.java != 17 }}
-    #   run: mvn verify -Ponline-its -D"invoker.test"="dev-it" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -214,21 +214,6 @@
                 <runtimeKernelId>wlp-kernel</runtimeKernelId>
                 <runtimeVersion>${runtimeVersion}</runtimeVersion>
             </properties>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-invoker-plugin</artifactId>
-                            <configuration>
-                                <pomExcludes>
-                                    <pomExclude>dev-it/pom.xml</pomExclude>
-                                </pomExcludes>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
         </profile>
         <profile>
             <id>ol-its</id>
@@ -253,7 +238,6 @@
                             <artifactId>maven-invoker-plugin</artifactId>
                             <configuration>
                                 <pomExcludes>
-                                    <pomExclude>dev-it/pom.xml</pomExclude>
                                     <pomExclude>server-config-props-it/pom.xml</pomExclude>
                                     <pomExclude>basic-it/pom.xml</pomExclude>
                                     <pomExclude>assembly-it/pom.xml</pomExclude>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear1/pom.xml
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear2/pom.xml
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/jar/pom.xml
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
             </plugin>
         </plugins>
     </build>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/war/pom.xml
@@ -67,13 +67,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
             </plugin>
             <!-- Surefire plugin to run unit tests --> 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
             </plugin>
         </plugins>
     </build>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/ear/pom.xml
@@ -95,7 +95,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/jar/pom.xml
@@ -39,7 +39,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
             </plugin>
 
             <plugin>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/war/pom.xml
@@ -60,13 +60,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
             </plugin>
             <!-- Surefire plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
             </plugin>
 
             <plugin>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/jar/pom.xml
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
             </plugin>
         </plugins>
     </build>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/pom.xml
@@ -67,13 +67,21 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
             </plugin>
             <!-- Surefire plugin to run unit tests --> 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.2</version>
+                <configuration>
+                    <packagingExcludes>pom.xml</packagingExcludes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
@@ -108,7 +108,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/ear/pom.xml
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
@@ -129,7 +129,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
@@ -84,7 +84,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/war/pom.xml
@@ -51,4 +51,17 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.2</version>
+                <configuration>
+                    <packagingExcludes>pom.xml</packagingExcludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/pom.xml
@@ -92,7 +92,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/ear/pom.xml
@@ -92,7 +92,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
@@ -91,7 +91,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/pom.xml
@@ -113,7 +113,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/pom.xml
@@ -113,7 +113,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/pom/pom.xml
@@ -77,7 +77,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>


### PR DESCRIPTION
- maven failsafe/surefire plugin upgrade from 2.22.2 -> 3.0.0-M7
- explicitly add war plugin 3.2.2 to dev-it multimodules, typeA and typeH, which otherwise use 2.2