### PR TITLE
Remove ant dependency and update exception handling

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/AbstractLibertySupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/AbstractLibertySupport.java
@@ -70,7 +70,6 @@ public abstract class AbstractLibertySupport extends MojoSupport {
     @Parameter(defaultValue = "${settings}", required = true, readonly = true)
     protected Settings settings;
     
-    //@Component(role = AntHelper.class)
     protected AntTaskFactory ant;
     
     @Component
@@ -105,7 +104,6 @@ public abstract class AbstractLibertySupport extends MojoSupport {
     protected void init() throws MojoExecutionException, MojoFailureException {
         super.init();
         // Initialize ant helper instance
-        //ant.setProject(getProject());
         ant = AntTaskFactory.forMavenProject(getProject());
     }
     

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/AbstractLibertySupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/AbstractLibertySupport.java
@@ -35,7 +35,6 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.settings.Settings;
 import org.codehaus.mojo.pluginsupport.MojoSupport;
-import org.codehaus.mojo.pluginsupport.ant.AntHelper;
 import org.codehaus.mojo.pluginsupport.util.ArtifactItem;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -46,6 +45,8 @@ import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResolutionException;
 import org.eclipse.aether.resolution.VersionRangeResult;
+
+import io.openliberty.tools.maven.utils.AntTaskFactory;
 
 import static java.util.Objects.requireNonNull;
 
@@ -69,8 +70,8 @@ public abstract class AbstractLibertySupport extends MojoSupport {
     @Parameter(defaultValue = "${settings}", required = true, readonly = true)
     protected Settings settings;
     
-    @Component(role = AntHelper.class)
-    protected AntHelper ant;
+    //@Component(role = AntHelper.class)
+    protected AntTaskFactory ant;
     
     @Component
     protected RepositorySystem repositorySystem;
@@ -104,7 +105,8 @@ public abstract class AbstractLibertySupport extends MojoSupport {
     protected void init() throws MojoExecutionException, MojoFailureException {
         super.init();
         // Initialize ant helper instance
-        ant.setProject(getProject());
+        //ant.setProject(getProject());
+        ant = AntTaskFactory.forMavenProject(getProject());
     }
     
     protected boolean isReactorMavenProject(Artifact artifact) {
@@ -307,7 +309,7 @@ public abstract class AbstractLibertySupport extends MojoSupport {
                 resolvedDependencies.add(artifact);
                 findTransitiveDependencies(artifact, getProject().getArtifacts(), resolvedDependencies);
             } else {
-                log.warn("Unable to find artifact matching groupId "+ groupId +", artifactId "+artifactId+", version "+version+", type "+type+" and classifier "+classifier+" in configured repositories.");
+                getLog().warn("Unable to find artifact matching groupId "+ groupId +", artifactId "+artifactId+", version "+version+", type "+type+" and classifier "+classifier+" in configured repositories.");
             }
         } else {
             Set<Artifact> artifacts = getProject().getArtifacts();
@@ -341,7 +343,7 @@ public abstract class AbstractLibertySupport extends MojoSupport {
                     }
                     // Ignore test-scoped artifacts, by design
                     if (!"test".equals(projectArtifact.getScope())) {
-                        log.debug("Found resolved dependency from project dependencies: " + projectArtifact.getGroupId() + ":"
+                        getLog().debug("Found resolved dependency from project dependencies: " + projectArtifact.getGroupId() + ":"
                             + projectArtifact.getArtifactId() + ":" + projectArtifact.getVersion());
                         resolvedDependencies.add(projectArtifact);
                         findTransitiveDependencies(projectArtifact, getProject().getArtifacts(), resolvedDependencies);
@@ -359,7 +361,7 @@ public abstract class AbstractLibertySupport extends MojoSupport {
                         Artifact artifact = getArtifact(item);
                         // Ignore test-scoped artifacts, by design
                         if (!"test".equals(artifact.getScope())) {
-                            log.debug("Found resolved dependency from project dependencyManagement " + dependency.getGroupId() + ":"
+                            getLog().debug("Found resolved dependency from project dependencyManagement " + dependency.getGroupId() + ":"
                             + dependency.getArtifactId() + ":" + dependency.getVersion());
                             resolvedDependencies.add(artifact);
                             findTransitiveDependencies(artifact, getProject().getArtifacts(), resolvedDependencies);
@@ -370,7 +372,7 @@ public abstract class AbstractLibertySupport extends MojoSupport {
 
             if (resolvedDependencies.isEmpty()) {
                 // No matching artifacts were found in the resolved dependencies. Send warning.
-                log.warn("Unable to find artifact matching groupId "+ groupId +", artifactId "+artifactId+" of any version in either project dependencies or in project dependencyManagement (note test-scoped dependencies are excluded).");
+                getLog().warn("Unable to find artifact matching groupId "+ groupId +", artifactId "+artifactId+" of any version in either project dependencies or in project dependencyManagement (note test-scoped dependencies are excluded).");
             }
         }
 
@@ -462,7 +464,7 @@ public abstract class AbstractLibertySupport extends MojoSupport {
             if (!artifact.equals(resolvedArtifact) && (!isProvidedScope || isProvidedScopeAllowed)) {
                 List<String> depTrail = artifact.getDependencyTrail();
                 if (dependencyTrailContainsArtifact(coords, resolvedArtifact.getVersion(), depTrail)) {
-                    log.info("Adding transitive dependency with scope: "+artifact.getScope()+" and GAV: "+artifact.getGroupId()+":"+artifact.getArtifactId()+":"+artifact.getVersion());
+                    getLog().info("Adding transitive dependency with scope: "+artifact.getScope()+" and GAV: "+artifact.getGroupId()+":"+artifact.getArtifactId()+":"+artifact.getVersion());
                     resolvedDependencies.add(artifact);
                 }
             }
@@ -515,7 +517,7 @@ public abstract class AbstractLibertySupport extends MojoSupport {
             if (artifact.getGroupId().equals(item.getGroupId()) && 
                 artifact.getArtifactId().equals(item.getArtifactId()) && 
                 artifact.getType().equals(item.getType())) {
-                log.debug("Found ArtifactItem from project dependencies: " + artifact.getGroupId() + ":"
+                    getLog().debug("Found ArtifactItem from project dependencies: " + artifact.getGroupId() + ":"
                         + artifact.getArtifactId() + ":" + artifact.getVersion());
                 // if (!artifact.getVersion().equals(item.getVersion())) {
                 // item.setVersion(artifact.getVersion());
@@ -524,7 +526,7 @@ public abstract class AbstractLibertySupport extends MojoSupport {
             }
         }
         
-        log.debug(item.getGroupId() + ":" + item.getArtifactId() + ":" + item.getVersion()
+        getLog().debug(item.getGroupId() + ":" + item.getArtifactId() + ":" + item.getVersion()
                 + " is not found from project dependencies.");
         return null;
     }
@@ -538,13 +540,13 @@ public abstract class AbstractLibertySupport extends MojoSupport {
                 if (dependency.getGroupId().equals(item.getGroupId()) && 
                     dependency.getArtifactId().equals(item.getArtifactId()) && 
                     dependency.getType().equals(item.getType())) {
-                    log.debug("Found ArtifactItem from project dependencyManagement " + dependency.getGroupId() + ":"
+                        getLog().debug("Found ArtifactItem from project dependencyManagement " + dependency.getGroupId() + ":"
                             + dependency.getArtifactId() + ":" + dependency.getVersion());
                     return dependency;
                 }
             }
         }
-        log.debug(item.getGroupId() + ":" + item.getArtifactId() + ":" + item.getVersion()
+        getLog().debug(item.getGroupId() + ":" + item.getArtifactId() + ":" + item.getVersion()
                 + " is not found from project dependencyManagement.");
         return null;
     }
@@ -570,7 +572,7 @@ public abstract class AbstractLibertySupport extends MojoSupport {
             	artifact.setFile(artifactFile);
             }   
             artifact.setResolved(true);
-            log.debug(item.getGroupId() + ":" + item.getArtifactId() + ":" + item.getVersion()
+            getLog().debug(item.getGroupId() + ":" + item.getArtifactId() + ":" + item.getVersion()
                     + " is resolved from project repositories.");
         } else {
             getLog().warn("Artifact " + item.getGroupId() + ":" + item.getArtifactId() + ":" + item.getVersion()

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/BasicSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/BasicSupport.java
@@ -388,9 +388,9 @@ public class BasicSupport extends AbstractLibertySupport {
 		public void flush() {
 			for (int i = 0; i < msgTypes.size(); i++) {
 				if (msgTypes.get(i) == MessageType.INFO) {
-					log.info(messages.get(i));
+					getLog().info(messages.get(i));
 				} else {
-					log.debug(messages.get(i));
+					getLog().debug(messages.get(i));
 				}
 			}
 			msgTypes.clear();
@@ -414,10 +414,10 @@ public class BasicSupport extends AbstractLibertySupport {
      * 
      * @throws Exception
      */
-    protected void installServerAssembly() throws Exception {
+    protected void installServerAssembly() throws MojoExecutionException, IOException {
         initLog.flush();
         if (installType == InstallType.ALREADY_EXISTS) {
-            log.info(MessageFormat.format(messages.getString("info.install.type.preexisting"), ""));
+            getLog().info(MessageFormat.format(messages.getString("info.install.type.preexisting"), ""));
         } else {
             if (installType == InstallType.FROM_ARCHIVE) {
                 installFromArchive();
@@ -428,7 +428,7 @@ public class BasicSupport extends AbstractLibertySupport {
         }
     }
     
-    protected void installFromFile() throws Exception {
+    protected void installFromFile() throws MojoExecutionException, IOException {
         // Check if there is a different/newer archive or missing marker to trigger assembly install
         File installMarker = new File(installDirectory, ".installed");
 
@@ -436,18 +436,18 @@ public class BasicSupport extends AbstractLibertySupport {
             if (!installMarker.exists()) {
                 refresh = true;
             } else if (assemblyArchive.lastModified() > installMarker.lastModified()) {
-                log.debug(MessageFormat.format(messages.getString("debug.detect.assembly.archive"), ""));
+                getLog().debug(MessageFormat.format(messages.getString("debug.detect.assembly.archive"), ""));
                 refresh = true;
             } else if(!assemblyArchive.getCanonicalPath().equals(FileUtils.fileRead(installMarker))) {
                 refresh = true;
             }
         } else {
-            log.debug(MessageFormat.format(messages.getString("debug.request.refresh"), ""));
+            getLog().debug(MessageFormat.format(messages.getString("debug.request.refresh"), ""));
         }
 
         String userDirectoryPath = userDirectory.getCanonicalPath();
         if (refresh && installDirectory.exists() && installDirectory.isDirectory()) {
-            log.info(MessageFormat.format(messages.getString("info.uninstalling.server.home"), installDirectory));
+            getLog().info(MessageFormat.format(messages.getString("info.uninstalling.server.home"), installDirectory));
             // Delete everything in the install directory except usr directory
             for(File f : installDirectory.listFiles()) {
                 if(!(f.isDirectory() && f.getCanonicalPath().equals(userDirectoryPath))) {
@@ -458,7 +458,7 @@ public class BasicSupport extends AbstractLibertySupport {
 
         // Install the assembly
         if (!installMarker.exists()) {
-            log.info("Installing assembly...");
+            getLog().info("Installing assembly...");
 
             FileUtils.forceMkdir(installDirectory);
 
@@ -483,11 +483,11 @@ public class BasicSupport extends AbstractLibertySupport {
             // Write the assembly archive path so we can determine whether to install a different assembly in future invocations
             FileUtils.fileWrite(installMarker, assemblyArchive.getCanonicalPath());
         } else {
-            log.info(MessageFormat.format(messages.getString("info.reuse.installed.assembly"), ""));
+            getLog().info(MessageFormat.format(messages.getString("info.reuse.installed.assembly"), ""));
         }
     }
 
-    protected void installFromArchive() throws Exception {
+    protected void installFromArchive() throws MojoExecutionException, IOException {
         InstallLibertyTask installTask = (InstallLibertyTask) ant.createTask("antlib:io/openliberty/tools/ant:install-liberty");
         if (installTask == null) {
             throw new IllegalStateException(MessageFormat.format(messages.getString("error.dependencies.not.found"), "install-liberty"));
@@ -540,7 +540,7 @@ public class BasicSupport extends AbstractLibertySupport {
         if (licenseArtifact != null) {
             Artifact license = getArtifact(licenseArtifact);
             if (!hasSameLicense(license)) {
-                log.info(MessageFormat.format(messages.getString("info.install.license"), 
+                getLog().info(MessageFormat.format(messages.getString("info.install.license"), 
                         licenseArtifact.getGroupId() + ":" + licenseArtifact.getArtifactId() + ":" + licenseArtifact.getVersion()));
                 Java installLicenseTask = (Java) ant.createTask("java");
                 installLicenseTask.setJar(license.getFile());
@@ -606,7 +606,7 @@ public class BasicSupport extends AbstractLibertySupport {
         if (license != null) {
             InputStream licenseInfo = getZipEntry(license.getFile(), "wlp/lafiles/LI_en");
             if (licenseInfo == null) {
-                log.warn(MessageFormat.format(messages.getString("warn.install.license"), license.getId()));
+                getLog().warn(MessageFormat.format(messages.getString("warn.install.license"), license.getId()));
                 return sameLicense;
             } 
             
@@ -686,11 +686,11 @@ public class BasicSupport extends AbstractLibertySupport {
             try {
                 return getLibertyDirectoryPropertyFiles(installDirectory, userDirectory, serverDirectory);
             } catch (Exception e) {
-                log.warn("The properties for directories could not be initialized because an error occurred when accessing the directories.");
-                log.debug("Exception received: "+e.getMessage(), (Throwable) e);
+                getLog().warn("The properties for directories could not be initialized because an error occurred when accessing the directories.");
+                getLog().debug("Exception received: "+e.getMessage(), (Throwable) e);
             }
         } else {
-            log.warn("The " + serverDirectory + " directory cannot be accessed. The properties for directories could not be initialized.");
+            getLog().warn("The " + serverDirectory + " directory cannot be accessed. The properties for directories could not be initialized.");
         }
 
         return new HashMap<String,File> ();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/InstallFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/InstallFeatureSupport.java
@@ -57,42 +57,42 @@ public class InstallFeatureSupport extends ServerFeatureSupport {
 
         @Override
         public void debug(String msg) {
-            log.debug(msg);
+            getLog().debug(msg);
         }
         
         @Override
         public void debug(String msg, Throwable e) {
-            log.debug(msg, e);
+            getLog().debug(msg, e);
         }
         
         @Override
         public void debug(Throwable e) {
-            log.debug(e);
+            getLog().debug(e);
         }
         
         @Override
         public void warn(String msg) {
-            log.warn(msg);
+            getLog().warn(msg);
         }
 
         @Override
         public void info(String msg) {
-            log.info(msg);
+            getLog().info(msg);
         }
         
         @Override
         public boolean isDebugEnabled() {
-            return log.isDebugEnabled();
+            return getLog().isDebugEnabled();
         }
 
         @Override
         public void error(String msg) {
-            log.error(msg);
+            getLog().error(msg);
         }
 
         @Override
         public void error(String msg, Throwable e) {
-            log.error(msg, e);
+            getLog().error(msg, e);
         }
         
         @Override
@@ -111,7 +111,7 @@ public class InstallFeatureSupport extends ServerFeatureSupport {
             if ((findEsaFiles && feature.getFeature().endsWith(".esa"))
                     || (!findEsaFiles && !feature.getFeature().endsWith(".esa"))) {
                 result.add(feature.getFeature());
-                log.debug("Plugin listed " + (findEsaFiles ? "ESA" : "feature") + ": " + feature.getFeature());
+                getLog().debug("Plugin listed " + (findEsaFiles ? "ESA" : "feature") + ": " + feature.getFeature());
             }
         }
         return result;
@@ -123,7 +123,7 @@ public class InstallFeatureSupport extends ServerFeatureSupport {
         for (org.apache.maven.model.Dependency dependencyArtifact: dependencyArtifacts){
             if (("esa").equals(dependencyArtifact.getType())) {
                 result.add(dependencyArtifact.getArtifactId());
-                log.debug("Dependency feature: " + dependencyArtifact.getArtifactId());
+                getLog().debug("Dependency feature: " + dependencyArtifact.getArtifactId());
             }
         }
         return result;
@@ -135,7 +135,7 @@ public class InstallFeatureSupport extends ServerFeatureSupport {
         List<String> result = new ArrayList<String>();
         org.apache.maven.model.DependencyManagement dependencyManagement = project.getDependencyManagement();
         if(dependencyManagement == null) {
-        	log.debug("Feature-bom is not provided by the user");
+        	getLog().debug("Feature-bom is not provided by the user");
         	return null;
         }
         List<org.apache.maven.model.Dependency> dependencyManagementArtifacts = dependencyManagement.getDependencies();
@@ -144,7 +144,7 @@ public class InstallFeatureSupport extends ServerFeatureSupport {
                 String coordinate = String.format("%s:%s:%s",
                         dependencyArtifact.getGroupId(), FEATURES_JSON_ARTIFACT_ID, dependencyArtifact.getVersion());
                 result.add(coordinate);
-                log.info("Additional user feature json coordinate: " + coordinate);
+                getLog().info("Additional user feature json coordinate: " + coordinate);
             }
         }
         return result;
@@ -209,16 +209,16 @@ public class InstallFeatureSupport extends ServerFeatureSupport {
         try {
             util = new InstallFeatureMojoUtil(pluginListedEsas, propertiesList, openLibertyVerion, containerName, additionalJsons);
         } catch (PluginScenarioException e) {
-            log.debug(e.getMessage());
+            getLog().debug(e.getMessage());
             if (noFeaturesSection) {
-                log.debug("Skipping feature installation with installUtility because the "
+                getLog().debug("Skipping feature installation with installUtility because the "
                         + "features configuration element with an acceptLicense parameter "
                         + "was not specified for the install-feature goal.");
             } else if(additionalJsons != null && !additionalJsons.isEmpty()) {
-            	log.debug("Skipping feature installation with installUtility because it is not supported for user feature");
+            	getLog().debug("Skipping feature installation with installUtility because it is not supported for user feature");
         	}else {
                 installFromAnt = true;
-                log.debug("Installing features from installUtility.");
+                getLog().debug("Installing features from installUtility.");
             }
         }
     }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/InstallFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/InstallFeatureSupport.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2020, 2021.
+ * (C) Copyright IBM Corporation 2020, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/PrepareFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/PrepareFeatureSupport.java
@@ -37,42 +37,42 @@ public class PrepareFeatureSupport extends BasicSupport {
 
         @Override
         public void debug(String msg) {
-            log.debug(msg);
+            getLog().debug(msg);
         }
         
         @Override
         public void debug(String msg, Throwable e) {
-            log.debug(msg, e);
+            getLog().debug(msg, e);
         }
         
         @Override
         public void debug(Throwable e) {
-            log.debug(e);
+            getLog().debug(e);
         }
         
         @Override
         public void warn(String msg) {
-            log.warn(msg);
+            getLog().warn(msg);
         }
 
         @Override
         public void info(String msg) {
-            log.info(msg);
+            getLog().info(msg);
         }
         
         @Override
         public boolean isDebugEnabled() {
-            return log.isDebugEnabled();
+            return getLog().isDebugEnabled();
         }
 
         @Override
         public void error(String msg) {
-            log.error(msg);
+            getLog().error(msg);
         }
 
         @Override
         public void error(String msg, Throwable e) {
-            log.error(msg, e);
+            getLog().error(msg, e);
         }
         
         @Override
@@ -109,7 +109,7 @@ public class PrepareFeatureSupport extends BasicSupport {
                 	String coordinate = String.format("%s:%s:%s",
                     		dependencyArtifact.getGroupId(), dependencyArtifact.getArtifactId(), dependencyArtifact.getVersion());
                     result.add(coordinate);
-                    log.debug("Dependency BOM: " + coordinate);
+                    getLog().debug("Dependency BOM: " + coordinate);
                 }
             }
         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/PrepareFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/PrepareFeatureSupport.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2021.
+ * (C) Copyright IBM Corporation 2021, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/ServerFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/ServerFeatureSupport.java
@@ -38,28 +38,28 @@ public class ServerFeatureSupport extends BasicSupport {
         @Override
         public void debug(String msg) {
             if (isDebugEnabled()) {
-                log.debug(msg);
+                getLog().debug(msg);
             }
         }
 
         @Override
         public void debug(String msg, Throwable e) {
             if (isDebugEnabled()) {
-                log.debug(msg, e);
+                getLog().debug(msg, e);
             }
         }
 
         @Override
         public void debug(Throwable e) {
             if (isDebugEnabled()) {
-                log.debug(e);
+                getLog().debug(e);
             }
         }
 
         @Override
         public void warn(String msg) {
             if (!suppressLogs) {
-                log.warn(msg);
+                getLog().warn(msg);
             } else {
                 debug(msg);
             }
@@ -68,7 +68,7 @@ public class ServerFeatureSupport extends BasicSupport {
         @Override
         public void info(String msg) {
             if (!suppressLogs) {
-                log.info(msg);
+                getLog().info(msg);
             } else {
                 debug(msg);
             }
@@ -76,17 +76,17 @@ public class ServerFeatureSupport extends BasicSupport {
 
         @Override
         public void error(String msg, Throwable e) {
-            log.error(msg, e);
+            getLog().error(msg, e);
         }
 
         @Override
         public void error(String msg) {
-            log.error(msg);
+            getLog().error(msg);
         }
 
         @Override
         public boolean isDebugEnabled() {
-            return log.isDebugEnabled();
+            return getLog().isDebugEnabled();
         }
     }
 
@@ -214,10 +214,10 @@ public class ServerFeatureSupport extends BasicSupport {
             }
         }
         if (mostDownstreamModule != null && !mostDownstreamModule.equals(project)) {
-            log.debug("Found a previous module in the Reactor build order that does not have downstream dependencies: "
+            getLog().debug("Found a previous module in the Reactor build order that does not have downstream dependencies: "
                     + mostDownstreamModule);
             if (isSubModule(project, mostDownstreamModule)) {
-                log.debug(
+                getLog().debug(
                         "Detected that this multi module pom contains another module that does not have downstream dependencies. Skipping goal on this module.");
                 return true;
             }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojo.java
@@ -32,8 +32,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 
-//import org.apache.tools.ant.taskdefs.Copy;
-
 import io.openliberty.tools.maven.utils.SpringBootUtil;
 import io.openliberty.tools.common.plugins.config.ApplicationXmlDocument;
 import io.openliberty.tools.common.plugins.config.LooseConfigData;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
@@ -280,7 +280,6 @@ public class DeployMojoSupport extends LooseAppSupport {
         if (shouldValidateAppStart()) {
             String appName = appFile.substring(0, appFile.lastIndexOf('.'));
             if (getAppsDirectory().equals("apps")) {
-                ServerConfigDocument scd = null;
 
                 File serverXML = new File(serverDirectory, "server.xml");
 
@@ -288,7 +287,7 @@ public class DeployMojoSupport extends LooseAppSupport {
                     Map<String, File> libertyDirPropertyFiles = getLibertyDirectoryPropertyFiles();
                     CommonLogger logger = CommonLogger.getInstance(log);
                     setLog(logger.getLog());
-                    scd = ServerConfigDocument.getInstance(logger, serverXML, configDirectory,
+                    ServerConfigDocument.getInstance(logger, serverXML, configDirectory,
                             bootstrapPropertiesFile, combinedBootstrapProperties, serverEnvFile, false, libertyDirPropertyFiles);
 
                     //appName will be set to a name derived from appFile if no name can be found.

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/LooseEarApplication.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/LooseEarApplication.java
@@ -31,7 +31,6 @@ import org.w3c.dom.Element;
 import io.openliberty.tools.maven.utils.MavenProjectUtil;
 import io.openliberty.tools.common.plugins.config.LooseApplication;
 import io.openliberty.tools.common.plugins.config.LooseConfigData;
-import io.openliberty.tools.common.plugins.util.PluginScenarioException;
 
 public class LooseEarApplication extends LooseApplication {
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/LooseEarApplication.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/LooseEarApplication.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2017, 2021.
+ * (C) Copyright IBM Corporation 2017, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,22 @@
 package io.openliberty.tools.maven.applications;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.shared.mapping.MappingUtils;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.interpolation.InterpolationException;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.w3c.dom.Element;
 
 import io.openliberty.tools.maven.utils.MavenProjectUtil;
 import io.openliberty.tools.common.plugins.config.LooseApplication;
 import io.openliberty.tools.common.plugins.config.LooseConfigData;
+import io.openliberty.tools.common.plugins.util.PluginScenarioException;
 
 public class LooseEarApplication extends LooseApplication {
 
@@ -39,7 +42,7 @@ public class LooseEarApplication extends LooseApplication {
         this.project = project;
     }
 
-    public void addSourceDir() throws Exception {
+    public void addSourceDir() throws IOException {
         File sourceDir = new File(project.getBasedir(), "src/main/application");
         String path = MavenProjectUtil.getPluginConfiguration(project, "org.apache.maven.plugins", "maven-ear-plugin",
                 "earSourceDirectory");
@@ -49,7 +52,7 @@ public class LooseEarApplication extends LooseApplication {
         config.addDir(sourceDir, "/");
     }
 
-    public void addApplicationXmlFile() throws Exception {
+    public void addApplicationXmlFile() throws IOException {
         File applicationXmlFile = null;
         String path = MavenProjectUtil.getPluginConfiguration(project, "org.apache.maven.plugins", "maven-ear-plugin",
                 "applicationXml");
@@ -65,15 +68,15 @@ public class LooseEarApplication extends LooseApplication {
         }
     }
 
-    public Element addJarModule(MavenProject proj, Artifact artifact) throws Exception {
+    public Element addJarModule(MavenProject proj, Artifact artifact) throws MojoExecutionException, IOException {
         return addModule(proj, artifact, "maven-jar-plugin");
     }
 
-    public Element addEjbModule(MavenProject proj, Artifact artifact) throws Exception {
+    public Element addEjbModule(MavenProject proj, Artifact artifact) throws MojoExecutionException, IOException {
         return addModule(proj, artifact, "maven-ejb-plugin");
     }
 
-    public Element addModule(MavenProject proj, Artifact artifact, String pluginId) throws Exception {
+    public Element addModule(MavenProject proj, Artifact artifact, String pluginId) throws MojoExecutionException, IOException {
         File outputDirectory = new File(proj.getBuild().getOutputDirectory());
         Element moduleArchive = config.addArchive(getModuleUri(artifact));
         config.addDir(moduleArchive, outputDirectory, "/");
@@ -82,13 +85,17 @@ public class LooseEarApplication extends LooseApplication {
 
         String mavenProjectTargetDir = proj.getBuild().getDirectory();
 
-        addManifestFileWithParent(moduleArchive, manifestFile, mavenProjectTargetDir);
-        // add meta-inf files if any
-        addMetaInfFiles(moduleArchive, outputDirectory);
-        return moduleArchive;
+        try {
+            addManifestFileWithParent(moduleArchive, manifestFile, mavenProjectTargetDir);
+            // add meta-inf files if any
+            addMetaInfFiles(moduleArchive, outputDirectory);
+            return moduleArchive;    
+        } catch (Exception e) {
+            throw new MojoExecutionException("Error adding manifest or META-INF files for loose ear configuration: "+artifact, e);
+        }
     }
 
-    public Element addWarModule(MavenProject proj, Artifact artifact, File warSourceDir) throws Exception {
+    public Element addWarModule(MavenProject proj, Artifact artifact, File warSourceDir) throws MojoExecutionException, IOException {
         Element warArchive = config.addArchive(getModuleUri(artifact));
         config.addDir(warArchive, warSourceDir, "/");
         config.addDir(warArchive, new File(proj.getBuild().getOutputDirectory()), "/WEB-INF/classes");
@@ -104,11 +111,15 @@ public class LooseEarApplication extends LooseApplication {
         }
 
         // add Manifest file
-        addWarManifestFile(warArchive, artifact, proj);
+        try {
+            addWarManifestFile(warArchive, artifact, proj);
+        } catch (Exception e) {
+            throw new MojoExecutionException("Error adding manifest file for war module "+artifact, e);
+        }
         return warArchive;
     }
 
-    public Element addRarModule(MavenProject proj, Artifact artifact) throws Exception {
+    public Element addRarModule(MavenProject proj, Artifact artifact) throws MojoExecutionException, IOException {
         Element rarArchive = config.addArchive(getModuleUri(artifact));
         config.addDir(rarArchive, getRarSourceDirectory(proj), "/");
 
@@ -124,11 +135,15 @@ public class LooseEarApplication extends LooseApplication {
 
         // add Manifest file
         File manifestFile = MavenProjectUtil.getManifestFile(proj, "maven-rar-plugin");
-        addManifestFileWithParent(rarArchive, manifestFile, mavenProjectTargetDir);
+        try {
+            addManifestFileWithParent(rarArchive, manifestFile, mavenProjectTargetDir);
+        } catch (Exception e) {
+            throw new MojoExecutionException("Error adding manifest file for rar module "+artifact, e);
+        }
         return rarArchive;
     }
 
-    public File getRarSourceDirectory(MavenProject proj) throws Exception {
+    public File getRarSourceDirectory(MavenProject proj) {
         String dir = MavenProjectUtil.getPluginConfiguration(proj, "org.apache.maven.plugins", "maven-rar-plugin",
                 "rarSourceDirectory");
         if (dir != null) {
@@ -138,7 +153,7 @@ public class LooseEarApplication extends LooseApplication {
         }
     }
 
-    public String getModuleUri(Artifact artifact) throws Exception {
+    public String getModuleUri(Artifact artifact) throws MojoExecutionException {
         String defaultUri = "/" + getModuleName(artifact);
         // both "jar" and "bundle" packaging type project are "jar" type dependencies
         // that will be packaged in the ear lib directory
@@ -204,12 +219,12 @@ public class LooseEarApplication extends LooseApplication {
         return null;
     }
 
-    public void addModuleFromM2(Artifact artifact) throws Exception {
+    public void addModuleFromM2(Artifact artifact) throws MojoExecutionException, IOException {
         String artifactName = getModuleUri(artifact);
         config.addFile(artifact.getFile(), artifactName);
     }
 
-    public String getModuleName(Artifact artifact) throws Exception {
+    public String getModuleName(Artifact artifact) throws MojoExecutionException {
         int earPluginVersion = MavenProjectUtil.getMajorPluginVersion(project, "org.apache.maven.plugins:maven-ear-plugin");
         if (earPluginVersion < 3) {
             return getEarFileNameMappingHelper(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion(), artifact.getType());
@@ -248,16 +263,21 @@ public class LooseEarApplication extends LooseApplication {
     }
     
     // Valid for maven-ear-plugin version 3 and greater
-    public String getEarOutputFileNameMapping(Artifact artifact) throws Exception {
+    public String getEarOutputFileNameMapping(Artifact artifact) throws MojoExecutionException {
         String outputFileNameMapping = MavenProjectUtil.getPluginConfiguration(project, "org.apache.maven.plugins",
             "maven-ear-plugin", "outputFileNameMapping");
-        String fileNameMapping = MappingUtils.evaluateFileNameMapping( outputFileNameMapping, artifact );
-        if (fileNameMapping == null || fileNameMapping.isEmpty()) {
-            // default format if none is specified
-            String defaultFormat = "@{groupId}@-@{artifactId}@-@{version}@@{dashClassifier?}@.@{extension}@";
-            fileNameMapping = MappingUtils.evaluateFileNameMapping( defaultFormat, artifact );
-        }
-        return fileNameMapping;
+            try {
+                String fileNameMapping = MappingUtils.evaluateFileNameMapping( outputFileNameMapping, artifact );
+                if (fileNameMapping == null || fileNameMapping.isEmpty()) {
+                    // default format if none is specified
+                    String defaultFormat = "@{groupId}@-@{artifactId}@-@{version}@@{dashClassifier?}@.@{extension}@";
+                    fileNameMapping = MappingUtils.evaluateFileNameMapping( defaultFormat, artifact );
+                }
+                return fileNameMapping;
+        
+            } catch (InterpolationException e) {
+                throw new MojoExecutionException("Error getting outputFileNameMapping for ear artifact "+artifact, e);
+            }
     }
 
     // Deprecated for maven-ear-plugin version 3 and greater

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/LooseWarApplication.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/LooseWarApplication.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2019, 2021.
+ * (C) Copyright IBM Corporation 2019, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package io.openliberty.tools.maven.applications;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -66,7 +65,7 @@ public class LooseWarApplication extends LooseApplication {
     	return isExploded(project);
     }
     
-    public void addSourceDir() throws Exception {
+    public void addSourceDir() throws IOException {
         Path warSourceDir = getWarSourceDirectory();
         config.addDir(warSourceDir.toFile(), "/");
     }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/UndeployAppMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/UndeployAppMojo.java
@@ -16,6 +16,7 @@
 package io.openliberty.tools.maven.applications;
 
 import java.io.File;
+import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Map;
 import java.util.Set;
@@ -54,6 +55,10 @@ public class UndeployAppMojo extends DeployMojoSupport {
             return;
         }
         
+        doUndeploy();        
+    }
+
+    private void doUndeploy() throws MojoExecutionException {
         checkServerHomeExists();
         checkServerDirectoryExists();
 
@@ -110,7 +115,7 @@ public class UndeployAppMojo extends DeployMojoSupport {
                         undeployApp(new File(installDir, depArchive.getName()));
                     }
                 } else {
-                    log.warn(MessageFormat.format(messages.getString("error.application.not.supported"),
+                    getLog().warn(MessageFormat.format(messages.getString("error.application.not.supported"),
                             project.getId()));
                 }
             }
@@ -136,13 +141,15 @@ public class UndeployAppMojo extends DeployMojoSupport {
                 File serverXML = new File(serverDirectory.getCanonicalPath(), "server.xml");
             
                 Map<String, File> libertyDirPropertyFiles = getLibertyDirectoryPropertyFiles();
-                scd = ServerConfigDocument.getInstance(CommonLogger.getInstance(log), serverXML, configDirectory,
+                CommonLogger logger = CommonLogger.getInstance(log);
+                setLog(logger.getLog());
+                scd = ServerConfigDocument.getInstance(logger, serverXML, configDirectory,
                 bootstrapPropertiesFile, combinedBootstrapProperties, serverEnvFile, false, libertyDirPropertyFiles);
 
                 //appName will be set to a name derived from file if no name can be found.
                 appName = ServerConfigDocument.findNameForLocation(appName);
             } catch (Exception e) {
-                log.warn(e.getLocalizedMessage());
+                getLog().warn(e.getLocalizedMessage());
             } 
         }
 
@@ -158,7 +165,7 @@ public class UndeployAppMojo extends DeployMojoSupport {
         String stopMessage = STOP_APP_MESSAGE_CODE_REG + appName;
         ServerTask serverTask = initializeJava();
         if (serverTask.waitForStringInLog(stopMessage, APP_STOP_TIMEOUT_DEFAULT, new File(serverDirectory, "logs/messages.log")) == null) {
-            throw new MojoExecutionException("CWWKM2022E: Failed to undeploy application " + file.getPath() + ". The Stop application message cannot be found in console.log.");
+            throw new MojoExecutionException("CWWKM2022E: Failed to undeploy application " + file.getPath() + ". The Stop application message cannot be found in console.getLog().");
         }
     }
 }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/UndeployAppMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/UndeployAppMojo.java
@@ -16,7 +16,6 @@
 package io.openliberty.tools.maven.applications;
 
 import java.io.File;
-import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Map;
 import java.util.Set;
@@ -41,8 +40,6 @@ public class UndeployAppMojo extends DeployMojoSupport {
 
     private static final String STOP_APP_MESSAGE_CODE_REG = "CWWKZ0009I.*";
     private static final long APP_STOP_TIMEOUT_DEFAULT = 30 * 1000;
-
-    private ServerConfigDocument scd;
     
     /*
      * (non-Javadoc)
@@ -135,7 +132,6 @@ public class UndeployAppMojo extends DeployMojoSupport {
         String appName = file.getName().substring(0, file.getName().lastIndexOf('.'));
 
         if (getAppsDirectory().equals("apps")) {
-            scd = null;
 
             try {
                 File serverXML = new File(serverDirectory.getCanonicalPath(), "server.xml");
@@ -143,7 +139,7 @@ public class UndeployAppMojo extends DeployMojoSupport {
                 Map<String, File> libertyDirPropertyFiles = getLibertyDirectoryPropertyFiles();
                 CommonLogger logger = CommonLogger.getInstance(log);
                 setLog(logger.getLog());
-                scd = ServerConfigDocument.getInstance(logger, serverXML, configDirectory,
+                ServerConfigDocument.getInstance(logger, serverXML, configDirectory,
                 bootstrapPropertiesFile, combinedBootstrapProperties, serverEnvFile, false, libertyDirPropertyFiles);
 
                 //appName will be set to a name derived from file if no name can be found.

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/extensions/arquillian/ConfigureArquillianMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/extensions/arquillian/ConfigureArquillianMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2017, 2021.
+ * (C) Copyright IBM Corporation 2017, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ public class ConfigureArquillianMojo extends BasicSupport {
                 String artifactId = artifact.getArtifactId();
                 if (groupId.equals(coors.getGroupId()) && artifactId.equals(coors.getArtifactId())) {
                     type = TypeProperty.REMOTE;
-                    log.info("Automatically detected the Arquillian Liberty Remote container at the following coordinates: " + groupId + ":" + artifactId + ".");
+                    getLog().info("Automatically detected the Arquillian Liberty Remote container at the following coordinates: " + groupId + ":" + artifactId + ".");
                     break outerloop;
                 }
             }
@@ -87,19 +87,19 @@ public class ConfigureArquillianMojo extends BasicSupport {
                 String artifactId = artifact.getArtifactId();
                 if (groupId.equals(coors.getGroupId()) && artifactId.equals(coors.getArtifactId())) {
                     type = TypeProperty.MANAGED;
-                    log.info("Automatically detected the Arquillian Liberty Managed container at the following coordinates: " + groupId + ":" + artifactId + ".");
+                    getLog().info("Automatically detected the Arquillian Liberty Managed container at the following coordinates: " + groupId + ":" + artifactId + ".");
                     break outerloop;
                 }
             }
         }
         
         if (type == TypeProperty.NOTFOUND) {
-            log.warn("Arquillian Liberty Managed and Remote dependencies were not found. Defaulting to use the Liberty Managed container.");
+            getLog().warn("Arquillian Liberty Managed and Remote dependencies were not found. Defaulting to use the Liberty Managed container.");
             type = TypeProperty.MANAGED;
         }
 
         if (skipIfArquillianXmlExists && arquillianXml.exists()) {
-            log.info("Skipping configure-arquillian goal because arquillian.xml already exists in \"target/test-classes\".");
+            getLog().info("Skipping configure-arquillian goal because arquillian.xml already exists in \"target/test-classes\".");
             return;
         }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/jsp/CompileJspMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/jsp/CompileJspMojo.java
@@ -17,7 +17,6 @@ package io.openliberty.tools.maven.jsp;
 
 import java.io.File;
 import java.text.MessageFormat;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -160,10 +159,7 @@ public class CompileJspMojo extends InstallFeatureSupport {
             compile.setJspVersion(jspVersion);
         }
         else {
-            Iterator it = installedFeatures.iterator();
-            String currentFeature;
-            while (it.hasNext()) {
-                currentFeature = (String) it.next();
+            for (String currentFeature : installedFeatures) {
                 if(currentFeature.startsWith("jsp-")) {
                     String version = currentFeature.replace("jsp-", "");
                     compile.setJspVersion(version);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/jsp/CompileJspMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/jsp/CompileJspMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2017, 2020.
+ * (C) Copyright IBM Corporation 2017, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 import io.openliberty.tools.ant.jsp.CompileJSPs;
+import io.openliberty.tools.common.plugins.util.PluginExecutionException;
 import io.openliberty.tools.maven.InstallFeatureSupport;
 
 /**
@@ -62,6 +63,10 @@ public class CompileJspMojo extends InstallFeatureSupport {
             return;
         }
 
+        doCompileJsps();
+    }
+
+    private void doCompileJsps() throws MojoExecutionException {
         CompileJSPs compile = (CompileJSPs) ant.createTask("antlib:io/openliberty/tools/ant:compileJSPs");
         if (compile == null) {
             throw new IllegalStateException(
@@ -123,11 +128,16 @@ public class CompileJspMojo extends InstallFeatureSupport {
         }
 
         String classpathStr = join(classpath, File.pathSeparator);
-        log.debug("Classpath: " + classpathStr);
+        getLog().debug("Classpath: " + classpathStr);
         compile.setClasspath(classpathStr);
 
         if(initialize()) {
-            Set<String> installedFeatures = getSpecifiedFeatures(null);
+            Set<String> installedFeatures;
+            try {
+                installedFeatures = getSpecifiedFeatures(null);
+            } catch (PluginExecutionException e) {
+                throw new MojoExecutionException("Error getting the list of specified features.", e);
+            }
 
             //Set JSP Feature Version
             setJspVersion(compile, installedFeatures);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CheckStatusMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CheckStatusMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2019.
+ * (C) Copyright IBM Corporation 2014, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
  */
 package io.openliberty.tools.maven.server;
 
+import java.io.IOException;
 import java.text.MessageFormat;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 
 import io.openliberty.tools.ant.ServerTask;
@@ -32,14 +34,23 @@ public class CheckStatusMojo extends StartDebugMojoSupport {
             getLog().info("\nSkipping status goal.\n");
             return;
         }
+        
+        doCheckStatus();
+    }
+
+    private void doCheckStatus() throws MojoExecutionException {
         if (isInstall) {
-            installServerAssembly();
+            try {
+                installServerAssembly();
+            } catch (IOException e) {
+                throw new MojoExecutionException("Error during Liberty server installation.", e);
+            }
         } else {
-            log.info(MessageFormat.format(messages.getString("info.install.type.preexisting"), ""));
+            getLog().info(MessageFormat.format(messages.getString("info.install.type.preexisting"), ""));
             checkServerHomeExists();
         }
 
-        log.info(MessageFormat.format(messages.getString("info.server.status.check"), ""));
+        getLog().info(MessageFormat.format(messages.getString("info.server.status.check"), ""));
 
         ServerTask serverTask = initializeJava();
         serverTask.setOperation("status");

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CleanServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CleanServerMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2016, 2019.
+ * (C) Copyright IBM Corporation 2016, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.openliberty.tools.maven.server;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -56,6 +57,10 @@ public class CleanServerMojo extends StartDebugMojoSupport {
             return;
         }
         
+        doCleanServer();
+    }
+
+    private void doCleanServer() throws MojoExecutionException {
         CleanTask cleanTask = (CleanTask) ant.createTask("antlib:io/openliberty/tools/ant:clean");
         cleanTask.setInstallDir(installDirectory);
         cleanTask.setServerName(serverName);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CopyDependencies.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CopyDependencies.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2020.
+ * (C) Copyright IBM Corporation 2020, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -68,7 +68,7 @@ public class CopyDependencies {
     }
 
     public void setStripVersion(boolean strip) {
-        this.stripVersion = new Boolean(strip);
+        this.stripVersion = Boolean.valueOf(strip);
     }
     
     /**

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DebugServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DebugServerMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2017, 2020.
+ * (C) Copyright IBM Corporation 2017, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
  */
 package io.openliberty.tools.maven.server;
 
+import java.io.IOException;
 import java.text.MessageFormat;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -42,18 +44,31 @@ public class DebugServerMojo extends StartDebugMojoSupport {
             getLog().info("\nSkipping debug goal.\n");
             return;
         }
+
+        doDebug();
+    }
+
+    private void doDebug() throws MojoExecutionException {
         if (isInstall) {
-            installServerAssembly();
+            try {
+                installServerAssembly();
+            } catch (IOException e) {
+                throw new MojoExecutionException("Error installing the Liberty server.", e);
+            }
         } else {
-            log.info(MessageFormat.format(messages.getString("info.install.type.preexisting"), ""));
+            getLog().info(MessageFormat.format(messages.getString("info.install.type.preexisting"), ""));
             checkServerHomeExists();
         }
 
         ServerTask serverTask = initializeJava();
-        copyConfigFiles();
+        try {
+            copyConfigFiles();
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error copying configuration files to Liberty server directory.", e);
+        }
         serverTask.setClean(clean);
         serverTask.setOperation("debug");
-        serverTask.execute();        
+        serverTask.execute();    
     }
 
 }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DependencyGroup.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DependencyGroup.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2020.
+ * (C) Copyright IBM Corporation 2020, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -58,7 +58,7 @@ public class DependencyGroup {
     }
 
     public void setStripVersion(boolean strip) {
-        this.stripVersion = new Boolean(strip);
+        this.stripVersion = Boolean.valueOf(strip);
     }
     /**
      * Get all the current Dependency to copy.

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -25,7 +25,6 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.name;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2019, 2021.
+ * (C) Copyright IBM Corporation 2019, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -271,7 +271,7 @@ public class DevMojo extends LooseAppSupport {
         }
         if (resourceDirs.isEmpty()) {
             File defaultResourceDir = new File(project.getBasedir(), "src/main/resources");
-            log.debug("No resource directory detected, using default directory: " + defaultResourceDir);
+            getLog().debug("No resource directory detected, using default directory: " + defaultResourceDir);
             resourceDirs.add(defaultResourceDir);
         }
         return resourceDirs;
@@ -305,42 +305,42 @@ public class DevMojo extends LooseAppSupport {
 
         @Override
         public void debug(String msg) {
-            log.debug(msg);
+            getLog().debug(msg);
         }
 
         @Override
         public void debug(String msg, Throwable e) {
-            log.debug(msg, e);
+            getLog().debug(msg, e);
         }
 
         @Override
         public void debug(Throwable e) {
-            log.debug(e);
+            getLog().debug(e);
         }
 
         @Override
         public void warn(String msg) {
-            log.warn(msg);
+            getLog().warn(msg);
         }
 
         @Override
         public void info(String msg) {
-            log.info(msg);
+            getLog().info(msg);
         }
 
         @Override
         public void error(String msg) {
-            log.error(msg);
+            getLog().error(msg);
         }
 
         @Override
         public void error(String msg, Throwable e) {
-            log.error(msg, e);
+            getLog().error(msg, e);
         }
 
         @Override
         public boolean isDebugEnabled() {
-            return log.isDebugEnabled();
+            return getLog().isDebugEnabled();
         }
 
         @Override
@@ -357,12 +357,12 @@ public class DevMojo extends LooseAppSupport {
         public void libertyCreate() throws PluginExecutionException {
             try {
                 if (isUsingBoost()) {
-                    log.info("Running boost:package");
+                    getLog().info("Running boost:package");
                     runBoostMojo("package");
                 } else {
                     runLibertyMojoCreate();
                 }
-            } catch (MojoExecutionException | ProjectBuildingException e) {
+            } catch (MojoExecutionException e) {
                 throw new PluginExecutionException(e);
             }
         }
@@ -390,10 +390,10 @@ public class DevMojo extends LooseAppSupport {
                 // stacktrace
                 if (e.getCause() != null && e.getCause() instanceof PluginExecutionException) {
                     // PluginExecutionException indicates that the binary scanner jar could not be found
-                    log.error(e.getMessage() + ".\nDisabling the automatic generation of features.");
+                    getLog().error(e.getMessage() + ".\nDisabling the automatic generation of features.");
                     setFeatureGeneration(false);
                 } else {
-                    log.error(e.getMessage()
+                    getLog().error(e.getMessage()
                     + "\nTo disable the automatic generation of features, type 'g' and press Enter.");
                 }
                 return false;
@@ -431,7 +431,7 @@ public class DevMojo extends LooseAppSupport {
                 serverTask.setOperation("stop");
                 serverTask.execute();
             } catch (Exception e) {
-                log.warn(MessageFormat.format(messages.getString("warn.server.stopped"), serverName));
+                getLog().warn(MessageFormat.format(messages.getString("warn.server.stopped"), serverName));
             }
         }
 
@@ -612,7 +612,7 @@ public class DevMojo extends LooseAppSupport {
                 JavaCompilerOptions oldCompilerOptions = getMavenCompilerOptions(backupUpstreamProject);
                 JavaCompilerOptions compilerOptions = getMavenCompilerOptions(upstreamProject);
                 if (!oldCompilerOptions.getOptions().equals(compilerOptions.getOptions())) {
-                    log.debug("Maven compiler options have been modified: " + compilerOptions.getOptions());
+                    getLog().debug("Maven compiler options have been modified: " + compilerOptions.getOptions());
                     util.getProjectModule(buildFile).setCompilerOptions(compilerOptions);
                 }
 
@@ -652,7 +652,7 @@ public class DevMojo extends LooseAppSupport {
                     if (!dependencyListsEquals(getCompileDependency(deps), getCompileDependency(oldDeps))) {
                         // optimize generate features
                         if (generateFeatures) {
-                            log.debug("Detected a change in the compile dependencies for "
+                            getLog().debug("Detected a change in the compile dependencies for "
                                     + buildFile + " , regenerating features");
                             boolean generateFeaturesSuccess = libertyGenerateFeatures(null, true);
                             if (generateFeaturesSuccess) {
@@ -667,9 +667,9 @@ public class DevMojo extends LooseAppSupport {
                 }
             } catch (ProjectBuildingException | DependencyResolutionRequiredException | IOException
                     | MojoExecutionException e) {
-                log.error("An unexpected error occurred while processing changes in " + buildFile.getAbsolutePath()
+                getLog().error("An unexpected error occurred while processing changes in " + buildFile.getAbsolutePath()
                         + ": " + e.getMessage());
-                log.debug(e);
+                getLog().debug(e);
                 return false;
             }
             return true;
@@ -682,9 +682,9 @@ public class DevMojo extends LooseAppSupport {
                 updateChildProjectArtifactPaths(buildFile, parentProject.getCompileClasspathElements(),
                         parentProject.getTestClasspathElements());
             } catch (ProjectBuildingException | IOException | DependencyResolutionRequiredException e) {
-                log.error("An unexpected error occurred while processing changes in " + buildFile.getAbsolutePath()
+                getLog().error("An unexpected error occurred while processing changes in " + buildFile.getAbsolutePath()
                         + ": " + e.getMessage());
-                log.debug(e);
+                getLog().debug(e);
                 return false;
             }
             return true;
@@ -774,7 +774,7 @@ public class DevMojo extends LooseAppSupport {
                         // Validate maven-war-plugin version
                         Plugin warPlugin = getPlugin("org.apache.maven.plugins", "maven-war-plugin");
                         if (!validatePluginVersion(warPlugin.getVersion(), "3.3.1")) {
-                            log.warn("Exploded WAR functionality is enabled. Please use maven-war-plugin version 3.3.1 or greater for best results.");
+                            getLog().warn("Exploded WAR functionality is enabled. Please use maven-war-plugin version 3.3.1 or greater for best results.");
                         }
                         
                         redeployApp();
@@ -782,7 +782,7 @@ public class DevMojo extends LooseAppSupport {
                         try {
                             runExplodedMojo();
                         } catch (MojoExecutionException e) {
-                            log.error("Failed to run war:exploded goal", e);
+                            getLog().error("Failed to run war:exploded goal", e);
                         }
                     }
                 } else {
@@ -804,7 +804,7 @@ public class DevMojo extends LooseAppSupport {
                     runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
                     runExplodedMojo();
                 } catch (MojoExecutionException e) {
-                    log.error("Failed to run goal(s)", e);
+                    getLog().error("Failed to run goal(s)", e);
                 }
             } 
         }
@@ -816,7 +816,7 @@ public class DevMojo extends LooseAppSupport {
                     runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
                     runExplodedMojo();
                 } catch (MojoExecutionException e) {
-                    log.error("Failed to run goal(s)", e);
+                    getLog().error("Failed to run goal(s)", e);
                 }
             } else {
                 copyFile(fileChanged, resourceParent, outputDirectory, null);
@@ -830,7 +830,7 @@ public class DevMojo extends LooseAppSupport {
                 try {
                     runExplodedMojo();
                 } catch (MojoExecutionException e) {
-                    log.error("Failed to run goal(s)", e);
+                    getLog().error("Failed to run goal(s)", e);
                 }
             } 
         }
@@ -854,8 +854,8 @@ public class DevMojo extends LooseAppSupport {
                 build = mavenProjectBuilder.build(buildFile,
                         session.getProjectBuildingRequest().setResolveDependencies(true));
             } catch (ProjectBuildingException e) {
-                log.error("Could not parse pom.xml. " + e.getMessage());
-                log.debug(e);
+                getLog().error("Could not parse pom.xml. " + e.getMessage());
+                getLog().debug(e);
                 return false;
             }
 
@@ -871,7 +871,7 @@ public class DevMojo extends LooseAppSupport {
                 JavaCompilerOptions oldCompilerOptions = getMavenCompilerOptions(backupProject);
                 JavaCompilerOptions compilerOptions = getMavenCompilerOptions(project);
                 if (!oldCompilerOptions.getOptions().equals(compilerOptions.getOptions())) {
-                    log.debug("Maven compiler options have been modified: " + compilerOptions.getOptions());
+                    getLog().debug("Maven compiler options have been modified: " + compilerOptions.getOptions());
                     util.updateJavaCompilerOptions(compilerOptions);
                 }
 
@@ -887,8 +887,8 @@ public class DevMojo extends LooseAppSupport {
                 Xpp3Dom config;
                 Xpp3Dom oldConfig;
                 if (!restartServer) {
-                    config = ExecuteMojoUtil.getPluginGoalConfig(libertyPlugin, "create", log);
-                    oldConfig = ExecuteMojoUtil.getPluginGoalConfig(backupLibertyPlugin, "create", log);
+                    config = ExecuteMojoUtil.getPluginGoalConfig(libertyPlugin, "create", getLog());
+                    oldConfig = ExecuteMojoUtil.getPluginGoalConfig(backupLibertyPlugin, "create", getLog());
                     if (!Objects.equals(config, oldConfig)) {
                         createServer = true;
                         if (restartForLibertyMojoConfigChanged(config, oldConfig)) {
@@ -896,18 +896,18 @@ public class DevMojo extends LooseAppSupport {
                         }
                     }
                 }
-                config = ExecuteMojoUtil.getPluginGoalConfig(libertyPlugin, "install-feature", log);
-                oldConfig = ExecuteMojoUtil.getPluginGoalConfig(backupLibertyPlugin, "install-feature", log);
+                config = ExecuteMojoUtil.getPluginGoalConfig(libertyPlugin, "install-feature", getLog());
+                oldConfig = ExecuteMojoUtil.getPluginGoalConfig(backupLibertyPlugin, "install-feature", getLog());
                 if (!Objects.equals(config, oldConfig)) {
                     installFeature = true;
                 }
-                config = ExecuteMojoUtil.getPluginGoalConfig(libertyPlugin, "deploy", log);
-                oldConfig = ExecuteMojoUtil.getPluginGoalConfig(backupLibertyPlugin, "deploy", log);
+                config = ExecuteMojoUtil.getPluginGoalConfig(libertyPlugin, "deploy", getLog());
+                oldConfig = ExecuteMojoUtil.getPluginGoalConfig(backupLibertyPlugin, "deploy", getLog());
                 if (!Objects.equals(config, oldConfig)) {
                     redeployApp = true;
                 }
-                config = ExecuteMojoUtil.getPluginGoalConfig(libertyPlugin, "generate-features", log);
-                oldConfig = ExecuteMojoUtil.getPluginGoalConfig(backupLibertyPlugin, "generate-features", log);
+                config = ExecuteMojoUtil.getPluginGoalConfig(libertyPlugin, "generate-features", getLog());
+                oldConfig = ExecuteMojoUtil.getPluginGoalConfig(backupLibertyPlugin, "generate-features", getLog());
                 if (!Objects.equals(config, oldConfig)) {
                     optimizeGenerateFeatures = true;
                 }
@@ -947,7 +947,7 @@ public class DevMojo extends LooseAppSupport {
 
                 boolean generateFeaturesSuccess = false;
                 if (optimizeGenerateFeatures && generateFeatures) {
-                    log.debug("Detected a change in the compile dependencies, regenerating features");
+                    getLog().debug("Detected a change in the compile dependencies, regenerating features");
                     // always optimize generate features on dependency change
                     generateFeaturesSuccess = libertyGenerateFeatures(null, true);
                     if (generateFeaturesSuccess) {
@@ -967,7 +967,7 @@ public class DevMojo extends LooseAppSupport {
                     return true;
                 } else {
                     if (isUsingBoost() && (createServer || runBoostPackage)) {
-                        log.info("Running boost:package");
+                        getLog().info("Running boost:package");
                         runBoostMojo("package");
                     } else if (createServer) {
                         runLibertyMojoCreate();
@@ -983,15 +983,15 @@ public class DevMojo extends LooseAppSupport {
                 if (!(restartServer || createServer || redeployApp || installFeature || runBoostPackage)) {
                     // pom.xml is changed but not affecting liberty:dev mode. return true with the
                     // updated project set in the session
-                    log.debug("changes in the pom.xml are not monitored by dev mode");
+                    getLog().debug("changes in the pom.xml are not monitored by dev mode");
                     return true;
                 }
-            } catch (MojoExecutionException | ProjectBuildingException | DependencyResolutionRequiredException | IOException e) {
-                log.error("An unexpected error occurred while processing changes in pom.xml. " + e.getMessage());
+            } catch (MojoExecutionException | DependencyResolutionRequiredException | IOException e) {
+                getLog().error("An unexpected error occurred while processing changes in pom.xml. " + e.getMessage());
                 if (installFeature) {
                     libertyDependencyWarning(generateFeatures, e);
                 }
-                log.debug(e);
+                getLog().debug(e);
                 project = backupProject;
                 session.setCurrentProject(backupProject);
                 return false;
@@ -1004,7 +1004,7 @@ public class DevMojo extends LooseAppSupport {
         private void libertyDependencyWarning(boolean generateFeatures, Exception e) {
             if (generateFeatures && !getEsaDependency(project.getDependencies()).isEmpty()
                     && e.getMessage().contains(InstallFeatureUtil.CONFLICT_MESSAGE)) {
-                log.warn(GEN_FEAT_LIBERTY_DEP_WARNING);
+                getLog().warn(GEN_FEAT_LIBERTY_DEP_WARNING);
             }
         }
 
@@ -1022,13 +1022,13 @@ public class DevMojo extends LooseAppSupport {
                         Set<String> existingFeaturesCopy = new HashSet<String>(existingFeatures);
                         existingFeaturesCopy.removeAll(featuresCopy);
                         if (!existingFeaturesCopy.isEmpty()) {
-                            log.info("Configuration features have been removed: " + existingFeaturesCopy);
+                            getLog().info("Configuration features have been removed: " + existingFeaturesCopy);
                         }
                     }
 
                     // check if features have been added and install new features
                     if (!features.isEmpty()) {
-                        log.info("Configuration features have been added: " + features);
+                        getLog().info("Configuration features have been added: " + features);
                         // pass all new features to install-feature as backup in case the serverDir cannot be accessed
                         Element[] featureElems = new Element[features.size() + 1];
                         featureElems[0] = element(name("acceptLicense"), "true");
@@ -1040,7 +1040,7 @@ public class DevMojo extends LooseAppSupport {
                     }
                 }
             } catch (MojoExecutionException e) {
-                log.error("Failed to install features from configuration file", e);
+                getLog().error("Failed to install features from configuration file", e);
                 libertyDependencyWarning(generateFeatures, e);
             }
         }
@@ -1076,7 +1076,7 @@ public class DevMojo extends LooseAppSupport {
                 }
                 return true;
             } catch (MojoExecutionException e) {
-                log.error("Unable to compile", e);
+                getLog().error("Unable to compile", e);
                 return false;
             }
         }
@@ -1095,7 +1095,7 @@ public class DevMojo extends LooseAppSupport {
                 }
                 return true;
             } catch (MojoExecutionException e) {
-                log.error("Unable to compile", e);
+                getLog().error("Unable to compile", e);
                 return false;
             }
         }
@@ -1160,19 +1160,13 @@ public class DevMojo extends LooseAppSupport {
         return boostPlugin != null;
     }
 
-    @Override
-    protected void doExecute() throws Exception {
-        if (skip) {
-            getLog().info("\nSkipping dev goal.\n");
-            return;
-        }
-
+    private void doDevMode() throws MojoExecutionException {
         String mvnVersion = runtime.getMavenVersion();
-        log.debug("Maven version: " + mvnVersion);
+        getLog().debug("Maven version: " + mvnVersion);
         // Maven 3.8.2 and 3.8.3 contain a bug where compile artifacts are not resolved
         // correctly in threads. Block dev mode from running on these versions
         if (mvnVersion.equals("3.8.2") || mvnVersion.equals("3.8.3")) {
-            throw new PluginExecutionException("Detected Maven version " + mvnVersion
+            throw new MojoExecutionException("Detected Maven version " + mvnVersion
                     + ". This version is not supported for dev mode. Upgrade to Maven 3.8.4 or higher to use dev mode.");
         }
 
@@ -1191,13 +1185,13 @@ public class DevMojo extends LooseAppSupport {
             List<MavenProject> downstreamProjects = graph.getDownstreamProjects(project, true);
 
             if (!downstreamProjects.isEmpty()) {
-                log.debug("Downstream projects: " + downstreamProjects);
+                getLog().debug("Downstream projects: " + downstreamProjects);
                 if (isEar) {
                     runMojo("org.apache.maven.plugins", "maven-ear-plugin", "generate-application-xml");
                     runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
                     getOrCreateEarArtifact(project);
                 } else if (project.getPackaging().equals("pom")) {
-                    log.debug("Skipping compile/resources on module with pom packaging type");
+                    getLog().debug("Skipping compile/resources on module with pom packaging type");
                 } else {
                     runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
                     runCompileMojoLogWarning();
@@ -1224,12 +1218,12 @@ public class DevMojo extends LooseAppSupport {
         if (recompileDependencies == null) {
             if (upstreamMavenProjects.isEmpty()) {
                 // single module project default to false
-                log.debug(
+                getLog().debug(
                         "The recompileDependencies parameter was not explicitly set. The default value -DrecompileDependencies=false will be used.");
                 recompileDependencies = "false";
             } else {
                 // multi module project default to true
-                log.debug(
+                getLog().debug(
                         "The recompileDependencies parameter was not explicitly set. The default value for multi module projects -DrecompileDependencies=true will be used.");
                 recompileDependencies = "true";
             }
@@ -1237,12 +1231,12 @@ public class DevMojo extends LooseAppSupport {
         boolean recompileDeps = Boolean.parseBoolean(recompileDependencies);
         if (recompileDeps) {
             if (!upstreamMavenProjects.isEmpty()) {
-                log.info("The recompileDependencies parameter is set to \"true\". On a file change all dependent modules will be recompiled.");
+                getLog().info("The recompileDependencies parameter is set to \"true\". On a file change all dependent modules will be recompiled.");
             } else {
-                log.info("The recompileDependencies parameter is set to \"true\". On a file change the entire project will be recompiled.");
+                getLog().info("The recompileDependencies parameter is set to \"true\". On a file change the entire project will be recompiled.");
             }
         } else {
-            log.info("The recompileDependencies parameter is set to \"false\". On a file change only the affected classes will be recompiled.");
+            getLog().info("The recompileDependencies parameter is set to \"false\". On a file change only the affected classes will be recompiled.");
         }
 
         // Check if this is a Boost application
@@ -1269,7 +1263,7 @@ public class DevMojo extends LooseAppSupport {
             runMojo("org.apache.maven.plugins", "maven-ear-plugin", "generate-application-xml");
             runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
         } else if (project.getPackaging().equals("pom")) {
-            log.debug("Skipping compile/resources on module with pom packaging type");
+            getLog().debug("Skipping compile/resources on module with pom packaging type");
         } else {
             runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
             runCompileMojoLogWarning();
@@ -1286,13 +1280,13 @@ public class DevMojo extends LooseAppSupport {
         ArrayList<File> javaTestFiles = new ArrayList<File>();
         listFiles(testSourceDirectory, javaTestFiles, ".java");
 
-        log.debug("Source directory: " + sourceDirectory);
-        log.debug("Output directory: " + outputDirectory);
-        log.debug("Test Source directory: " + testSourceDirectory);
-        log.debug("Test Output directory: " + testOutputDirectory);
+        getLog().debug("Source directory: " + sourceDirectory);
+        getLog().debug("Output directory: " + outputDirectory);
+        getLog().debug("Test Source directory: " + testSourceDirectory);
+        getLog().debug("Test Output directory: " + testOutputDirectory);
 
         if (isUsingBoost()) {
-            log.info("Running boost:package");
+            getLog().info("Running boost:package");
             runBoostMojo("package");
         } else {
             if (generateFeatures) {
@@ -1307,14 +1301,14 @@ public class DevMojo extends LooseAppSupport {
                         generatedFileCanonicalPath = new File(configDirectory,
                                 BinaryScannerUtil.GENERATED_FEATURES_FILE_PATH).toString();
                     }
-                    log.warn(
+                    getLog().warn(
                             "The source configuration directory will be modified. Features will automatically be generated in a new file: "
                                     + generatedFileCanonicalPath);
                     runLibertyMojoGenerateFeatures(null, true);
                 } catch (MojoExecutionException e) {
                     if (e.getCause() != null && e.getCause() instanceof PluginExecutionException) {
                         // PluginExecutionException indicates that the binary scanner jar could not be found
-                        log.error(e.getMessage() + ".\nDisabling the automatic generation of features.");
+                        getLog().error(e.getMessage() + ".\nDisabling the automatic generation of features.");
                         generateFeatures = false;
                     } else {
                         throw new MojoExecutionException(e.getMessage()
@@ -1341,7 +1335,7 @@ public class DevMojo extends LooseAppSupport {
             if (isExplodedLooseWarApp) {
                 Plugin warPlugin = getPlugin("org.apache.maven.plugins", "maven-war-plugin");
                 if (!validatePluginVersion(warPlugin.getVersion(), "3.3.2")) {
-                    log.warn("Exploded WAR functionality is enabled. Please use maven-war-plugin version 3.3.2 or greater for best results.");
+                    getLog().warn("Exploded WAR functionality is enabled. Please use maven-war-plugin version 3.3.2 or greater for best results.");
                 }
             }
         }
@@ -1378,7 +1372,7 @@ public class DevMojo extends LooseAppSupport {
 
                 Plugin libertyPlugin = getLibertyPluginForProject(p);
                 // use "dev" goal, although we don't expect the skip tests flags to be bound to any goal
-                Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(libertyPlugin, "dev", log);
+                Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(libertyPlugin, "dev", getLog());
                 
                 boolean upstreamSkipTests = getBooleanFlag(config, userProps, props, "skipTests");
                 boolean upstreamSkipITs = getBooleanFlag(config, userProps, props, "skipITs");
@@ -1414,16 +1408,26 @@ public class DevMojo extends LooseAppSupport {
         // pom.xml
         File pom = project.getFile();
 
-        // collect artifacts canonical paths in order to build classpath
-        Set<String> compileArtifactPaths = new HashSet<String>(project.getCompileClasspathElements());
-        Set<String> testArtifactPaths = new HashSet<String>(project.getTestClasspathElements());
+        try {
+            // collect artifacts canonical paths in order to build classpath
+            Set<String> compileArtifactPaths = new HashSet<String>(project.getCompileClasspathElements());
+            Set<String> testArtifactPaths = new HashSet<String>(project.getTestClasspathElements());
 
-        util = new DevMojoUtil(installDirectory, userDirectory, serverDirectory, sourceDirectory, testSourceDirectory,
-                configDirectory, project.getBasedir(), multiModuleProjectDirectory, resourceDirs, compilerOptions,
-                settings.getLocalRepository(), upstreamProjects, upstreamMavenProjects, recompileDeps, pom, parentPoms, 
-                generateFeatures, compileArtifactPaths, testArtifactPaths, webResourceDirs);
+            util = new DevMojoUtil(installDirectory, userDirectory, serverDirectory, sourceDirectory, testSourceDirectory,
+                    configDirectory, project.getBasedir(), multiModuleProjectDirectory, resourceDirs, compilerOptions,
+                    settings.getLocalRepository(), upstreamProjects, upstreamMavenProjects, recompileDeps, pom, parentPoms, 
+                    generateFeatures, compileArtifactPaths, testArtifactPaths, webResourceDirs);
+        } catch (IOException | DependencyResolutionRequiredException e) {
+            throw new MojoExecutionException("Error initializing dev mode.", e);
+        }
+
         util.addShutdownHook(executor);
-        util.startServer();
+        
+        try {
+            util.startServer();
+        } catch (PluginExecutionException e) {
+            throw new MojoExecutionException("Error starting the server in dev mode.", e);
+        }
 
         // start watching for keypresses immediately
         util.runHotkeyReaderThread(executor);
@@ -1435,14 +1439,24 @@ public class DevMojo extends LooseAppSupport {
         try {
             util.watchFiles(outputDirectory, testOutputDirectory, executor, serverXmlFile, bootstrapPropertiesFile,
                     jvmOptionsFile);
-        } catch (PluginScenarioException e) {
+        } catch (Exception e) {
             if (e.getMessage() != null) {
                 // a proper message is included in the exception if the server has been stopped
                 // by another process
-                log.info(e.getMessage());
+                getLog().info(e.getMessage());
             }
             return; // enter shutdown hook
         }
+    }
+
+    @Override
+    protected void doExecute() throws Exception {
+        if (skip) {
+            getLog().info("\nSkipping dev goal.\n");
+            return;
+        }
+
+        doDevMode();
     }
 
 
@@ -1539,44 +1553,44 @@ public class DevMojo extends LooseAppSupport {
                 }
             }
         } catch (IOException e) {
-            log.error("An unexpected error occurred when trying to resolve " + proj.getFile() + ": " + e.getMessage());
-            log.debug(e);
+            getLog().error("An unexpected error occurred when trying to resolve " + proj.getFile() + ": " + e.getMessage());
+            getLog().debug(e);
         }
     }
 
     private JavaCompilerOptions getMavenCompilerOptions(MavenProject currentProject) {
         Plugin plugin = getPluginForProject("org.apache.maven.plugins", "maven-compiler-plugin", currentProject);
-        Xpp3Dom configuration = ExecuteMojoUtil.getPluginGoalConfig(plugin, "compile", log);
+        Xpp3Dom configuration = ExecuteMojoUtil.getPluginGoalConfig(plugin, "compile", getLog());
         JavaCompilerOptions compilerOptions = new JavaCompilerOptions();
 
         String showWarnings = getCompilerOption(configuration, "showWarnings", "maven.compiler.showWarnings", currentProject);
         if (showWarnings != null) {
             boolean showWarningsBoolean = Boolean.parseBoolean(showWarnings);
-            log.debug("Setting showWarnings to " + showWarningsBoolean);
+            getLog().debug("Setting showWarnings to " + showWarningsBoolean);
             compilerOptions.setShowWarnings(showWarningsBoolean);
         }
 
         String source = getCompilerOption(configuration, "source", "maven.compiler.source", currentProject);
         if (source != null) {
-            log.debug("Setting compiler source to " + source);
+            getLog().debug("Setting compiler source to " + source);
             compilerOptions.setSource(source);
         }
 
         String target = getCompilerOption(configuration, "target", "maven.compiler.target", currentProject);
         if (target != null) {
-            log.debug("Setting compiler target to " + target);
+            getLog().debug("Setting compiler target to " + target);
             compilerOptions.setTarget(target);
         }
 
         String release = getCompilerOption(configuration, "release", "maven.compiler.release", currentProject);
         if (release != null) {
-            log.debug("Setting compiler release to " + release);
+            getLog().debug("Setting compiler release to " + release);
             compilerOptions.setRelease(release);
         }
 
         String encoding = getCompilerOption(configuration, "encoding", "project.build.sourceEncoding", currentProject);
         if (encoding != null) {
-            log.debug("Setting compiler encoding to " + encoding);
+            getLog().debug("Setting compiler encoding to " + encoding);
             compilerOptions.setEncoding(encoding);
         }
 
@@ -1637,9 +1651,9 @@ public class DevMojo extends LooseAppSupport {
                 }
             }
         } catch (ProjectBuildingException | IOException e) {
-            log.error("An unexpected error occurred when trying to run integration tests for "
+            getLog().error("An unexpected error occurred when trying to run integration tests for "
                     + buildFile.getAbsolutePath() + ": " + e.getMessage());
-            log.debug(e);
+            getLog().debug(e);
         }
         return currentProject;
     }
@@ -1647,7 +1661,7 @@ public class DevMojo extends LooseAppSupport {
     private void runTestMojo(String groupId, String artifactId, String goal, MavenProject project)
             throws MojoExecutionException {
         Plugin plugin = getPluginForProject(groupId, artifactId, project);
-        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(plugin, goal, log);
+        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(plugin, goal, getLog());
 
         // check if this is a project module or main module
         if (util.isMultiModuleProject()) {
@@ -1664,9 +1678,9 @@ public class DevMojo extends LooseAppSupport {
                     injectClasspathElements(config, testArtifacts, project.getTestClasspathElements());
                 }
             } catch (IOException | DependencyResolutionRequiredException e) {
-                log.error(
+                getLog().error(
                         "Unable to resolve test artifact paths for " + project.getFile() + ". Restart dev mode to ensure classpaths are properly resolved.");
-                log.debug(e);
+                getLog().debug(e);
             }
         }
 
@@ -1685,19 +1699,19 @@ public class DevMojo extends LooseAppSupport {
                 summaryFile = new File(project.getBuild().getDirectory(), "failsafe-reports/failsafe-summary.xml");
             }
             try {
-                log.debug("Looking for summary file at " + summaryFile.getCanonicalPath());
+                getLog().debug("Looking for summary file at " + summaryFile.getCanonicalPath());
             } catch (IOException e) {
-                log.debug("Unable to resolve summary file " + e.getMessage());
+                getLog().debug("Unable to resolve summary file " + e.getMessage());
             }
             if (summaryFile.exists()) {
                 boolean deleteResult = summaryFile.delete();
-                log.debug("Summary file deleted? " + deleteResult);
+                getLog().debug("Summary file deleted? " + deleteResult);
             } else {
-                log.debug("Summary file doesn't exist");
+                getLog().debug("Summary file doesn't exist");
             }
         } else if (goal.equals("failsafe-report-only")) {
             Plugin failsafePlugin = getPluginForProject("org.apache.maven.plugins", "maven-failsafe-plugin", project);
-            Xpp3Dom failsafeConfig = ExecuteMojoUtil.getPluginGoalConfig(failsafePlugin, "integration-test", log);
+            Xpp3Dom failsafeConfig = ExecuteMojoUtil.getPluginGoalConfig(failsafePlugin, "integration-test", getLog());
             Xpp3Dom linkXRef = new Xpp3Dom("linkXRef");
             if (failsafeConfig != null) {
                 Xpp3Dom reportsDirectoryElement = failsafeConfig.getChild("reportsDirectory");
@@ -1715,7 +1729,7 @@ public class DevMojo extends LooseAppSupport {
             config.addChild(linkXRef);
         } else if (goal.equals("report-only")) {
             Plugin surefirePlugin = getPluginForProject("org.apache.maven.plugins", "maven-surefire-plugin", project);
-            Xpp3Dom surefireConfig = ExecuteMojoUtil.getPluginGoalConfig(surefirePlugin, "test", log);
+            Xpp3Dom surefireConfig = ExecuteMojoUtil.getPluginGoalConfig(surefirePlugin, "test", getLog());
             Xpp3Dom linkXRef = new Xpp3Dom("linkXRef");
             if (surefireConfig != null) {
                 Xpp3Dom reportsDirectoryElement = surefireConfig.getChild("reportsDirectory");
@@ -1733,7 +1747,7 @@ public class DevMojo extends LooseAppSupport {
             config.addChild(linkXRef);
         }
 
-        log.debug("POM file: " + project.getFile() + "\n" + groupId + ":" + artifactId + " " + goal
+        getLog().debug("POM file: " + project.getFile() + "\n" + groupId + ":" + artifactId + " " + goal
                 + " configuration:\n" + config);
         MavenSession tempSession = session.clone();
         tempSession.setCurrentProject(project);
@@ -1821,12 +1835,12 @@ public class DevMojo extends LooseAppSupport {
         }
     }
 
-    private void runBoostMojo(String goal) throws MojoExecutionException, ProjectBuildingException {
+    private void runBoostMojo(String goal) throws MojoExecutionException {
 
         MavenProject boostProject = this.project;
         MavenSession boostSession = this.session;
 
-        log.debug("plugin version: " + boostPlugin.getVersion());
+        getLog().debug("plugin version: " + boostPlugin.getVersion());
         executeMojo(boostPlugin, goal(goal), configuration(),
                 executionEnvironment(boostProject, boostSession, pluginManager));
 
@@ -1862,10 +1876,10 @@ public class DevMojo extends LooseAppSupport {
         MavenSession tempSession = session.clone();
         tempSession.setCurrentProject(mavenProject);
         MavenProject tempProject = mavenProject;
-        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(plugin, goal, log);
+        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(plugin, goal, getLog());
         config = Xpp3Dom.mergeXpp3Dom(configuration(element(name("failOnError"), "false")), config);
-        log.info("Running maven-compiler-plugin:" + goal + " on " + tempProject.getFile());
-        log.debug("configuration:\n" + config);
+        getLog().info("Running maven-compiler-plugin:" + goal + " on " + tempProject.getFile());
+        getLog().debug("configuration:\n" + config);
         executeMojo(plugin, goal(goal), config, executionEnvironment(tempProject, tempSession, pluginManager));
     }
 
@@ -1926,7 +1940,7 @@ public class DevMojo extends LooseAppSupport {
     @Override
     protected void runLibertyMojoCreate() throws MojoExecutionException {
         if (container) {
-            log.debug("runLibertyMojoCreate check for installDirectory and serverDirectory");
+            getLog().debug("runLibertyMojoCreate check for installDirectory and serverDirectory");
             if (!installDirectory.isDirectory()) {
                 installDirectory.mkdirs();
             }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallFeatureMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallFeatureMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2015, 2021.
+ * (C) Copyright IBM Corporation 2015, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -63,11 +64,20 @@ public class InstallFeatureMojo extends InstallFeatureSupport {
         if(!initialize()) {
             return;
         }
+
+        doInstallFeatures();
+    }
+
+    private void doInstallFeatures() throws MojoExecutionException {
         if (serverDir != null) {
             serverDirectory = serverDir;
-            log.debug("Overriding the server directory with: " + serverDirectory);
+            getLog().debug("Overriding the server directory with: " + serverDirectory);
         }
-        installFeatures();
+        try {
+            installFeatures();
+        } catch (PluginExecutionException e) {
+            throw new MojoExecutionException("Error installing features for server "+serverName, e);
+        }
     }
 
     private void installFeatures() throws PluginExecutionException {
@@ -81,7 +91,7 @@ public class InstallFeatureMojo extends InstallFeatureSupport {
             boolean skipBetaInstallFeatureWarning = Boolean.parseBoolean(System.getProperty(DevUtil.SKIP_BETA_INSTALL_WARNING));
             if (InstallFeatureUtil.isOpenLibertyBetaVersion(openLibertyVersion)) {
                 if (!skipBetaInstallFeatureWarning) {
-                    log.warn("Features that are not included with the beta runtime cannot be installed. Features that are included with the beta runtime can be enabled by adding them to your server.xml file.");
+                    getLog().warn("Features that are not included with the beta runtime cannot be installed. Features that are included with the beta runtime can be enabled by adding them to your server.xml file.");
                 }
                 return; // do not install features if the runtime is a beta version
             }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallServerMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2017.
+ * (C) Copyright IBM Corporation 2014, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.openliberty.tools.maven.server;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
@@ -31,6 +32,10 @@ public class InstallServerMojo extends PluginConfigSupport {
             return;
         }
 
+        doInstallServer();
+    }
+
+    private void doInstallServer() throws MojoExecutionException {
         installServerAssembly();
     }
 }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/JavaDumpServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/JavaDumpServerMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2020.
+ * (C) Copyright IBM Corporation 2014, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
  */
 package io.openliberty.tools.maven.server;
 
+import java.io.IOException;
 import java.text.MessageFormat;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -47,16 +49,29 @@ public class JavaDumpServerMojo extends StartDebugMojoSupport {
             getLog().info("\nSkipping java-dump goal.\n");
             return;
         }
+
+        doJavaDumpServer();
+    }
+
+    private void doJavaDumpServer() throws MojoExecutionException {
         if (isInstall) {
-            installServerAssembly();
+            try {
+                installServerAssembly();
+            } catch (IOException e) {
+                throw new MojoExecutionException("Error installing the Liberty server.", e);
+            }
         } else {
-            log.info(MessageFormat.format(messages.getString("info.install.type.preexisting"), ""));
+            getLog().info(MessageFormat.format(messages.getString("info.install.type.preexisting"), ""));
             checkServerHomeExists();
             checkServerDirectoryExists();
         }
 
         ServerTask serverTask = initializeJava();
-        copyConfigFiles();
+        try {
+            copyConfigFiles();
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error copying configuration files to Liberty server directory.", e);
+        }
         serverTask.setOperation("javadump");
         serverTask.setInclude(generateInclude());
         serverTask.execute();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2021. 
+ * (C) Copyright IBM Corporation 2014, 2023. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,15 +137,23 @@ public class PackageServerMojo extends StartDebugMojoSupport {
             return;
         }
 
+        try {
+            doPackage();
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error packaging the Liberty server.", e);
+        }
+    }
+
+    private void doPackage() throws MojoExecutionException, IOException {
         if (isInstall) {
             installServerAssembly();
         } else {
-            log.info(MessageFormat.format(messages.getString("info.install.type.preexisting"), ""));
+            getLog().info(MessageFormat.format(messages.getString("info.install.type.preexisting"), ""));
             checkServerHomeExists();
             checkServerDirectoryExists();
         }
 
-        log.info(MessageFormat.format(messages.getString("info.server.package"), serverName));
+        getLog().info(MessageFormat.format(messages.getString("info.server.package"), serverName));
         ServerTask serverTask = initializeJava();
         copyConfigFiles();
         serverTask.setOperation("package");
@@ -156,7 +164,7 @@ public class PackageServerMojo extends StartDebugMojoSupport {
         serverTask.setInclude(include);
         serverTask.setOs(os);
         serverTask.setServerRoot(serverRoot);
-        log.info(MessageFormat.format(messages.getString("info.server.package.file.location"), packageFile.getCanonicalPath()));
+        getLog().info(MessageFormat.format(messages.getString("info.server.package.file.location"), packageFile.getCanonicalPath()));
         serverTask.execute();
 
         if ("liberty-assembly".equals(project.getPackaging())) {
@@ -219,10 +227,10 @@ public class PackageServerMojo extends StartDebugMojoSupport {
         ArrayList<String> includeValues = parseInclude();
         if (packageType == null) {
             if (includeValues.contains("runnable")) {
-                log.debug("Defaulting `packageType` to `jar` because the `include` value contains `runnable`.");
+                getLog().debug("Defaulting `packageType` to `jar` because the `include` value contains `runnable`.");
                 packageFileType = PackageFileType.JAR;
             } else {
-                log.debug("Defaulting `packageType` to `zip`.");
+                getLog().debug("Defaulting `packageType` to `zip`.");
                 packageFileType = PackageFileType.ZIP;
             }
         } else {
@@ -234,7 +242,7 @@ public class PackageServerMojo extends StartDebugMojoSupport {
                 }
                 packageFileType = packType;
             } else {
-                log.info("The `packageType` value " + packageType + " is not supported. Defaulting to 'zip'.");
+                getLog().info("The `packageType` value " + packageType + " is not supported. Defaulting to 'zip'.");
                 packageFileType = PackageFileType.ZIP;
             }
         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PrepareFeatureMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PrepareFeatureMojo.java
@@ -15,9 +15,7 @@
  */
 package io.openliberty.tools.maven.server;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PrepareFeatureMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PrepareFeatureMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2021.
+ * (C) Copyright IBM Corporation 2021, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 
 import io.openliberty.tools.common.plugins.util.InstallFeatureUtil;
@@ -43,7 +44,15 @@ public class PrepareFeatureMojo extends PrepareFeatureSupport {
             return;
         }
         
-        prepareFeatures();
+        doPrepareFeatures();
+    }
+
+    private void doPrepareFeatures() throws MojoExecutionException {
+        try {
+            prepareFeatures();
+        } catch (PluginExecutionException e) {
+            throw new MojoExecutionException("Error preparing features.", e);
+        }
     }
     
     private void prepareFeatures() throws PluginExecutionException {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -15,9 +15,7 @@
  */
 package io.openliberty.tools.maven.server;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.List;
 
 import org.apache.maven.execution.ProjectDependencyGraph;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -185,9 +185,9 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
     
     protected void runMojo(String groupId, String artifactId, String goal) throws MojoExecutionException {
         Plugin plugin = getPlugin(groupId, artifactId);
-        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(plugin, goal, log);
-        log.info("Running " + artifactId + ":" + goal);
-        log.debug("configuration:\n" + config);
+        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(plugin, goal, getLog());
+        getLog().info("Running " + artifactId + ":" + goal);
+        getLog().debug("configuration:\n" + config);
         executeMojo(plugin, goal(goal), config,
                 executionEnvironment(project, session, pluginManager));
     }
@@ -200,13 +200,13 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
      */
     protected void runExplodedMojo() throws MojoExecutionException {
         Plugin warPlugin = getPlugin("org.apache.maven.plugins", "maven-war-plugin");
-        Xpp3Dom explodedConfig = ExecuteMojoUtil.getPluginGoalConfig(warPlugin, "exploded", log);
+        Xpp3Dom explodedConfig = ExecuteMojoUtil.getPluginGoalConfig(warPlugin, "exploded", getLog());
         
         if (validatePluginVersion(warPlugin.getVersion(), "3.3.1")) {
             explodedConfig.addChild(element(name("outdatedCheckPath"), "WEB-INF").toDom());
         }
-        log.info("Running maven-war-plugin:exploded");
-        log.debug("configuration:\n" + explodedConfig);
+        getLog().info("Running maven-war-plugin:exploded");
+        getLog().debug("configuration:\n" + explodedConfig);
         session.getRequest().setStartTime(new Date());
         executeMojo(warPlugin, goal("exploded"), explodedConfig, executionEnvironment(project, session, pluginManager));
     }
@@ -214,9 +214,9 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
     protected void runMojoForProject(String groupId, String artifactId, String goal, MavenProject project)
             throws MojoExecutionException {
         Plugin plugin = getPluginForProject(groupId, artifactId, project);
-        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(plugin, goal, log);
-        log.info("Running " + artifactId + ":" + goal + " on " + project.getFile());
-        log.debug("configuration:\n" + config);
+        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(plugin, goal, getLog());
+        getLog().info("Running " + artifactId + ":" + goal + " on " + project.getFile());
+        getLog().debug("configuration:\n" + config);
         MavenSession tempSession = session.clone();
         tempSession.setCurrentProject(project);
         executeMojo(plugin, goal(goal), config, executionEnvironment(project, tempSession, pluginManager));
@@ -274,7 +274,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
         String version = null;
         if (plugin != null && plugin.getPlugin() != null) {
             version = plugin.getVersion();
-            log.debug("Setting plugin version to " + version);
+            getLog().debug("Setting plugin version to " + version);
         }
         Plugin projectPlugin = currentProject.getPlugin(LIBERTY_MAVEN_PLUGIN_GROUP_ID + ":" + LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID);
         if (projectPlugin == null) {
@@ -304,7 +304,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
     }
 
     protected void runLibertyMojoCreate() throws MojoExecutionException {
-        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(getLibertyPlugin(), "create", log);
+        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(getLibertyPlugin(), "create", getLog());
         runLibertyMojo("create", config);
     }
 
@@ -313,11 +313,11 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
     }
     
     protected void runLibertyMojoDeploy(boolean forceLooseApp) throws MojoExecutionException {
-        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(getLibertyPlugin(), "deploy", log);
+        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(getLibertyPlugin(), "deploy", getLog());
         if(forceLooseApp) {
             Xpp3Dom looseApp = config.getChild("looseApplication");
             if (looseApp != null && "false".equals(looseApp.getValue())) {
-                log.warn("Overriding liberty plugin parameter, \"looseApplication\" to \"true\" and deploying application in looseApplication format");
+                getLog().warn("Overriding liberty plugin parameter, \"looseApplication\" to \"true\" and deploying application in looseApplication format");
                 looseApp.setValue("true");
             }
         }
@@ -330,7 +330,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
     }
 
     protected void runLibertyMojoInstallFeature(Element features, File serverDir, String containerName) throws MojoExecutionException {
-        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(getLibertyPlugin(), "install-feature", log);
+        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(getLibertyPlugin(), "install-feature", getLog());
         if (features != null) {
             config = Xpp3Dom.mergeXpp3Dom(configuration(features), config);
         }
@@ -341,7 +341,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
             try {
                 config.addChild(element(name("serverDir"), serverDir.getCanonicalPath()).toDom());
             } catch (IOException e) {
-                log.warn("Unable to pass 'serverDir' configuration parameter to liberty:install-feature: "
+                getLog().warn("Unable to pass 'serverDir' configuration parameter to liberty:install-feature: "
                         + serverDir);
             }
         }
@@ -349,7 +349,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
     }
 
     protected void runLibertyMojoGenerateFeatures(Element classFiles, boolean optimize) throws MojoExecutionException {
-        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(getLibertyPlugin(), "generate-features", log);
+        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(getLibertyPlugin(), "generate-features", getLog());
         if (classFiles != null) {
             config = Xpp3Dom.mergeXpp3Dom(configuration(classFiles), config);
         }
@@ -358,13 +358,13 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
     }
 
     private void runLibertyMojo(String goal, Xpp3Dom config) throws MojoExecutionException {
-        log.info("Running liberty:" + goal);
-        log.debug("configuration:\n" + config);
+        getLog().info("Running liberty:" + goal);
+        getLog().debug("configuration:\n" + config);
         executeMojo(getLibertyPlugin(), goal(goal), config,
                 executionEnvironment(project, session, pluginManager));
     }
 
-    private void copyDependencies() throws Exception {
+    private void copyDependencies() throws MojoExecutionException, IOException {
         if (copyDependencies != null) {
             List<Dependency> deps = copyDependencies.getDependencies();
             boolean defaultStripVersion = copyDependencies.isStripVersion();
@@ -386,7 +386,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
             String dftLocationPath = dftLocationFile.getCanonicalPath();
 
             if (!deps.isEmpty()) {      
-                log.debug("copyDependencies to location: "+dftLocationPath);
+                getLog().debug("copyDependencies to location: "+dftLocationPath);
             }
 
             for (Dependency dep : deps) {
@@ -398,9 +398,9 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
             for (DependencyGroup depGroup : depGroups) {
                 String overrideLocation = depGroup.getLocation();
                 if (overrideLocation != null) {
-                    log.debug("copyDependencies to location: "+ overrideLocation);
+                    getLog().debug("copyDependencies to location: "+ overrideLocation);
                 } else {
-                    log.debug("copyDependencies to location: "+dftLocationPath);
+                    getLog().debug("copyDependencies to location: "+dftLocationPath);
                 }
                 boolean stripVersion = defaultStripVersion;
                 Boolean overrideStripVersion = depGroup.getStripVersion();
@@ -416,7 +416,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
         }
     }
 
-    private void copyDependencies(Dependency dep, String overrideLocation, String defaultLocation, boolean stripVersion) throws Exception {
+    private void copyDependencies(Dependency dep, String overrideLocation, String defaultLocation, boolean stripVersion) throws MojoExecutionException, IOException {
 
         String location = defaultLocation;
 
@@ -433,7 +433,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
                 overrideLocationFile.mkdirs();
             } else if (!overrideLocationFile.isDirectory()) {
                 // send config error
-                log.warn("The specified dependency location "+ overrideLocationFile.getCanonicalPath() +" is not a directory. Using default copyDependencies location "+ defaultLocation +" instead.");
+                getLog().warn("The specified dependency location "+ overrideLocationFile.getCanonicalPath() +" is not a directory. Using default copyDependencies location "+ defaultLocation +" instead.");
                 location = defaultLocation;
             }
         }
@@ -454,7 +454,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
             sb.append(" and type "+dep.getType());
             sb.append(". No matching resolved dependencies were found.");
 
-            log.warn(sb.toString());
+            getLog().warn(sb.toString());
         } else {
             for (Artifact nextArtifact : artifactsToCopy) {
                 File nextFile = nextArtifact.getFile();
@@ -471,15 +471,17 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
                 copy.setOverwrite(true);
                 copy.execute();
 
-                log.info("copyDependencies copied file "+nextFile.getName()+" to location "+location+"/"+targetFileName+".");
+                getLog().info("copyDependencies copied file "+nextFile.getName()+" to location "+location+"/"+targetFileName+".");
             }
         }
     }
 
     /**
+     * @throws ParserConfigurationException
+     * @throws TransformerException
      * @throws Exception
      */
-    protected void copyConfigFiles() throws Exception {
+    protected void copyConfigFiles() throws IOException, MojoExecutionException {
 
         String jvmOptionsPath = null;
         String bootStrapPropertiesPath = null;
@@ -530,7 +532,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
         // copy server.xml file to server directory if end-user explicitly set it.
         if (serverXmlFile != null && serverXmlFile.exists()) {
             if (serverXMLPath != null && ! serverXmlFile.getCanonicalPath().equals(serverXMLPath)) {
-                log.warn("The " + serverXMLPath + " file is overwritten by the "+serverXmlFile.getCanonicalPath()+" file.");
+                getLog().warn("The " + serverXMLPath + " file is overwritten by the "+serverXmlFile.getCanonicalPath()+" file.");
             }
             Copy copy = (Copy) ant.createTask("copy");
             copy.setFile(serverXmlFile);
@@ -545,19 +547,19 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
         if (optionsFile.exists() && jvmOptionsPath == null) {
             // if using pre-existing installation, do not delete file
             if (installType != InstallType.ALREADY_EXISTS) {
-                log.warn(optionsFile.getCanonicalPath() + " file deleted before processing plugin configuration.");
+                getLog().warn(optionsFile.getCanonicalPath() + " file deleted before processing plugin configuration.");
                 optionsFile.delete();
             }
         }
         if (jvmOptions != null || !jvmMavenProps.isEmpty()) {
             if (jvmOptionsPath != null) {
-                log.warn("The " + jvmOptionsPath + " file is overwritten by inlined configuration.");
+                getLog().warn("The " + jvmOptionsPath + " file is overwritten by inlined configuration.");
             }
             writeJvmOptions(optionsFile, jvmOptions, jvmMavenProps);
             jvmOptionsPath = "inlined configuration";
         } else if (jvmOptionsFile != null && jvmOptionsFile.exists()) {
             if (jvmOptionsPath != null) {
-                log.warn("The " + jvmOptionsPath + " file is overwritten by the "+jvmOptionsFile.getCanonicalPath()+" file.");
+                getLog().warn("The " + jvmOptionsPath + " file is overwritten by the "+jvmOptionsFile.getCanonicalPath()+" file.");
             }
             Copy copy = (Copy) ant.createTask("copy");
             copy.setFile(jvmOptionsFile);
@@ -572,19 +574,19 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
         if (bootstrapFile.exists() && bootStrapPropertiesPath == null) {
             // if using pre-existing installation, do not delete file
             if (installType != InstallType.ALREADY_EXISTS) {
-                log.warn(bootstrapFile.getCanonicalPath() + " file deleted before processing plugin configuration.");
+                getLog().warn(bootstrapFile.getCanonicalPath() + " file deleted before processing plugin configuration.");
                 bootstrapFile.delete();
             }
         } 
         if (bootstrapProperties != null || !bootstrapMavenProps.isEmpty()) {
             if (bootStrapPropertiesPath != null) {
-                log.warn("The " + bootStrapPropertiesPath + " file is overwritten by inlined configuration.");
+                getLog().warn("The " + bootStrapPropertiesPath + " file is overwritten by inlined configuration.");
             }
             writeBootstrapProperties(bootstrapFile, bootstrapProperties, bootstrapMavenProps);
             bootStrapPropertiesPath = "inlined configuration";
         } else if (bootstrapPropertiesFile != null && bootstrapPropertiesFile.exists()) {
             if (bootStrapPropertiesPath != null) {
-                log.warn("The " + bootStrapPropertiesPath + " file is overwritten by the "+ bootstrapPropertiesFile.getCanonicalPath()+" file.");
+                getLog().warn("The " + bootStrapPropertiesPath + " file is overwritten by the "+ bootstrapPropertiesFile.getCanonicalPath()+" file.");
             }
             Copy copy = (Copy) ant.createTask("copy");
             copy.setFile(bootstrapPropertiesFile);
@@ -606,7 +608,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
                     // Do a special case merge but ONLY if there are no other config options present
                     envPropsToWrite = mergeSpecialPropsFromInstallServerEnvIfAbsent(envMavenProps);
                 } else if (serverEnvPath != null) {
-                    log.warn("The " + serverEnvPath + " file is overwritten by inlined configuration.");
+                    getLog().warn("The " + serverEnvPath + " file is overwritten by inlined configuration.");
                 }
                 writeServerEnvProperties(envFile, envPropsToWrite);
                 serverEnvPath = "inlined configuration";
@@ -622,7 +624,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
 
         File pluginVariableConfig = new File(serverDirectory, PLUGIN_VARIABLE_CONFIG_OVERRIDES_XML);
         if (pluginVariableConfig.exists()) {
-            log.warn(pluginVariableConfig.getCanonicalPath() + " file deleted before processing plugin configuration.");
+            getLog().warn(pluginVariableConfig.getCanonicalPath() + " file deleted before processing plugin configuration.");
             pluginVariableConfig.delete();
         }
         if (!varMavenProps.isEmpty()) {
@@ -631,7 +633,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
 
         pluginVariableConfig = new File(serverDirectory, PLUGIN_VARIABLE_CONFIG_DEFAULTS_XML);
         if (pluginVariableConfig.exists()) {
-            log.warn(pluginVariableConfig.getCanonicalPath() + " file deleted before processing plugin configuration.");
+            getLog().warn(pluginVariableConfig.getCanonicalPath() + " file deleted before processing plugin configuration.");
             pluginVariableConfig.delete();
         }
         if (!defaultVarMavenProps.isEmpty()) {
@@ -640,19 +642,19 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
 
         // log info on the configuration files that get used
         if (serverXMLPath != null && !serverXMLPath.isEmpty()) {
-            log.info(MessageFormat.format(messages.getString("info.server.start.update.config"),
+            getLog().info(MessageFormat.format(messages.getString("info.server.start.update.config"),
                 "server.xml", serverXMLPath));
         }
         if (jvmOptionsPath != null && !jvmOptionsPath.isEmpty()) {
-            log.info(MessageFormat.format(messages.getString("info.server.start.update.config"),
+            getLog().info(MessageFormat.format(messages.getString("info.server.start.update.config"),
                 "jvm.options", jvmOptionsPath));
         }
         if (bootStrapPropertiesPath != null && !bootStrapPropertiesPath.isEmpty()) {
-            log.info(MessageFormat.format(messages.getString("info.server.start.update.config"),
+            getLog().info(MessageFormat.format(messages.getString("info.server.start.update.config"),
                 "bootstrap.properties", bootStrapPropertiesPath));
         }
         if (serverEnvPath != null && !serverEnvPath.isEmpty()) {
-            log.info(MessageFormat.format(messages.getString("info.server.start.update.config"),
+            getLog().info(MessageFormat.format(messages.getString("info.server.start.update.config"),
                 "server.env", serverEnvPath));
         }
 
@@ -796,7 +798,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
             if (propType != null) {
                 String suffix = key.substring(propType.getPrefix().length());
                 String value = (String) entry.getValue();
-                log.debug("Processing Liberty configuration from property with key "+key+" and value "+value);
+                getLog().debug("Processing Liberty configuration from property with key "+key+" and value "+value);
                 switch (propType) {
                     case ENV:        envMavenProps.put(suffix, value);
                                      break;
@@ -843,7 +845,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
        
                 writer.println((value != null) ? value.replace("\\", "/") : "");
                 if (value == null) {
-                    log.warn("The value of the bootstrap property " + key + " is null. Verify if the needed POM properties are set correctly.");
+                    getLog().warn("The value of the bootstrap property " + key + " is null. Verify if the needed POM properties are set correctly.");
                 }
             }
         } finally {
@@ -866,7 +868,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
                 String value = entry.getValue();
                 writer.println((value != null) ? value.replace("\\", "/") : "");
                 if (value == null) {
-                    log.warn("The value of the server.env property " + entry.getKey() + " is null. Verify if the needed POM properties are set correctly.");
+                    getLog().warn("The value of the server.env property " + entry.getKey() + " is null. Verify if the needed POM properties are set correctly.");
                 }
             }
         } finally {
@@ -906,20 +908,23 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
         }
     }
 
-    private void writeConfigDropinsServerVariables(File file, Map<String,String> props, boolean isDefaultVar) throws IOException, TransformerException, ParserConfigurationException {
+    private void writeConfigDropinsServerVariables(File file, Map<String,String> props, boolean isDefaultVar) throws IOException, MojoExecutionException {
 
-        ServerConfigXmlDocument configDocument = ServerConfigXmlDocument.newInstance();
+        try {
+            ServerConfigXmlDocument configDocument = ServerConfigXmlDocument.newInstance();
 
-        configDocument.createComment(HEADER);
-
-        for (Map.Entry<String, String> entry : props.entrySet()) {
-            configDocument.createVariableWithValue(entry.getKey(), entry.getValue(), isDefaultVar);
+            configDocument.createComment(HEADER);
+    
+            for (Map.Entry<String, String> entry : props.entrySet()) {
+                configDocument.createVariableWithValue(entry.getKey(), entry.getValue(), isDefaultVar);
+            }
+    
+            // write XML document to file
+            makeParentDirectory(file);
+            configDocument.writeXMLDocument(file);    
+        } catch (ParserConfigurationException | TransformerException e) {
+            throw new MojoExecutionException("Error writing configDropins variable file "+file.getCanonicalPath(), e);
         }
-
-        // write XML document to file
-        makeParentDirectory(file);
-        configDocument.writeXMLDocument(file);
-
     }
 
     private void makeParentDirectory(File file) {
@@ -943,9 +948,9 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
         ArtifactItem existingEarItem = createArtifactItem(earProject.getGroupId(), earProject.getArtifactId(), earProject.getPackaging(), earProject.getVersion());
         try {
             Artifact existingEarArtifact = getArtifact(existingEarItem);
-            log.debug("EAR artifact already exists at " + existingEarArtifact.getFile());
+            getLog().debug("EAR artifact already exists at " + existingEarArtifact.getFile());
         } catch (MojoExecutionException e) {
-            log.debug("Installing empty EAR artifact to .m2 directory...");
+            getLog().debug("Installing empty EAR artifact to .m2 directory...");
             updateArtifactPathToOutputDirectory(earProject);
         }
     }
@@ -953,7 +958,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
     private void installEmptyEAR(MavenProject earProject) throws MojoExecutionException {
         String goal = "install-file";
         Plugin plugin = getPlugin("org.apache.maven.plugins", "maven-install-plugin");
-        log.debug("Running maven-install-plugin:" + goal);
+        getLog().debug("Running maven-install-plugin:" + goal);
 
         File tempFile;
         try {
@@ -961,7 +966,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
             tempFile.deleteOnExit();
         } catch (IOException e) {
             String module = getModuleRelativePath(earProject);
-            log.debug(e);
+            getLog().debug(e);
             throw new MojoExecutionException("Could not install placeholder EAR artifact for module " + module + ". Manually run the following command to resolve this issue: mvn install -pl " + module + " -am");
         }
 
@@ -970,12 +975,12 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
             element(name("pomFile"), earProject.getFile().getAbsolutePath())
         );
 
-        log.debug("configuration:\n" + config);
+        getLog().debug("configuration:\n" + config);
         try {
             executeMojo(plugin, goal(goal), config, executionEnvironment(project, session, pluginManager));
         } catch (MojoExecutionException e) {
             String module = getModuleRelativePath(earProject);
-            log.debug(e);
+            getLog().debug(e);
             throw new MojoExecutionException("Could not install placeholder EAR artifact for module " + module + ". Manually run the following command to resolve this issue: mvn install -pl " + module + " -am");
         }
     }
@@ -991,14 +996,14 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
     protected void purgeLocalRepositoryArtifact() throws MojoExecutionException {
         Plugin plugin = getPlugin("org.apache.maven.plugins", "maven-dependency-plugin");
         String goal = "purge-local-repository";
-        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(plugin, goal, log);
+        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(plugin, goal, getLog());
         config = Xpp3Dom.mergeXpp3Dom(configuration(
             element(name("reResolve"), "false"), 
             element(name("actTransitively"), "false"), 
             element(name("manualIncludes"), project.getGroupId()+":"+project.getArtifactId())
             ), config);
-        log.info("Running maven-dependency-plugin:" + goal);
-        log.debug("configuration:\n" + config);
+        getLog().info("Running maven-dependency-plugin:" + goal);
+        getLog().debug("configuration:\n" + config);
         executeMojo(plugin, goal(goal), config, executionEnvironment(project, session, pluginManager));
     }
     
@@ -1036,7 +1041,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
             }
         } catch(IOException ioe) {
             // Since this is kind of a hack it seems to draw too much attention to issue a warning message here.
-            log.debug("Failure creating output directory: " + outputDir, ioe);
+            getLog().debug("Failure creating output directory: " + outputDir, ioe);
         }
     
         artifactToUpdate.setFile(outputDir.toFile());

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StopServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StopServerMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2019.
+ * (C) Copyright IBM Corporation 2014, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package io.openliberty.tools.maven.server;
 
 import java.text.MessageFormat;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -41,7 +42,11 @@ public class StopServerMojo extends StartDebugMojoSupport {
             return;
         }
         
-        log.info(MessageFormat.format(messages.getString("info.server.stopping"), serverName));
+        doStopServer();
+    }
+
+    private void doStopServer() throws MojoExecutionException {
+        getLog().info(MessageFormat.format(messages.getString("info.server.stopping"), serverName));
         
         if (serverDirectory.exists()) {
             try {
@@ -54,11 +59,10 @@ public class StopServerMojo extends StartDebugMojoSupport {
                 // not fully exist in the file structure and is not running anyway.
                 // Continue with a warning rather than ending with hard failure especially
                 // as we have bound stop-server to a clean.
-                log.warn(MessageFormat.format(messages.getString("warn.server.stopped"), serverName));
+                getLog().warn(MessageFormat.format(messages.getString("warn.server.stopped"), serverName));
             }
-        }
-        else {
-            log.info(MessageFormat.format(messages.getString("info.server.stop.noexist"), serverName));
+        } else {
+            getLog().info(MessageFormat.format(messages.getString("info.server.stop.noexist"), serverName));
         }
     }
 }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/AntTaskFactory.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/AntTaskFactory.java
@@ -1,0 +1,100 @@
+/**
+ * (C) Copyright IBM Corporation 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */package io.openliberty.tools.maven.utils;
+
+import java.io.PrintStream;
+import java.util.Objects;
+
+import org.apache.maven.project.MavenProject;
+import org.apache.tools.ant.DefaultLogger;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AntTaskFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(AntTaskFactory.class);
+
+    //private final MavenProject mavenProject;
+    private final Project ant;
+
+    private AntTaskFactory(MavenProject mavenProject) {
+        //this.mavenProject = mavenProject;
+
+        this.ant = new Project();
+        ant.setBaseDir(mavenProject.getBasedir());
+
+        initAntLogger(ant);
+
+        ant.init();
+    }
+
+    protected void initAntLogger(final Project ant) {
+        Slf4jLoggingBuildListener antLogger = new Slf4jLoggingBuildListener(LOG);
+        antLogger.setEmacsMode(true);
+        antLogger.setOutputPrintStream(System.out);
+        antLogger.setErrorPrintStream(System.err);
+
+        if (LOG.isDebugEnabled()) {
+            antLogger.setMessageOutputLevel(Project.MSG_VERBOSE);
+        } else {
+            antLogger.setMessageOutputLevel(Project.MSG_INFO);
+        }
+
+        ant.addBuildListener(antLogger);
+    }
+
+    public static AntTaskFactory forMavenProject(MavenProject mavenProject) {
+        return new AntTaskFactory(mavenProject);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends Task> T createTask(String taskName) {
+        return (T) this.ant.createTask(taskName);
+    }
+
+    static class Slf4jLoggingBuildListener extends DefaultLogger {
+
+        private final Logger logger;
+
+        public Slf4jLoggingBuildListener(Logger logger) {
+            super();
+            this.logger = Objects.requireNonNull(logger);
+        }
+
+        @Override
+        protected void printMessage(String message, PrintStream stream, int priority) {
+            switch (priority) {
+                case Project.MSG_ERR:
+                    logger.error(message);
+                    break;
+                case Project.MSG_WARN:
+                    logger.warn(message);
+                    break;
+                case Project.MSG_INFO:
+                    logger.info(message);
+                    break;
+                case Project.MSG_DEBUG:
+                    logger.debug(message);
+                    break;
+                case Project.MSG_VERBOSE:
+                    logger.trace(message);
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Unknown logging level: " + priority);
+            }
+        }
+    }
+}

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/AntTaskFactory.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/AntTaskFactory.java
@@ -27,11 +27,9 @@ import org.slf4j.LoggerFactory;
 public class AntTaskFactory {
     private static final Logger LOG = LoggerFactory.getLogger(AntTaskFactory.class);
 
-    //private final MavenProject mavenProject;
     private final Project ant;
 
     private AntTaskFactory(MavenProject mavenProject) {
-        //this.mavenProject = mavenProject;
 
         this.ant = new Project();
         ant.setBaseDir(mavenProject.getBasedir());

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/CommonLogger.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/CommonLogger.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2019.
+ * (C) Copyright IBM Corporation 2019, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,14 @@
 package io.openliberty.tools.maven.utils;
 
 import org.apache.maven.plugin.logging.Log;
-import org.codehaus.mojo.pluginsupport.MojoSupport;
+import org.apache.maven.plugin.logging.SystemStreamLog;
 
 import io.openliberty.tools.common.CommonLoggerI;
 
-public class CommonLogger extends MojoSupport implements CommonLoggerI {
+public class CommonLogger implements CommonLoggerI {
 
     private static CommonLogger logger = null;
+    private Log loggerImpl;
 
     public static CommonLogger getInstance(Log mojoLogger) {
         if (logger == null) {
@@ -35,11 +36,19 @@ public class CommonLogger extends MojoSupport implements CommonLoggerI {
     }
 
     private CommonLogger(Log mojoLogger) {
-        setLog(mojoLogger);
+        loggerImpl = mojoLogger;
     }
 
     private void setLogger(Log mojoLogger) {
-        setLog(mojoLogger);
+        loggerImpl = mojoLogger;
+    }
+
+    public Log getLog() {
+        if (this.loggerImpl == null) {
+            this.loggerImpl = new SystemStreamLog();
+        }
+
+        return this.loggerImpl;
     }
 
     @Override

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2019, 2021.
+ * (C) Copyright IBM Corporation 2019, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
@@ -17,9 +17,6 @@ package io.openliberty.tools.maven.utils;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.element;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.executeMojo;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.executionEnvironment;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.goal;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.name;
 
 import java.util.ArrayList;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/MavenProjectUtil.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/MavenProjectUtil.java
@@ -16,10 +16,8 @@
 package io.openliberty.tools.maven.utils;
 
 import java.io.File;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/MavenProjectUtil.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/MavenProjectUtil.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2018, 2020.
+ * (C) Copyright IBM Corporation 2018, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -193,9 +193,8 @@ public class MavenProjectUtil {
      * @param project
      * @param pluginKey
      * @return the major plugin version
-     * @throws PluginScenarioException
      */
-    public static int getMajorPluginVersion(MavenProject project, String pluginKey) throws PluginScenarioException {
+    public static int getMajorPluginVersion(MavenProject project, String pluginKey) {
         Plugin plugin = project.getPlugin(pluginKey);
         return Character.getNumericValue(plugin.getVersion().charAt(0));
     }


### PR DESCRIPTION
Preparation to remove all references to Maven 2.x APIs (org.codehaus) related to #1651.

1. Added our own `AntTaskFactory` to replace `org.codehaus.mojo.pluginsupport.ant.AntHelper`.
2. Changed all goal implementations to throw `MojoExecutionException` as a precursor to having `AbstractLibertySupport` extend `org.apache.maven.plugin.AbstractMojo` instead of `org.codehaus.mojo.pluginsupport.MojoSupport`.
3. Moved code from `doExecute` methods into their own method that throws `MojoExecutionException` in order to identify all other exceptions that need to be caught and wrapped in a `MojoExecutionException`. The `protected void doExecute() throws Exception` methods will get replaced by `@Override public void execute() throws MojoExecutionException` once the inheritance is changed.
4. Changed all references to the `log` variable to use `getLog()` instead. Modified `CommonLogger` to instantiate a `org.apache.maven.plugin.logging.SystemStreamLog` if no logger was available when instantiated.