### PR TITLE
Change hierarchy and remove use of ArtifactRepository

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.8.6</version>
+            <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.2</version>
+            <version>3.8.1</version>
             <scope>provided</scope>            <!-- annotations are needed only to build the plugin -->
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -36,39 +36,21 @@
             <version>1.9.11</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>plugin-support</artifactId>
-            <version>1.0-alpha-1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.maven</groupId>
-                    <artifactId>maven-project</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.maven</groupId>
-                    <artifactId>maven-artifact</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.maven</groupId>
-                    <artifactId>maven-plugin-api</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.8.6</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-mapping</artifactId>
             <version>3.0.0</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-core</artifactId>
-            <version>3.8.6</version>
-        </dependency>
         <!-- dependencies to annotations -->
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.4</version>
+            <version>3.2</version>
             <scope>provided</scope>            <!-- annotations are needed only to build the plugin -->
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseScannerTest.java
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseScannerTest.java
@@ -51,7 +51,7 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.io.input.ReversedLinesFileReader;
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -148,7 +148,7 @@ public class BaseScannerTest {
         assertTrue(tempProj.exists());
         assertTrue(basicProj.exists());
 
-        FileUtils.copyDirectoryStructure(basicProj, tempProj);
+        FileUtils.copyDirectory(basicProj, tempProj);
         assertTrue(tempProj.listFiles().length > 0);
         logFile = new File(basicProj, "logFile.txt");
         logFile.delete();

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
@@ -44,7 +44,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.input.ReversedLinesFileReader;
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -121,7 +122,7 @@ public class BaseDevTest {
 
       assertTrue(projectRoot+" directory does not exist", basicDevProj.exists());
 
-      FileUtils.copyDirectoryStructure(basicDevProj, tempProj);
+      FileUtils.copyDirectory(basicDevProj, tempProj);
       assertTrue("temp directory does not contain expected copied files from "+projectRoot, tempProj.listFiles().length > 0);
 
       // in case cleanup was not successful, try to delete the various log files so we can proceed

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
@@ -30,7 +30,7 @@ import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.GetMethod;
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevCopyProvidedDependenciesTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevCopyProvidedDependenciesTest.java
@@ -23,7 +23,7 @@ import java.io.FileWriter;
 import java.nio.file.Files;
 import java.util.Scanner;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevCopyProvidedDependenciesVersionTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevCopyProvidedDependenciesVersionTest.java
@@ -23,7 +23,7 @@ import java.io.FileWriter;
 import java.nio.file.Files;
 import java.util.Scanner;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevCopyTestDependenciesTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevCopyTestDependenciesTest.java
@@ -23,7 +23,7 @@ import java.io.FileWriter;
 import java.nio.file.Files;
 import java.util.Scanner;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevCopyTestDependenciesVersionTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevCopyTestDependenciesVersionTest.java
@@ -23,7 +23,7 @@ import java.io.FileWriter;
 import java.nio.file.Files;
 import java.util.Scanner;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
@@ -23,7 +23,7 @@ import java.io.FileWriter;
 import java.nio.file.Files;
 import java.util.Scanner;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/ExplodedLooseWarAppTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/ExplodedLooseWarAppTest.java
@@ -23,7 +23,7 @@ import java.io.FileWriter;
 import java.nio.file.Files;
 import java.util.Scanner;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MPStarterTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MPStarterTest.java
@@ -23,7 +23,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleEjbTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleEjbTest.java
@@ -24,7 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleHotTestingTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleHotTestingTest.java
@@ -22,7 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleM2InstalledTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleM2InstalledTest.java
@@ -24,7 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModulePackagingTypeCompileTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModulePackagingTypeCompileTest.java
@@ -24,7 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRecompileDepsTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRecompileDepsTest.java
@@ -22,7 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunEjbTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunEjbTest.java
@@ -24,7 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunInstallEarTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunInstallEarTest.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunM2InstalledTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunM2InstalledTest.java
@@ -24,7 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunTest.java
@@ -30,7 +30,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleSkipFlagsIntegrationTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleSkipFlagsIntegrationTest.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Properties;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleSkipFlagsUnitTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleSkipFlagsUnitTest.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Properties;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -39,6 +39,7 @@ import org.junit.Test;
 
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import io.openliberty.tools.maven.server.DevMojo;
+import io.openliberty.tools.maven.utils.DevHelper;
 
 public class MultiModuleSkipFlagsUnitTest {
 
@@ -47,12 +48,12 @@ public class MultiModuleSkipFlagsUnitTest {
     */
    @Test
    public void getFirstNonNullValueTest() throws Exception {
-      assertTrue(DevMojo.getFirstNonNullValue(null, null, Boolean.valueOf(true)));
-      assertTrue(DevMojo.getFirstNonNullValue(null, Boolean.valueOf(true), Boolean.valueOf(false)));
-      assertFalse(DevMojo.getFirstNonNullValue(null, Boolean.valueOf(false), Boolean.valueOf(true)));
-      assertFalse(DevMojo.getFirstNonNullValue(Boolean.valueOf(false), Boolean.valueOf(true), Boolean.valueOf(false)));
-      assertTrue(DevMojo.getFirstNonNullValue(Boolean.valueOf(true), Boolean.valueOf(true), Boolean.valueOf(false)));
-      assertFalse(DevMojo.getFirstNonNullValue(null, null, null));
+      assertTrue(DevHelper.getFirstNonNullValue(null, null, Boolean.valueOf(true)));
+      assertTrue(DevHelper.getFirstNonNullValue(null, Boolean.valueOf(true), Boolean.valueOf(false)));
+      assertFalse(DevHelper.getFirstNonNullValue(null, Boolean.valueOf(false), Boolean.valueOf(true)));
+      assertFalse(DevHelper.getFirstNonNullValue(Boolean.valueOf(false), Boolean.valueOf(true), Boolean.valueOf(false)));
+      assertTrue(DevHelper.getFirstNonNullValue(Boolean.valueOf(true), Boolean.valueOf(true), Boolean.valueOf(false)));
+      assertFalse(DevHelper.getFirstNonNullValue(null, null, null));
    }
 
    /**
@@ -92,7 +93,7 @@ public class MultiModuleSkipFlagsUnitTest {
          props.setProperty(param, propBool.toString());
       }
 
-      return DevMojo.getBooleanFlag(dom, userProps, props, param);
+      return DevHelper.getBooleanFlag(dom, userProps, props, param);
    }
 
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA2Test.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA2Test.java
@@ -24,7 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA3Test.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA3Test.java
@@ -24,7 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeATest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeATest.java
@@ -24,7 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeBTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeBTest.java
@@ -24,7 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeETest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeETest.java
@@ -24,7 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeGTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeGTest.java
@@ -24,7 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeHTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeHTest.java
@@ -24,7 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeI2Test.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeI2Test.java
@@ -24,7 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeITest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeITest.java
@@ -24,7 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeJTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeJTest.java
@@ -24,7 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleUpdatePomsTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleUpdatePomsTest.java
@@ -25,7 +25,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleConcurrentLibertyModulesPlTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleConcurrentLibertyModulesPlTest.java
@@ -34,7 +34,7 @@ import java.io.OutputStreamWriter;
 import java.nio.file.Files;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleLibertyModulesPlTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleLibertyModulesPlTest.java
@@ -33,7 +33,7 @@ import java.io.OutputStreamWriter;
 import java.nio.file.Files;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleLibertyModulesTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleLibertyModulesTest.java
@@ -33,7 +33,7 @@ import java.io.OutputStreamWriter;
 import java.nio.file.Files;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/RunTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/RunTest.java
@@ -28,7 +28,7 @@ import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.GetMethod;
 
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/liberty-maven-plugin/src/it/generate-features-it/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/pom.xml
@@ -42,6 +42,11 @@
             <artifactId>plexus-utils</artifactId>
             <version>3.4.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-shared-utils</artifactId>
+            <version>3.3.4</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/liberty-maven-plugin/src/it/generate-features-it/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/pom.xml
@@ -42,11 +42,6 @@
             <artifactId>plexus-utils</artifactId>
             <version>3.4.2</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-shared-utils</artifactId>
-            <version>3.3.4</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseGenerateFeaturesTest.java
+++ b/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseGenerateFeaturesTest.java
@@ -48,7 +48,7 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.io.input.ReversedLinesFileReader;
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -75,7 +75,7 @@ public class BaseGenerateFeaturesTest {
         assertTrue(tempProj.exists());
         assertTrue(basicProj.exists());
 
-        FileUtils.copyDirectoryStructure(basicProj, tempProj);
+        FileUtils.copyDirectory(basicProj, tempProj);
         assertTrue(tempProj.listFiles().length > 0);
         logFile = new File(basicProj, "logFile.txt");
         assertTrue(logFile.createNewFile());

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/AbstractLibertySupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/AbstractLibertySupport.java
@@ -58,9 +58,6 @@ public abstract class AbstractLibertySupport extends AbstractMojo {
     @Parameter(defaultValue = "${project}", required = true, readonly = true)
     protected MavenProject project = null;
     
-    //@Parameter(defaultValue = "${localRepository}", required = true, readonly = true)
-    //protected ArtifactRepository artifactRepository = null;
-    
     /**
      * The build settings.
      */
@@ -477,7 +474,6 @@ public abstract class AbstractLibertySupport extends AbstractMojo {
      *
      * @throws MojoExecutionException   Failed to create artifact
      */
-    //@Override
     protected Artifact createArtifact(final Dependency item) throws MojoExecutionException {
         assert item != null;
         

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/InstallFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/InstallFeatureSupport.java
@@ -32,7 +32,7 @@ import io.openliberty.tools.common.plugins.util.InstallFeatureUtil.ProductProper
 import io.openliberty.tools.maven.server.types.Features;
 
 
-public class InstallFeatureSupport extends ServerFeatureSupport {
+public abstract class InstallFeatureSupport extends ServerFeatureSupport {
 
     /**
      * Define a set of features to install in the server and the configuration

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/PluginConfigXmlDocument.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/PluginConfigXmlDocument.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2017.
+ * (C) Copyright IBM Corporation 2017, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import java.util.Map;
 
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Profile;
-import org.codehaus.mojo.pluginsupport.util.ArtifactItem;
 import org.w3c.dom.Element;
 
 import io.openliberty.tools.common.plugins.config.XmlDocument;
@@ -77,7 +77,7 @@ public class PluginConfigXmlDocument extends XmlDocument {
         doc.getDocumentElement().appendChild(child);
     }
     
-    public void createElement(String name, ArtifactItem value) {
+    public void createElement(String name, Dependency value) {
         if (value == null) {
             return;
         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/PrepareFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/PrepareFeatureSupport.java
@@ -24,11 +24,11 @@ import io.openliberty.tools.common.plugins.util.PluginExecutionException;
 import io.openliberty.tools.common.plugins.util.PluginScenarioException;
 import io.openliberty.tools.common.plugins.util.PrepareFeatureUtil;
 
-public class PrepareFeatureSupport extends BasicSupport {
+public abstract class PrepareFeatureSupport extends BasicSupport {
 	
 	
 	private PrepareFeatureUtil util;
-	
+
     protected class PrepareFeatureMojoUtil extends PrepareFeatureUtil {
         public PrepareFeatureMojoUtil(String openLibertyVersion)
                 throws PluginScenarioException, PluginExecutionException {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/ServerFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/ServerFeatureSupport.java
@@ -29,7 +29,7 @@ import org.apache.maven.project.MavenProject;
 
 import io.openliberty.tools.common.plugins.util.ServerFeatureUtil;
 
-public class ServerFeatureSupport extends BasicSupport {
+public abstract class ServerFeatureSupport extends BasicSupport {
 
     private ServerFeatureUtil servUtil;
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojo.java
@@ -47,8 +47,11 @@ import io.openliberty.tools.common.plugins.util.DevUtil;
  */
 @Mojo(name = "deploy", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class DeployMojo extends DeployMojoSupport {
-
-    protected void doExecute() throws Exception {
+    
+    @Override
+    public void execute() throws MojoExecutionException {
+        init();
+        
         if (skip) {
             getLog().info("\nSkipping deploy goal.\n");
             return;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
@@ -24,12 +24,12 @@ import java.util.Set;
 
 import org.apache.commons.lang3.Validate;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.tools.ant.taskdefs.Copy;
-import org.codehaus.mojo.pluginsupport.util.ArtifactItem;
 import org.w3c.dom.Element;
 
 import io.openliberty.tools.ant.ServerTask;
@@ -46,7 +46,7 @@ import io.openliberty.tools.common.plugins.util.DevUtil;
 /**
  * Support for installing and deploying applications to a Liberty server.
  */
-public class DeployMojoSupport extends LooseAppSupport {
+public abstract class DeployMojoSupport extends LooseAppSupport {
 
     private final String PROJECT_ROOT_TARGET_LIBS = "target/libs";
 
@@ -140,7 +140,7 @@ public class DeployMojoSupport extends LooseAppSupport {
             setLooseProjectRootForContainer(proj, config);
         }
 
-        LooseWarApplication looseWar = new LooseWarApplication(proj, config, log);
+        LooseWarApplication looseWar = new LooseWarApplication(proj, config, getLog());
 
         if (looseWar.isExploded()) {
         	
@@ -285,7 +285,7 @@ public class DeployMojoSupport extends LooseAppSupport {
 
                 try {
                     Map<String, File> libertyDirPropertyFiles = getLibertyDirectoryPropertyFiles();
-                    CommonLogger logger = CommonLogger.getInstance(log);
+                    CommonLogger logger = CommonLogger.getInstance(getLog());
                     setLog(logger.getLog());
                     ServerConfigDocument.getInstance(logger, serverXML, configDirectory,
                             bootstrapPropertiesFile, combinedBootstrapProperties, serverEnvFile, false, libertyDirPropertyFiles);
@@ -443,7 +443,7 @@ public class DeployMojoSupport extends LooseAppSupport {
         springBootUtilTask.execute();
     }
 
-    protected boolean matches(Artifact artifact, ArtifactItem assemblyArtifact) {
+    protected boolean matches(Artifact artifact, Dependency assemblyArtifact) {
         return artifact.getGroupId().equals(assemblyArtifact.getGroupId())
                 && artifact.getArtifactId().equals(assemblyArtifact.getArtifactId())
                 && artifact.getType().equals(assemblyArtifact.getType());

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DisplayUrlMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DisplayUrlMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2017.
+ * (C) Copyright IBM Corporation 2017, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,9 @@ public class DisplayUrlMojo extends AbstractMojo {
     @Parameter
     protected URI applicationURL;
  
+    @Override
     public void execute() throws MojoExecutionException {
+        
         if (applicationURL != null && Desktop.isDesktopSupported()) {
             try {
                 Desktop.getDesktop().browse(applicationURL);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/UndeployAppMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/UndeployAppMojo.java
@@ -40,13 +40,11 @@ public class UndeployAppMojo extends DeployMojoSupport {
 
     private static final String STOP_APP_MESSAGE_CODE_REG = "CWWKZ0009I.*";
     private static final long APP_STOP_TIMEOUT_DEFAULT = 30 * 1000;
-    
-    /*
-     * (non-Javadoc)
-     * @see org.codehaus.mojo.pluginsupport.MojoSupport#doExecute()
-     */
+        
     @Override
-    protected void doExecute() throws Exception {
+    public void execute() throws MojoExecutionException {
+        init();
+
         if (skip) {
             getLog().info("\nSkipping undeploy goal.\n");
             return;
@@ -137,7 +135,7 @@ public class UndeployAppMojo extends DeployMojoSupport {
                 File serverXML = new File(serverDirectory.getCanonicalPath(), "server.xml");
             
                 Map<String, File> libertyDirPropertyFiles = getLibertyDirectoryPropertyFiles();
-                CommonLogger logger = CommonLogger.getInstance(log);
+                CommonLogger logger = CommonLogger.getInstance(getLog());
                 setLog(logger.getLog());
                 ServerConfigDocument.getInstance(logger, serverXML, configDirectory,
                 bootstrapPropertiesFile, combinedBootstrapProperties, serverEnvFile, false, libertyDirPropertyFiles);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/extensions/arquillian/ConfigureArquillianMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/extensions/arquillian/ConfigureArquillianMojo.java
@@ -28,7 +28,6 @@ import javax.xml.xpath.XPathExpressionException;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -60,14 +59,11 @@ public class ConfigureArquillianMojo extends BasicSupport {
      */
     @Parameter(property = "skipIfArquillianXmlExists", defaultValue = "false")
     protected boolean skipIfArquillianXmlExists = false;
-
+    
     @Override
-    protected void init() throws MojoExecutionException, MojoFailureException {
-        super.init();
-    }
-
-    @Override
-    public void doExecute() throws MojoExecutionException, MojoFailureException {
+    public void execute() throws MojoExecutionException {
+        init();
+        
         File arquillianXml = new File(project.getBuild().getDirectory(), "test-classes/arquillian.xml");
         Set<Artifact> artifacts = project.getArtifacts();
         

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/jsp/CompileJspMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/jsp/CompileJspMojo.java
@@ -24,7 +24,6 @@ import java.util.TreeSet;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -54,9 +53,11 @@ public class CompileJspMojo extends InstallFeatureSupport {
      */
     @Parameter(defaultValue = "40")
     protected int timeout;
-
+    
     @Override
-    protected void doExecute() throws Exception {
+    public void execute() throws MojoExecutionException {
+        init();
+
         if (skip) {
             getLog().info("\nSkipping compile-jsp goal.\n");
             return;
@@ -115,7 +116,7 @@ public class CompileJspMojo extends InstallFeatureSupport {
         for (Artifact dep : dependencies) {
             if (!dep.isResolved()) {
                 // TODO: Is transitive=true correct here?
-                dep = resolveArtifact(dep, true);
+                dep = resolveArtifact(dep);
             }
             if (dep.getFile() != null) {
                 if (!classpath.add(dep.getFile().getAbsolutePath())) {
@@ -180,8 +181,7 @@ public class CompileJspMojo extends InstallFeatureSupport {
         return sb.toString();
     }
 
-    @Override
-    protected void init() throws MojoExecutionException, MojoFailureException {
+    protected void init() throws MojoExecutionException {
         boolean doInstall = (installDirectory == null);
 
         super.init();

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CheckStatusMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CheckStatusMojo.java
@@ -28,8 +28,11 @@ import io.openliberty.tools.ant.ServerTask;
  */
 @Mojo(name = "status")
 public class CheckStatusMojo extends StartDebugMojoSupport {
-
-    protected void doExecute() throws Exception {
+    
+    @Override
+    public void execute() throws MojoExecutionException {
+        init();
+        
         if (skip) {
             getLog().info("\nSkipping status goal.\n");
             return;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CleanServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CleanServerMojo.java
@@ -50,8 +50,11 @@ public class CleanServerMojo extends StartDebugMojoSupport {
      */
     @Parameter(property = "cleanApps", defaultValue = "false")
     private boolean cleanApps = false;
+    
+    @Override
+    public void execute() throws MojoExecutionException {
+        init();
 
-    protected void doExecute() throws Exception {
         if (skip) {
             getLog().info("\nSkipping clean goal.\n");
             return;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CreateServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/CreateServerMojo.java
@@ -52,7 +52,9 @@ public class CreateServerMojo extends PluginConfigSupport {
     private boolean noPassword;
     
     @Override
-    protected void doExecute() throws Exception {
+    public void execute() throws MojoExecutionException {
+        init();
+
         if (skip) {
             getLog().info("\nSkipping create goal.\n");
             return;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DebugServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DebugServerMojo.java
@@ -37,9 +37,11 @@ public class DebugServerMojo extends StartDebugMojoSupport {
      */
     @Parameter(property = "clean", defaultValue = "false")
     protected boolean clean;
-
+    
     @Override
-    protected void doExecute() throws Exception {
+    public void execute() throws MojoExecutionException {
+        init();
+
         if (skip) {
             getLog().info("\nSkipping debug goal.\n");
             return;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevcMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevcMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2020.
+ * (C) Copyright IBM Corporation 2020, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.openliberty.tools.maven.server;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
@@ -23,11 +24,12 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  */
 @Mojo(name = "devc", requiresDependencyCollection = ResolutionScope.TEST, requiresDependencyResolution = ResolutionScope.TEST)
 public class DevcMojo extends DevMojo {
+
     @Override
-    protected void doExecute() throws Exception {
+    public void execute() throws MojoExecutionException {
         super.setContainer(true);
 
         // call dev mode
-        super.doExecute();
+        super.execute();
     }
 }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DumpServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DumpServerMojo.java
@@ -55,9 +55,11 @@ public class DumpServerMojo extends StartDebugMojoSupport {
      */
     @Parameter(property = "threadDump")
     private boolean threadDump;
-
+    
     @Override
-    protected void doExecute() throws Exception {
+    public void execute() throws MojoExecutionException {
+        init();
+
         if (skip) {
             getLog().info("\nSkipping dump goal.\n");
             return;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -29,7 +29,6 @@ import javax.xml.transform.TransformerException;
 import org.apache.maven.execution.ProjectDependencyGraph;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
@@ -78,26 +77,29 @@ public class GenerateFeaturesMojo extends ServerFeatureSupport {
     @Parameter(property = "optimize", defaultValue = "true")
     private boolean optimize;
 
-    /*
-     * (non-Javadoc)
-     * @see org.codehaus.mojo.pluginsupport.MojoSupport#doExecute()
-     */
     @Override
-    protected void doExecute() throws Exception {
-        if (skip) {
-            getLog().info("\nSkipping generate-features goal.\n");
-            return;
-        }
-        generateFeatures();
-    }
-
-    @Override
-    protected void init() throws MojoExecutionException, MojoFailureException {
+    protected void init() throws MojoExecutionException {
         // @see io.openliberty.tools.maven.BasicSupport#init() skip server config
         // setup as generate features does not require the server to be set up install
         // dir, wlp dir, outputdir, etc.
         this.skipServerConfigSetup = true;
+
         super.init();
+    }
+    
+    @Override
+    public void execute() throws MojoExecutionException {
+        init();
+
+        if (skip) {
+            getLog().info("\nSkipping generate-features goal.\n");
+            return;
+        }
+        try {
+            generateFeatures();
+        } catch (PluginExecutionException e) {
+            throw new MojoExecutionException("Error during generation of features.", e);
+        }
     }
 
     /**

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallFeatureMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallFeatureMojo.java
@@ -55,12 +55,10 @@ public class InstallFeatureMojo extends InstallFeatureSupport {
     @Parameter
     private File serverDir;
 
-    /*
-     * (non-Javadoc)
-     * @see org.codehaus.mojo.pluginsupport.MojoSupport#doExecute()
-     */
     @Override
-    protected void doExecute() throws Exception {
+    public void execute() throws MojoExecutionException {
+        init();
+
         if(!initialize()) {
             return;
         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/InstallServerMojo.java
@@ -24,9 +24,11 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  */
 @Mojo(name = "install-server", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class InstallServerMojo extends PluginConfigSupport {
-
+   
     @Override
-    protected void doExecute() throws Exception {
+    public void execute() throws MojoExecutionException {
+        init();
+
         if (skip) {
             getLog().info("\nSkipping install-server goal.\n");
             return;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/JavaDumpServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/JavaDumpServerMojo.java
@@ -42,9 +42,11 @@ public class JavaDumpServerMojo extends StartDebugMojoSupport {
      */
     @Parameter(property = "systemDump")
     private boolean systemDump;
-
+    
     @Override
-    protected void doExecute() throws Exception {
+    public void execute() throws MojoExecutionException {
+        init();
+
         if (skip) {
             getLog().info("\nSkipping java-dump goal.\n");
             return;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/LooseAppSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/LooseAppSupport.java
@@ -26,7 +26,7 @@ import io.openliberty.tools.maven.utils.MavenProjectUtil;
 /**
  * Loose application Liberty server support.
  */
-public class LooseAppSupport extends PluginConfigSupport {
+public abstract class LooseAppSupport extends PluginConfigSupport {
 
     // get loose application configuration file name for project artifact
     public String getLooseConfigFileName(MavenProject project) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PackageServerMojo.java
@@ -124,9 +124,11 @@ public class PackageServerMojo extends StartDebugMojoSupport {
      */
     @Parameter(property = "skipLibertyPackage", defaultValue = "false")
     protected boolean skipLibertyPackage = false;
-    
+       
     @Override
-    protected void doExecute() throws Exception {
+    public void execute() throws MojoExecutionException {
+        init();
+
         // Set default outputDirectory to liberty-alt-output-dir for package goal.
         if (defaultOutputDirSet) {
             outputDirectory = new File(project.getBuild().getDirectory(), "liberty-alt-output-dir");

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PluginConfigSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PluginConfigSupport.java
@@ -45,7 +45,7 @@ import io.openliberty.tools.common.plugins.config.ServerConfigDocument;
  * 
  * 
  */
-public class PluginConfigSupport extends StartDebugMojoSupport {
+public abstract class PluginConfigSupport extends StartDebugMojoSupport {
 
     /**
      * Application directory.
@@ -325,7 +325,7 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
         if (serverXML != null && serverXML.exists()) {
             try {
             Map<String, File> libertyDirPropertyFiles = getLibertyDirectoryPropertyFiles();
-            CommonLogger logger = CommonLogger.getInstance(log);
+            CommonLogger logger = CommonLogger.getInstance(getLog());
             setLog(logger.getLog());
             scd = ServerConfigDocument.getInstance(logger, serverXML, configDirectory,
                         bootstrapPropertiesFile, combinedBootstrapProperties, serverEnvFile, false,

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PrepareFeatureMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/PrepareFeatureMojo.java
@@ -33,10 +33,11 @@ import io.openliberty.tools.maven.PrepareFeatureSupport;
  */
 @Mojo(name = "prepare-feature")
 public class PrepareFeatureMojo extends PrepareFeatureSupport {
-	
-	
+	    
     @Override
-    protected void doExecute() throws Exception {
+    public void execute() throws MojoExecutionException {
+        init();
+
         if (skip) {
             getLog().info("\nSkipping prepare-feature goal.\n");
             return;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/RunServerMojo.java
@@ -44,9 +44,11 @@ public class RunServerMojo extends PluginConfigSupport {
      */
     @Parameter(property = "embedded", defaultValue = "false")
     private boolean embedded;
-
+    
     @Override
-    protected void doExecute() throws Exception {
+    public void execute() throws MojoExecutionException {
+        init();
+
         if (skip) {
             getLog().info("\nSkipping run goal.\n");
             return;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -63,7 +63,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.tools.ant.taskdefs.Copy;
 import org.apache.tools.ant.types.FileSet;
-import org.codehaus.mojo.pluginsupport.util.ArtifactItem;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.twdata.maven.mojoexecutor.MojoExecutor.Element;
 
@@ -76,7 +75,7 @@ import io.openliberty.tools.maven.utils.ExecuteMojoUtil;
 /**
  * Start/Debug server support.
  */
-public class StartDebugMojoSupport extends ServerFeatureSupport {
+public abstract class StartDebugMojoSupport extends ServerFeatureSupport {
 
     private static final String LIBERTY_MAVEN_PLUGIN_GROUP_ID = "io.openliberty.tools";
     private static final String LIBERTY_MAVEN_PLUGIN_ARTIFACT_ID = "liberty-maven-plugin";
@@ -945,7 +944,7 @@ public class StartDebugMojoSupport extends ServerFeatureSupport {
      * @param earProject
      */
     protected void getOrCreateEarArtifact(MavenProject earProject) {
-        ArtifactItem existingEarItem = createArtifactItem(earProject.getGroupId(), earProject.getArtifactId(), earProject.getPackaging(), earProject.getVersion());
+        org.apache.maven.model.Dependency existingEarItem = createArtifactItem(earProject.getGroupId(), earProject.getArtifactId(), earProject.getPackaging(), earProject.getVersion());
         try {
             Artifact existingEarArtifact = getArtifact(existingEarItem);
             getLog().debug("EAR artifact already exists at " + existingEarArtifact.getFile());

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartServerMojo.java
@@ -61,9 +61,11 @@ public class StartServerMojo extends StartDebugMojoSupport {
      */
     @Parameter(property = "embedded", defaultValue = "false")
     private boolean embedded;
-
+   
     @Override
-    protected void doExecute() throws Exception {
+    public void execute() throws MojoExecutionException {
+        init();
+
         if (skip) {
             getLog().info("\nSkipping start goal.\n");
             return;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StopServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StopServerMojo.java
@@ -34,9 +34,11 @@ public class StopServerMojo extends StartDebugMojoSupport {
      */
     @Parameter(property = "embedded", defaultValue = "false")
     private boolean embedded;
-
+    
     @Override
-    protected void doExecute() throws Exception {
+    public void execute() throws MojoExecutionException {
+        init();
+
         if (skip) {
             getLog().info("\nSkipping stop goal.\n");
             return;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/TestStartServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/TestStartServerMojo.java
@@ -15,6 +15,7 @@
  */
 package io.openliberty.tools.maven.server;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -27,9 +28,9 @@ public class TestStartServerMojo extends StartServerMojo {
     
     @Parameter(property = "skipTestServer", defaultValue = "false")
     private boolean skipTestServer;
-
+    
     @Override
-    protected void doExecute() throws Exception {
+    public void execute() throws MojoExecutionException {
         
         String mavenSkipTest = System.getProperty( "maven.test.skip" );
         String skipTests = System.getProperty( "skipTests" );
@@ -41,6 +42,6 @@ public class TestStartServerMojo extends StartServerMojo {
             getLog().info("\nSkipping test-start goal.\n");
             return;
         }
-        super.doExecute();
+        super.execute();
     }
 }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/TestStopServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/TestStopServerMojo.java
@@ -15,6 +15,7 @@
  */
 package io.openliberty.tools.maven.server;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -27,10 +28,10 @@ public class TestStopServerMojo extends StopServerMojo {
     
     @Parameter(property = "skipTestServer", defaultValue = "false")
     private boolean skipTestServer;
-
+    
     @Override
-    protected void doExecute() throws Exception {
-        
+    public void execute() throws MojoExecutionException {
+         
         String mavenSkipTest = System.getProperty( "maven.test.skip" );
         String skipTests = System.getProperty( "skipTests" );
         String skipITs = System.getProperty( "skipITs" );
@@ -41,6 +42,6 @@ public class TestStopServerMojo extends StopServerMojo {
             getLog().info("\nSkipping test-stop goal.\n");
             return;
         }
-        super.doExecute();
+        super.execute();
     }
 }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/UninstallFeatureMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/UninstallFeatureMojo.java
@@ -18,7 +18,6 @@ package io.openliberty.tools.maven.server;
 import java.text.MessageFormat;
 
 import org.apache.maven.plugin.MojoExecutionException;
-
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -45,13 +44,11 @@ public class UninstallFeatureMojo extends BasicSupport {
     @Parameter
     private Features features;
 
-    /*
-     * (non-Javadoc)
-     * @see org.codehaus.mojo.pluginsupport.MojoSupport#doExecute()
-     */
     @Override
-    protected void doExecute() throws Exception {
-        if (skip) {
+    public void execute() throws MojoExecutionException {
+        init();
+
+         if (skip) {
             getLog().info("\nSkipping uninstall-feature goal.\n");
             return;
         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/AntTaskFactory.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/AntTaskFactory.java
@@ -12,7 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */package io.openliberty.tools.maven.utils;
+ */
+package io.openliberty.tools.maven.utils;
 
 import java.io.PrintStream;
 import java.util.Objects;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/DevHelper.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/DevHelper.java
@@ -1,0 +1,86 @@
+/**
+ * (C) Copyright IBM Corporation 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.tools.maven.utils;
+
+import java.util.Properties;
+
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+public class DevHelper {
+
+    /**
+     * Use the following priority ordering for skip test flags: <br>
+     * 1. within Liberty Maven plugin’s configuration in a module <br>
+     * 2. within Liberty Maven plugin’s configuration in a parent pom’s pluginManagement <br>
+     * 3. by command line with -D <br>
+     * 4. within a module’s properties <br>
+     * 5. within a parent pom’s properties <br>
+     * 
+     * @param config the config xml that might contain the param as an attribute
+     * @param userProps the Maven user properties
+     * @param props the Maven project's properties
+     * @param param the Boolean parameter to look for
+     * @return a boolean in priority order, or null if the param was not found anywhere
+     */
+    public static boolean getBooleanFlag(Xpp3Dom config, Properties userProps, Properties props, String param) {
+        // this handles 1 and 2
+        Boolean pluginConfig = parseBooleanIfDefined(getConfigValue(config, param));
+        
+        // this handles 3
+        Boolean userProp = parseBooleanIfDefined(userProps.getProperty(param));
+        
+        // this handles 4 and 5
+        Boolean prop = parseBooleanIfDefined(props.getProperty(param));
+        
+        return getFirstNonNullValue(pluginConfig, userProp, prop);
+    }
+
+    /**
+     * Gets the value of the given attribute, or null if the attribute is not found.
+     * @param config
+     * @param attribute
+     * @return
+     */
+    private static String getConfigValue(Xpp3Dom config, String attribute) {
+        return (config.getChild(attribute) == null ? null : config.getChild(attribute).getValue());
+    }
+
+    /**
+     * Parses a Boolean from a String if the String is not null.  Otherwise returns null.
+     * @param value the String to parse
+     * @return a Boolean, or null if value is null
+     */
+    private static Boolean parseBooleanIfDefined(String value) {
+        if (value != null) {
+            return Boolean.parseBoolean(value);
+        }
+        return null;
+    }
+
+    /**
+     * Gets the value of the first Boolean object that is not null, in order from lowest to highest index.
+     * @param booleans an array of Boolean objects, some of which may be null
+     * @return the value of the first non-null Boolean, or false if everything is null
+     */
+    public static boolean getFirstNonNullValue(Boolean... booleans) {
+        for (Boolean b : booleans) {
+            if (b != null) {
+                return b.booleanValue();
+            }
+        }
+        return false;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
+	<maven.version>3.8.6</maven.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
More preparation to remove all references to Maven 2.x APIs (org.codehaus) related to https://github.com/OpenLiberty/ci.maven/issues/1651.

1. Changed hierarchy from `org.codehaus.mojo.pluginsupport.MojoSupport` to `org.apache.maven.plugin.AbstractMojo`.
2. Removed reference to `org.apache.maven.artifact.repository.ArtifactRepository` and used `org.eclipse.aether.RepositorySystemSession` instead.
3. Changed all references from `org.codehaus.mojo.pluginsupport.util.ArtifactItem` to `org.apache.maven.model.Dependency`.
4. Fixed all mojos to call `init()` method from `execute()` method.
5. Changed references from `org.apache.maven.shared.utils.io.FileUtils` to `org.apache.commons.io.FileUtils` and used a different `copyDirectory` method.
6. Moved some static methods from `DevMojo` to a new `DevHelper` because using them from a unit test was not working with the new hierarchy. It was trying to activate the mojo and got an exception since no project was set up.
7. Update pom dependency versions - using maven-core 3.8.6 and updated maven-plugin-annotations to 3.8.1.