### PR TITLE
[BUILD] remove ANSI output, transfer output; do not trim stack traces and show maven errors.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -64,13 +64,13 @@ jobs:
     - name: Install ci.ant and ci.common
       run: |
         cd ./ci.ant
-        mvn clean install
+        mvn clean install --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false
         cd ../ci.common
-        mvn clean install
+        mvn clean install --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false
         cd ..
     # Run tests
     - name: Run tests
-      run: mvn verify -Ponline-its -D"invoker.streamLogs"=true -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
+      run: mvn verify --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -Ponline-its -D"invoker.streamLogs"=true -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
 
 # WINDOWS BUILD
   build-windows:
@@ -118,10 +118,10 @@ jobs:
     - name: Install ci.ant and ci.common
       run: |
         cd C:/ci.ant
-        mvn clean install
+        mvn clean install --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false
         cd C:/ci.common
-        mvn clean install
+        mvn clean install --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false
     # Run tests
     - name: Run tests
       working-directory: C:/ci.maven
-      run: mvn verify -Ponline-its -D"invoker.streamLogs"=true -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
+      run: mvn verify -Ponline-its --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -D"invoker.streamLogs"=true -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"


### PR DESCRIPTION
It is almost impossible to see the actual maven output on GitHub.

To remedy this, here is what we (Apache Shiro, Apache Maven) use:

* `--batch-mode`: Will remove any coloring or multiline progress (see screenshot for multiline transfer progress, really spams the logs).
* `--no-transfer-progress`: will only report errors if artifact transfer failed. It is really not interesting that on the new build the surefire-plugin was downloaded as always.
* `--errors`: enable error stack traces when maven fails for a reason.
* `-DtrimStackTrace`: Applies to Maven's failsafe and surefire plugin. Stack traces are shortened by default, not revealing the actual cause. For a CI, this setting will not be helpful.


Here's what I am referring to:

![Screenshot 2022-12-12 at 11 04 59](https://user-images.githubusercontent.com/1413391/207018641-95191c5e-9cdf-4694-b092-78f650727e06.png)

Compare to what we do in Apache Shiro. You can see multiple executions on one screen (the same what you would experience locally unless you cleaned your `$HOME/.m2/repository` folder before each build):

![Screenshot 2022-12-12 at 11 09 58](https://user-images.githubusercontent.com/1413391/207019167-79d29b52-3204-4627-b6d2-ee28ab0ff47b.png)
