### PR TITLE
Restructure multiline replacements and use EE8 in umbrella tests.

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -214,6 +214,21 @@
                 <runtimeKernelId>wlp-kernel</runtimeKernelId>
                 <runtimeVersion>${runtimeVersion}</runtimeVersion>
             </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-invoker-plugin</artifactId>
+                            <configuration>
+                                <pomExcludes>
+                                    <pomExclude>binary-scanner-it/pom.xml</pomExclude>
+                                </pomExcludes>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
         <profile>
             <id>ol-its</id>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/pom.xml
@@ -63,7 +63,7 @@
                         <mavenPluginVersion>@pom.version@</mavenPluginVersion>
                         <runtimeVersion>${runtimeVersion}</runtimeVersion>
                         <!-- Scanner version e.g. 22.0.0.3 or 22.0.0.3-SNAPSHOT -->
-                        <scannerVersion>22.0.0.4-SNAPSHOT</scannerVersion>
+                        <scannerVersion>22.0.0.3-SNAPSHOT</scannerVersion>
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/pom.xml
@@ -63,7 +63,7 @@
                         <mavenPluginVersion>@pom.version@</mavenPluginVersion>
                         <runtimeVersion>${runtimeVersion}</runtimeVersion>
                         <!-- Scanner version e.g. 22.0.0.3 or 22.0.0.3-SNAPSHOT -->
-                        <scannerVersion>22.0.0.3-SNAPSHOT</scannerVersion>
+                        <scannerVersion>22.0.0.4-SNAPSHOT</scannerVersion>
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project8/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project8/pom.xml
@@ -45,12 +45,15 @@
 
   <dependencies>
     <!-- Umbrella features -->
+    <!-- Jakarta dependency start -->
     <dependency>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakarta.jakartaee-api</artifactId>
         <version>8.0.0</version>
         <scope>provided</scope>
     </dependency>
+    <!-- Jakarta dependency end -->
+    <!-- MicroProfile dependency start -->
     <dependency>
         <groupId>org.eclipse.microprofile</groupId>
         <artifactId>microprofile</artifactId>
@@ -58,6 +61,7 @@
         <type>pom</type>
         <scope>provided</scope>
     </dependency>
+    <!-- MicroProfile dependency end -->
     <!-- For tests -->
     <dependency>
       <groupId>junit</groupId>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/run-binary-scanner-it
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/run-binary-scanner-it
@@ -1,0 +1,13 @@
+# Manually cd to ci.maven to start
+# Edit liberty-maven-plugin/src/it/binary-scanner-it/pom.xml and add the version of
+# binary scanner you expect in <scannerVersion>.
+# Execute liberty-maven-plugin/src/it/binary-scanner-it/run-binary-scanner-it
+cd liberty-maven-plugin/
+cp src/it/binary-scanner-it/pom.xml /tmp
+for i in 3.6 3.6.1 3.6.2-SNAPSHOT
+do
+sed "s/@pom.version@/$i/g" </tmp/pom.xml >src/it/binary-scanner-it/pom.xml
+mvn install verify -Ponline-its -Dinvoker.streamLogs=true -Druntime=ol -DruntimeVersion=22.0.0.6 -Dinvoker.test=binary-scanner-it
+read j
+done
+cp /tmp/pom.xml src/it/binary-scanner-it/pom.xml

