### PR TITLE
Fix incorrect snapshot version reference

### DIFF
--- a/liberty-maven-app-parent/pom.xml
+++ b/liberty-maven-app-parent/pom.xml
@@ -44,7 +44,7 @@
                 <plugin>
                     <groupId>io.openliberty.tools</groupId>
                     <artifactId>liberty-maven-plugin</artifactId>
-                    <version>3.9-SNAPSHOT</version>
+                    <version>3.8.1-SNAPSHOT</version>
                     <executions>
                         <execution>
                             <id>stop-before-clean</id>


### PR DESCRIPTION
Change `3.9-SNAPSHOT` to `3.8.1-SNAPSHOT` to match version to be released.