### PR TITLE
Revert "Copy springBoot application to devc hidden folder in container mode"

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojo.java
@@ -120,16 +120,11 @@ public class DeployMojo extends DeployMojoSupport {
         String appsDirName = getAppsDirectory();
         File archiveTarget = null;
         File appsDir = null;
-        File rootDirectory = serverDirectory;
-        
-        if (project.getProperties().containsKey("container")) {
-            rootDirectory = new File(project.getBuild().getDirectory(), DevUtil.DEVC_HIDDEN_FOLDER);
-        }
         
         if("apps".equals(appsDirName)){
-            appsDir = new File(rootDirectory, appsDirName);        
+            appsDir = new File(serverDirectory, appsDirName);        
         } else if ("dropins".equals(appsDirName)) {
-            appsDir = new File(rootDirectory, appsDirName+"/spring");         
+            appsDir = new File(serverDirectory, appsDirName+"/spring");         
         }       
         archiveTarget = new File(appsDir, "thin-" + archiveSrc.getName());
         return archiveTarget;


### PR DESCRIPTION
Reverts OpenLiberty/ci.maven#1576

After further internal discussion, we determined that this change is not warranted. The `devc` container mode requires that loose application is enabled. But Spring Boot JAR applications are not supported as loose applications. 

There is an open [issue](https://github.com/OpenLiberty/ci.maven/issues/1144) to address supporting SpringBoot JARs in `dev` and `devc` mode. And there is discussion [here](https://github.com/OpenLiberty/ci.maven/issues/1143) on how to run Spring Boot apps in dev mode.