--- a/liberty-maven-plugin/src/it/binary-scanner-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseScannerTest.java
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseScannerTest.java
@@ -73,63 +73,33 @@ public class BaseScannerTest {
     static final String GENERATED_FEATURES_FILE_PATH = "/src/main/liberty/config/configDropins/overrides/" + GENERATED_FEATURES_FILE_NAME;
     static final String TARGET_EE_NULL = "targetJavaEE: null";
     static final String TARGET_MP_NULL = "targetMicroP: null";
-    static final String JEE9_UMBRELLA = "<dependency>\n" +
-        "        <groupId>jakarta.platform</groupId>\n" +
-        "        <artifactId>jakarta.jakartaee-api</artifactId>\n" +
-        "        <version>9.1.0</version>\n" +
-        "        <scope>provided</scope>\n" +
-        "    </dependency>";
-    static final String JEE8_UMBRELLA = "<dependency>\n" +
-        "        <groupId>jakarta.platform</groupId>\n" +
-        "        <artifactId>jakarta.jakartaee-api</artifactId>\n" +
-        "        <version>8.0.0</version>\n" +
-        "        <scope>provided</scope>\n" +
-        "    </dependency>";
     static final String EE8_UMBRELLA = "<dependency>\n" +
         "        <groupId>javax</groupId>\n" +
         "        <artifactId>javaee-api</artifactId>\n" +
         "        <version>8.0</version>\n" +
         "        <scope>provided</scope>\n" +
         "    </dependency>";
-    static final String ESA_JEE9_DEPENDENCY = "<dependency>\n" +
+    static final String ESA_JEE8_DEPENDENCY = "<dependency>\n" +
         "        <groupId>io.openliberty.features</groupId>\n" +
-        "        <artifactId>servlet-5.0</artifactId>\n" +
+        "        <artifactId>servlet-4.0</artifactId>\n" +
         "        <type>esa</type>\n" +
         "        <scope>provided</scope>\n" +
         "    </dependency>\n" +
         "    <dependency>\n" +
         "        <groupId>io.openliberty.features</groupId>\n" +
-        "        <artifactId>restfulWS-3.0</artifactId>\n" +
+        "        <artifactId>jaxrs-2.1</artifactId>\n" +
         "        <type>esa</type>\n" +
         "        <scope>provided</scope>\n" +
         "    </dependency>";
     // Dependency declared in basic-dev-project7
-    static final String MP1_UMBRELLA = "<dependency>\n" +
-        "        <groupId>org.eclipse.microprofile</groupId>\n" +
-        "        <artifactId>microprofile</artifactId>\n" +
-        "        <version>1.4</version>\n" +
-        "        <type>pom</type>\n" +
-        "        <scope>provided</scope>\n" +
-        "    </dependency>";
+    static final String MP1_UMBRELLA = "<version>1.4</version>";
     // Dependency declared in basic-dev-project8
-    static final String MP4_UMBRELLA = "<dependency>\n" +
-        "        <groupId>org.eclipse.microprofile</groupId>\n" +
-        "        <artifactId>microprofile</artifactId>\n" +
-        "        <version>4.1</version>\n" +
-        "        <type>pom</type>\n" +
-        "        <scope>provided</scope>\n" +
-        "    </dependency>";
+    static final String MP4_UMBRELLA = "<version>4.1</version>";
     // Dependency declared in basic-dev-project9
-    static final String MP5_UMBRELLA = "<dependency>\n" +
-        "        <groupId>org.eclipse.microprofile</groupId>\n" +
-        "        <artifactId>microprofile</artifactId>\n" +
-        "        <version>5.0</version>\n" +
-        "        <type>pom</type>\n" +
-        "        <scope>provided</scope>\n" +
-        "    </dependency>";
+    static final String MP5_UMBRELLA = "<version>5.0</version>";
     static final String ESA_MP_DEPENDENCY = "<dependency>\n" +
         "        <groupId>io.openliberty.features</groupId>\n" +
-        "        <artifactId>mpHealth-4.0</artifactId>\n" +
+        "        <artifactId>mpHealth-3.0</artifactId>\n" +
         "        <type>esa</type>\n" +
         "        <scope>provided</scope>\n" +
         "    </dependency>";

--- a/liberty-maven-plugin/src/it/binary-scanner-it/src/test/java/net/wasdev/wlp/test/dev/it/ScannerTest.java
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/src/test/java/net/wasdev/wlp/test/dev/it/ScannerTest.java
@@ -201,8 +201,8 @@ public class ScannerTest extends BaseScannerTest {
     }
 
     // TODO FeatureModifiedException
-    // TODO java.lang.IllegalArgumentException - targetJavaEE N.B. tested in DevTest.java
-    // TODO java.lang.IllegalArgumentException - targetMicroProfile N.B. tested in DevTest.java
+    // java.lang.IllegalArgumentException - targetJavaEE N.B. tested in DevTest.java
+    // java.lang.IllegalArgumentException - targetMicroProfile N.B. tested in DevTest.java
 
     /**
      * Test calling the scanner with both the EE umbrella dependency and the MP
@@ -212,6 +212,7 @@ public class ScannerTest extends BaseScannerTest {
      */
     @Test
     public void bothEEMPUmbrellaTest() throws Exception {
+        setUpBeforeTest("../resources/basic-dev-project8");
         runCompileAndGenerateFeatures("-X");
         // Check for "  targetJavaEE: null" in the debug output
         String line = findLogMessage(TARGET_EE_NULL, 3000, logFile);
@@ -229,7 +230,8 @@ public class ScannerTest extends BaseScannerTest {
      */
     @Test
     public void onlyEEUmbrellaTest() throws Exception {
-        replaceString(MP5_UMBRELLA, ESA_MP_DEPENDENCY, pom);
+        setUpBeforeTest("../resources/basic-dev-project8");
+        replaceMicroProfileDependency(ESA_MP_DEPENDENCY, pom);
         runCompileAndGenerateFeatures("-X");
         // Check for "  targetJavaEE: null" in the debug output
         String line = findLogMessage(TARGET_EE_NULL, 3000, logFile);
@@ -247,7 +249,8 @@ public class ScannerTest extends BaseScannerTest {
      */
     @Test
     public void onlyMPUmbrellaTest() throws Exception {
-        replaceString(JEE9_UMBRELLA, ESA_JEE9_DEPENDENCY, pom);
+        setUpBeforeTest("../resources/basic-dev-project8");
+        replaceJakartaDependency(ESA_JEE8_DEPENDENCY, pom);
         runCompileAndGenerateFeatures("-X");
         // Check for "  targetJavaEE: null" in the debug output
         String line = findLogMessage(TARGET_EE_NULL, 3000, logFile);
@@ -265,8 +268,9 @@ public class ScannerTest extends BaseScannerTest {
      */
     @Test
     public void noUmbrellaTest() throws Exception {
-        replaceString(JEE9_UMBRELLA, ESA_JEE9_DEPENDENCY, pom);
-        replaceString(MP5_UMBRELLA, ESA_MP_DEPENDENCY, pom);
+        setUpBeforeTest("../resources/basic-dev-project8");
+        replaceJakartaDependency(ESA_JEE8_DEPENDENCY, pom);
+        replaceMicroProfileDependency(ESA_MP_DEPENDENCY, pom);
         runCompileAndGenerateFeatures("-X");
         // Check for "  targetJavaEE: null" in the debug output
         String line = findLogMessage(TARGET_EE_NULL, 3000, logFile);
@@ -329,7 +333,7 @@ public class ScannerTest extends BaseScannerTest {
         for (String mpVersion : keys) {
             setUpBeforeTest("../resources/basic-dev-project8");
             assertFalse(newFeatureFile.exists());
-            replaceString(JEE8_UMBRELLA, EE8_UMBRELLA, pom); // Revert Jakarta EE 8.0.0 to Java EE 8.0
+            replaceJakartaDependency(EE8_UMBRELLA, pom); // Revert Jakarta EE 8.0.0 to Java EE 8.0
             String oldUmbrella = MP4_UMBRELLA; // for basic-dev-project8
             String newUmbrella = MP4_UMBRELLA.replace("<version>4.1", "<version>" + mpVersion);
             replaceString(oldUmbrella, newUmbrella, pom);
@@ -421,8 +425,16 @@ public class ScannerTest extends BaseScannerTest {
 
     // change MP version in pom file
     protected void modifyMPVersion(String currentVersion, String updatedVersion) throws IOException { 
-        replaceString("<artifactId>microprofile</artifactId>\n" + 
-        "        <version>" + currentVersion + "</version>", "<artifactId>microprofile</artifactId>\n" + 
-        "        <version>" + updatedVersion + "</version>", pom);
+        replaceString("<version>" + currentVersion + "</version>", "<version>" + updatedVersion + "</version>", pom);
+    }
+
+    private void replaceJakartaDependency(String dep, File file) throws IOException {
+        replaceString("<!-- Jakarta dependency start -->", "<!-- Jakarta dependency start", file); // open a comment
+        replaceString("<!-- Jakarta dependency end -->", " Jakarta dependency end -->" + dep, file); // close a comment
+    }
+
+    private void replaceMicroProfileDependency(String dep, File file) throws IOException {
+        replaceString("<!-- MicroProfile dependency start -->", "<!-- MicroProfile dependency start", file); // open a comment
+        replaceString("<!-- MicroProfile dependency end -->", " MicroProfile dependency end -->" + dep, file); // close a comment
     }
 }


### PR DESCRIPTION
Also add script that could be used when running the suite on various plugin versions.