### PR TITLE
Update to use ci.common 1.8.26-SNAPSHOT

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -43,7 +43,8 @@ jobs:
     - name: Checkout ci.common
       uses: actions/checkout@v3
       with:
-        repository: OpenLiberty/ci.common
+        repository: cherylking/ci.common
+        ref: fixesForTempConfigDir
         path: ci.common
     - name: Checkout ci.ant
       uses: actions/checkout@v3
@@ -98,7 +99,7 @@ jobs:
     - name: Clone ci.ant, ci.common, ci.maven repos to C drive
       run: |
         cp -r D:/a/ci.maven/ci.maven C:/ci.maven
-        git clone https://github.com/OpenLiberty/ci.common.git C:/ci.common
+        git clone https://github.com/cherylking/ci.common.git --branch fixesForTempConfigDir --single-branch C:/ci.common
         git clone https://github.com/OpenLiberty/ci.ant.git C:/ci.ant
     - name: Cache maven packages
       uses: actions/cache@v3

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>io.openliberty.tools</groupId>
             <artifactId>ci.common</artifactId>
-            <version>1.8.25</version>
+            <version>1.8.26-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.twdata.maven</groupId>


### PR DESCRIPTION
Related to https://github.com/OpenLiberty/liberty-tools-intellij/issues/429