### PR TITLE
Issue warning in devc if server is running; it can interfere with validation in early deploy 

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -1251,7 +1251,7 @@ public class DevMojo extends LooseAppSupport {
                         + " is already running. Terminate all instances of the server before starting dev mode."
                         + " You can stop a server instance with the command 'mvn liberty:stop'.");
                 } else {
-                    getLog().warn("Running server detected from previous execution that did not stop cleanly. If startup does not complete and times out do a clean before re-running.");
+                    getLog().warn("Running server detected, which could cause unexpected results. To terminate the local running server, run the command 'mvn liberty:stop'.  Also, the warning may occur because a previous server execution did not stop cleanly, in which case you may want to run 'mvn clean' before re-running");
                 }
             }
         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -1251,7 +1251,7 @@ public class DevMojo extends LooseAppSupport {
                         + " is already running. Terminate all instances of the server before starting dev mode."
                         + " You can stop a server instance with the command 'mvn liberty:stop'.");
                 } else {
-                    log.warn("Running server detected from previous execution that did not stop cleanly. If startup does not complete and times out do a clean before re-running.");
+                    getLog().warn("Running server detected from previous execution that did not stop cleanly. If startup does not complete and times out do a clean before re-running.");
                 }
             }
         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -1244,15 +1244,17 @@ public class DevMojo extends LooseAppSupport {
 
         processContainerParams();
 
-        if (!container) {
-            if (serverDirectory.exists()) {
-                if (ServerStatusUtil.isServerRunning(installDirectory, super.outputDirectory, serverName)) {
+        if (serverDirectory.exists()) {
+            if (ServerStatusUtil.isServerRunning(installDirectory, super.outputDirectory, serverName)) {
+                if (!container) {
                     throw new MojoExecutionException("The server " + serverName
-                            + " is already running. Terminate all instances of the server before starting dev mode."
-                            + " You can stop a server instance with the command 'mvn liberty:stop'.");
+                        + " is already running. Terminate all instances of the server before starting dev mode."
+                        + " You can stop a server instance with the command 'mvn liberty:stop'.");
+                } else {
+                    log.warn("Running server detected from previous execution that did not stop cleanly. If startup does not complete and times out do a clean before re-running.");
                 }
             }
-        } // else TODO check if the container is already running?
+        }
 
         // create an executor for tests with an additional queue of size 1, so
         // any further changes detected mid-test will be in the following run


### PR DESCRIPTION
This is a bit particular a circumstance to recreate...but... 

The devc goal seems to do a special deploy of the devc-specific loose app early in startup.

If you use LMP with non-container goals, e.g. regular dev mode, and you kill the server (don't do a clean stop) before the app deployment completes, and then start **devc**, you can fail with a message 

> [INFO] CWWKM2011E: Timed out searching for CWWKZ0001I.*intro in C:\ydosppa\application-stack-intro\target\liberty\wlp\usr\servers\defaultServer\logs\messages.log.

That's because the deploy goal we call does extra validation if the server is detected as running, and it is detecting this because the server was previously taken down abruptly without cleanup. 

Again, this is a bit hard to recreate because:
* the check to see if the server is running itself is able to cleanup some of the time
* if the app had successfully deployed the validation might pass.

Some ideas to fix this:
1. Issue a warning at the beginning of devc if running server is detected
2. Throw exc and abort if running server is detected in devc (just like we do for **dev** itself)
3. Refactor the call to the deploy goal/mojo a bit to add an extra flag whether to do validation, so we can continue validating during devc once things are up and running, but bypass the validation on the initial deploy.

So 3., seems like too much work for this small window of problem.   

As for 2., this could be the best solution, but it would force cleanup in a set of cases that work just fine today.   

I went with 1., but could be convinced on 2.