### PR TITLE
#743 support encoding parameter

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -1574,6 +1574,12 @@ public class DevMojo extends LooseAppSupport {
             compilerOptions.setRelease(release);
         }
 
+        String encoding = getCompilerOption(configuration, "encoding", "project.build.sourceEncoding", currentProject);
+        if (encoding != null) {
+            log.debug("Setting compiler encoding to " + encoding);
+            compilerOptions.setEncoding(encoding);
+        }
+
         return compilerOptions;
     }
 


### PR DESCRIPTION
Solution for issue #743 on ci.maven to support setting the file encoding of the java source files.