### PR TITLE
Update several plugin versions

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.9.0</version>
                 <executions>
                     <execution>
                         <id>help-goal</id>

--- a/liberty-maven-plugin/src/it/alt-outputdir-it/pom.xml
+++ b/liberty-maven-plugin/src/it/alt-outputdir-it/pom.xml
@@ -50,7 +50,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <packagingExcludes>pom.xml</packagingExcludes>

--- a/liberty-maven-plugin/src/it/appsdirectory-apps-configured-bootstraps-default-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-apps-configured-bootstraps-default-it/pom.xml
@@ -51,17 +51,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/appsdirectory-apps-configured-bootstraps-default-recursive-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-apps-configured-bootstraps-default-recursive-it/pom.xml
@@ -45,17 +45,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/appsdirectory-apps-configured-bootstraps-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-apps-configured-bootstraps-it/pom.xml
@@ -45,17 +45,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/appsdirectory-apps-configured-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-apps-configured-it/pom.xml
@@ -39,17 +39,17 @@
           <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/appsdirectory-apps-configured-variables-include-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-apps-configured-variables-include-it/pom.xml
@@ -44,17 +44,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
@@ -154,7 +154,7 @@
        <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.1</version>
         <executions>
             <execution>
                 <id>default-cli</id>

--- a/liberty-maven-plugin/src/it/appsdirectory-apps-configured-variables-include-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-apps-configured-variables-include-it/pom.xml
@@ -59,7 +59,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
+                <version>5.1.9</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/appsdirectory-apps-configured-variables-include-looseapp-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-apps-configured-variables-include-looseapp-it/pom.xml
@@ -44,17 +44,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
@@ -154,7 +154,7 @@
        <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.1</version>
         <executions>
             <execution>
                 <id>default-cli</id>

--- a/liberty-maven-plugin/src/it/appsdirectory-apps-configured-variables-include-looseapp-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-apps-configured-variables-include-looseapp-it/pom.xml
@@ -59,7 +59,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
+                <version>5.1.9</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/appsdirectory-apps-configured-variables-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-apps-configured-variables-it/pom.xml
@@ -45,17 +45,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/appsdirectory-apps-dependency-notconfigured-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-apps-dependency-notconfigured-it/pom.xml
@@ -45,17 +45,17 @@
            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/appsdirectory-apps-notconfigured-dependency-configured-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-apps-notconfigured-dependency-configured-it/pom.xml
@@ -45,17 +45,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/appsdirectory-apps-notconfigured-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-apps-notconfigured-it/pom.xml
@@ -39,17 +39,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/appsdirectory-configdropins-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-configdropins-it/pom.xml
@@ -39,17 +39,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/appsdirectory-dropins-notconfigured-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-dropins-notconfigured-it/pom.xml
@@ -39,17 +39,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/appsdirectory-include-configured-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-include-configured-it/pom.xml
@@ -39,17 +39,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/appsdirectory-notset-configured-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-notset-configured-it/pom.xml
@@ -45,17 +45,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/appsdirectory-notset-notconfigured-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-notset-notconfigured-it/pom.xml
@@ -49,17 +49,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/appsdirectory-set-appz-notconfigured-it/pom.xml
+++ b/liberty-maven-plugin/src/it/appsdirectory-set-appz-notconfigured-it/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -98,7 +98,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>3.1.2</version>
                 <executions>
                     <execution>
                         <id>integration-test</id>

--- a/liberty-maven-plugin/src/it/arquillian-tests/pom.xml
+++ b/liberty-maven-plugin/src/it/arquillian-tests/pom.xml
@@ -151,7 +151,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <packagingExcludes>pom.xml</packagingExcludes>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -263,7 +263,7 @@
 
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>3.1.2</version>
                 <configuration>
                     <runOrder>alphabetical</runOrder>
                 </configuration>
@@ -287,7 +287,7 @@
 
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>copy-test-resources</id>

--- a/liberty-maven-plugin/src/it/arquillian-tests/pom.xml
+++ b/liberty-maven-plugin/src/it/arquillian-tests/pom.xml
@@ -131,7 +131,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.10</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>copy-server-files</id>
@@ -313,7 +313,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>compile-and-copy-test-classes</id>

--- a/liberty-maven-plugin/src/it/assembly-archive-update-it/pom.xml
+++ b/liberty-maven-plugin/src/it/assembly-archive-update-it/pom.xml
@@ -69,7 +69,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <libertyRuntimeVersion>${liberty.runtime.version}</libertyRuntimeVersion>

--- a/liberty-maven-plugin/src/it/assembly-it/assembly-it-tests/pom.xml
+++ b/liberty-maven-plugin/src/it/assembly-it/assembly-it-tests/pom.xml
@@ -33,12 +33,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.1.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/liberty-maven-plugin/src/it/basic-it/pom.xml
+++ b/liberty-maven-plugin/src/it/basic-it/pom.xml
@@ -45,12 +45,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.1.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/liberty-maven-plugin/src/it/basic-runtime-properties-dependency-mgmt-it/pom.xml
+++ b/liberty-maven-plugin/src/it/basic-runtime-properties-dependency-mgmt-it/pom.xml
@@ -45,12 +45,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.1.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/liberty-maven-plugin/src/it/basic-runtime-properties-override-it/pom.xml
+++ b/liberty-maven-plugin/src/it/basic-runtime-properties-override-it/pom.xml
@@ -33,12 +33,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.1.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/liberty-maven-plugin/src/it/basic-runtime-properties-pom-override-it/pom.xml
+++ b/liberty-maven-plugin/src/it/basic-runtime-properties-pom-override-it/pom.xml
@@ -39,12 +39,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.1.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/pom.xml
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkMode>once</forkMode>
@@ -86,7 +86,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project6/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project6/pom.xml
@@ -127,7 +127,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.3.2</version>
+        <version>3.4.0</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
           <packagingExcludes>pom.xml</packagingExcludes>
@@ -137,7 +137,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <phase>test</phase>
@@ -177,7 +177,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <phase>integration-test</phase>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project7/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project7/pom.xml
@@ -134,7 +134,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.3.2</version>
+        <version>3.4.0</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
           <packagingExcludes>pom.xml</packagingExcludes>
@@ -144,7 +144,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <phase>test</phase>
@@ -184,7 +184,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <phase>integration-test</phase>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project8/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project8/pom.xml
@@ -138,7 +138,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.3.2</version>
+        <version>3.4.0</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
           <packagingExcludes>pom.xml</packagingExcludes>
@@ -148,7 +148,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <phase>test</phase>
@@ -188,7 +188,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <phase>integration-test</phase>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project9/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project9/pom.xml
@@ -134,7 +134,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.3.2</version>
+        <version>3.4.0</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
           <packagingExcludes>pom.xml</packagingExcludes>
@@ -144,7 +144,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <phase>test</phase>
@@ -184,7 +184,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <phase>integration-test</phase>

--- a/liberty-maven-plugin/src/it/compile-jsp-it/pom.xml
+++ b/liberty-maven-plugin/src/it/compile-jsp-it/pom.xml
@@ -33,17 +33,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/config-directory-it/pom.xml
+++ b/liberty-maven-plugin/src/it/config-directory-it/pom.xml
@@ -44,17 +44,17 @@
            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>
@@ -160,7 +160,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.19.1</version>
+                    <version>3.1.2</version>
                     <configuration>
                         <excludes>
                             <exclude>**/MicroClean*.java</exclude>>
@@ -187,7 +187,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.19.1</version>
+                    <version>3.1.2</version>
                     <configuration>
                         <includes>
                             <include>**/MicroCleanBefore*.java</include>
@@ -209,7 +209,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.19.1</version>
+                    <version>3.1.2</version>
                     <configuration>
                         <includes>
                             <include>**/MicroCleanAfter*.java</include>

--- a/liberty-maven-plugin/src/it/config-directory-it/src/test/resources/invalidDirPom.xml
+++ b/liberty-maven-plugin/src/it/config-directory-it/src/test/resources/invalidDirPom.xml
@@ -18,7 +18,7 @@
            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/config-packagefile-multi-module-runnable-it/deploy-app/pom.xml
+++ b/liberty-maven-plugin/src/it/config-packagefile-multi-module-runnable-it/deploy-app/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <packagingExcludes>pom.xml</packagingExcludes>
@@ -117,7 +117,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkMode>once</forkMode>
@@ -147,7 +147,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/liberty-maven-plugin/src/it/config-packagefile-multi-module-runnable-it/make-package/pom.xml
+++ b/liberty-maven-plugin/src/it/config-packagefile-multi-module-runnable-it/make-package/pom.xml
@@ -36,17 +36,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/pom.xml
+++ b/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/pom.xml
@@ -50,7 +50,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <packagingExcludes>pom.xml</packagingExcludes>
@@ -132,7 +132,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkMode>once</forkMode>
@@ -162,7 +162,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -191,7 +191,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.19.1</version>
+                        <version>3.1.2</version>
                         <configuration>
                             <excludes>
                                 <include>**/AppFileTest.java</include>
@@ -227,7 +227,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.19.1</version>
+                        <version>3.1.2</version>
                         <configuration>
                             <excludes>
                                 <include>**/LooseConfigTest.java</include>
@@ -260,7 +260,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.19.1</version>
+                        <version>3.1.2</version>
                         <configuration>
                             <excludes>
                                 <include>**/AppFileTest.java</include>

--- a/liberty-maven-plugin/src/it/deploy-loose-config-it/pom.xml
+++ b/liberty-maven-plugin/src/it/deploy-loose-config-it/pom.xml
@@ -50,7 +50,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <packagingExcludes>pom.xml</packagingExcludes>
@@ -122,7 +122,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkMode>once</forkMode>
@@ -152,7 +152,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -181,7 +181,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.19.1</version>
+                        <version>3.1.2</version>
                         <configuration>
                             <excludes>
                                 <include>**/AppFileTest.java</include>
@@ -217,7 +217,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.19.1</version>
+                        <version>3.1.2</version>
                         <configuration>
                             <excludes>
                                 <include>**/LooseConfigTest.java</include>
@@ -254,7 +254,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.19.1</version>
+                        <version>3.1.2</version>
                         <configuration>
                             <excludes>
                                 <include>**/AppFileTest.java</include>

--- a/liberty-maven-plugin/src/it/dev-it/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/pom.xml
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.2</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkCount>1</forkCount>
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-umbrella-deps/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-umbrella-deps/pom.xml
@@ -95,7 +95,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.3.2</version>
+        <version>3.4.0</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
           <packagingExcludes>pom.xml</packagingExcludes>
@@ -105,7 +105,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <phase>test</phase>
@@ -144,7 +144,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <phase>integration-test</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
@@ -169,7 +169,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.3.2</version>
+        <version>3.4.0</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
           <packagingExcludes>pom.xml</packagingExcludes>
@@ -179,7 +179,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <phase>test</phase>
@@ -219,7 +219,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <phase>integration-test</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/exploded-war-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/exploded-war-project/pom.xml
@@ -149,7 +149,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>3.2.2</version>
+				<version>3.4.0</version>
 				<configuration>
 					<failOnMissingWebXml>false</failOnMissingWebXml>
 					<packagingExcludes>pom.xml</packagingExcludes>
@@ -175,7 +175,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0-M1</version>
+				<version>3.1.2</version>
 				<executions>
 					<execution>
 						<phase>test</phase>
@@ -215,7 +215,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>3.0.0-M1</version>
+				<version>3.1.2</version>
 				<executions>
 					<execution>
 						<phase>integration-test</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear1/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.0</version>
                 <configuration>
                     <modules>
                         <jarModule>
@@ -97,7 +97,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear1/pom.xml
@@ -97,7 +97,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear2/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.0</version>
                 <configuration>
                     <modules>
                         <jarModule>
@@ -97,7 +97,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear2/pom.xml
@@ -97,7 +97,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/jar/pom.xml
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </build>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/war/pom.xml
@@ -67,13 +67,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
             </plugin>
             <!-- Surefire plugin to run unit tests --> 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </build>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-ear/pom.xml
@@ -60,11 +60,22 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>2.10.1</version>
+                <version>3.3.0</version>
                 <configuration>
                     <version>7</version>
-                    <fileNameMapping>no-version</fileNameMapping>
                     <generateApplicationXml>true</generateApplicationXml>
+                    <modules>
+                        <webModule>
+                            <groupId>sample</groupId>
+                            <artifactId>ejb-war</artifactId>
+                            <bundleFileName>ejb-war.war</bundleFileName>
+                        </webModule>
+                        <ejbModule>
+                            <groupId>sample</groupId>
+                            <artifactId>ejb-ejb</artifactId>
+                            <bundleFileName>ejb-ejb.jar</bundleFileName>
+                        </ejbModule>
+                    </modules>
                 </configuration>
             </plugin>
             <plugin>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-ejb/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-ejb/pom.xml
@@ -34,7 +34,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ejb-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.1</version>
                 <configuration>
                     <ejbVersion>3.1</ejbVersion>
                 </configuration>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-war/pom.xml
@@ -41,7 +41,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.4.0</version>
                 <configuration>
                     <packagingExcludes>pom.xml</packagingExcludes>
                 </configuration>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/ear/pom.xml
@@ -55,7 +55,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.0</version>
                 <configuration>
                     <modules>
                         <jarModule>
@@ -81,7 +81,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>
@@ -95,7 +95,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/ear/pom.xml
@@ -81,7 +81,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/jar/pom.xml
@@ -39,7 +39,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
             </plugin>
 
             <plugin>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/pom.xml
@@ -58,13 +58,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <!-- Surefire plugin to run unit tests -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.1.2</version>
                 </plugin>
             </plugins>
 

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/war/pom.xml
@@ -60,13 +60,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
             </plugin>
             <!-- Surefire plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
             </plugin>
 
             <plugin>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.0</version>
                 <configuration>
                     <modules>
                         <jarModule>
@@ -97,7 +97,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
@@ -97,7 +97,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/jar/pom.xml
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </build>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/pom.xml
@@ -67,18 +67,18 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
             </plugin>
             <!-- Surefire plugin to run unit tests --> 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <packagingExcludes>pom.xml</packagingExcludes>
                 </configuration>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
@@ -93,7 +93,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.0</version>
                 <configuration>
                     <modules>
                         <jarModule>
@@ -93,7 +93,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>
@@ -108,7 +108,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/ear/pom.xml
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/ear/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.0</version>
                 <configuration>
                     <modules>
                         <jarModule>
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/pom.xml
@@ -40,20 +40,20 @@
                 <plugin>
                     <groupId>io.openliberty.tools</groupId>
                     <artifactId>liberty-maven-plugin</artifactId>
-                    <version>3.4-SNAPSHOT</version>
+                    <version>3.8.2-SNAPSHOT</version>
                 </plugin>
 
                 <!-- Plugin to run integration tests -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <!-- Surefire plugin to run unit tests -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.1.2</version>
                 </plugin>
             </plugins>
 

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
@@ -83,7 +83,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.4.0</version>
                 <configuration>
                     <modules>
                         <jarModule>
@@ -114,7 +114,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>
@@ -129,7 +129,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
@@ -114,7 +114,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/ear/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.0</version>
                 <configuration>
                     <modules>
                         <jarModule>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
@@ -70,7 +70,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
@@ -70,7 +70,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/ear/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.0</version>
                 <configuration>
                     <modules>
                         <jarModule>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
@@ -69,7 +69,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
@@ -69,7 +69,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>
@@ -84,7 +84,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/ear/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.0</version>
                 <configuration>
                     <modules>
                         <jarModule>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
@@ -70,7 +70,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
@@ -70,7 +70,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/war/pom.xml
@@ -56,7 +56,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <packagingExcludes>pom.xml</packagingExcludes>
                 </configuration>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/pom.xml
@@ -77,7 +77,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.0</version>
                 <configuration>
                     <modules>
                         <jarModule>
@@ -77,7 +77,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>
@@ -92,7 +92,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/ear/pom.xml
@@ -77,7 +77,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/ear/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.0</version>
                 <configuration>
                     <modules>
                         <jarModule>
@@ -77,7 +77,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>
@@ -92,7 +92,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
@@ -76,7 +76,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
@@ -76,7 +76,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>
@@ -91,7 +91,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/pom.xml
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.4.0</version>
                 <configuration>
                     <modules>
                         <jarModule>
@@ -98,7 +98,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>
@@ -113,7 +113,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/pom.xml
@@ -98,7 +98,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/pom.xml
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.4.0</version>
                 <configuration>
                     <modules>
                         <jarModule>
@@ -98,7 +98,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>
@@ -113,7 +113,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/pom.xml
@@ -98,7 +98,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/liberty-maven-plugin/src/it/ear-project-it/AppXmlEAR/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/AppXmlEAR/pom.xml
@@ -134,7 +134,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkMode>once</forkMode>

--- a/liberty-maven-plugin/src/it/ear-project-it/AppXmlEAR/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/AppXmlEAR/pom.xml
@@ -53,7 +53,7 @@
                         libraries are in easy way to package any libraries needed in the ear, and 
                         automatically have any modules (EJB-JARs and WARs) use them -->
                     <defaultLibBundleDir>lib</defaultLibBundleDir>
-                    <!--outputFileNameMapping>@{artifactId}@.@{extension}@</outputFileNameMapping-->
+                    <outputFileNameMapping>@{artifactId}@.@{extension}@</outputFileNameMapping>
                     <applicationXml>${project.basedir}/src/main/application/META-INF/application.xml</applicationXml>
                 </configuration>
             </plugin>

--- a/liberty-maven-plugin/src/it/ear-project-it/AppXmlEAR/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/AppXmlEAR/pom.xml
@@ -53,7 +53,7 @@
                         libraries are in easy way to package any libraries needed in the ear, and 
                         automatically have any modules (EJB-JARs and WARs) use them -->
                     <defaultLibBundleDir>lib</defaultLibBundleDir>
-                    <fileNameMapping>no-version</fileNameMapping>
+                    <!--outputFileNameMapping>@{artifactId}@.@{extension}@</outputFileNameMapping-->
                     <applicationXml>${project.basedir}/src/main/application/META-INF/application.xml</applicationXml>
                 </configuration>
             </plugin>

--- a/liberty-maven-plugin/src/it/ear-project-it/SampleEAR-classifier-app/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/SampleEAR-classifier-app/pom.xml
@@ -66,6 +66,17 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>default-install</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
                 <version>@pom.version@</version>

--- a/liberty-maven-plugin/src/it/ear-project-it/SampleEAR-classifier-app/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/SampleEAR-classifier-app/pom.xml
@@ -47,7 +47,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>3.0.2</version>
                 <configuration>
                     <!-- Tell Maven we are using Java EE 7 -->
                     <version>7</version>
@@ -139,7 +138,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkMode>once</forkMode>

--- a/liberty-maven-plugin/src/it/ear-project-it/SampleEAR/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/SampleEAR/pom.xml
@@ -52,7 +52,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>3.0.2</version>
                 <configuration>
                     <!-- Tell Maven we are using Java EE 7 -->
                     <version>7</version>
@@ -153,7 +152,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkMode>once</forkMode>

--- a/liberty-maven-plugin/src/it/ear-project-it/SampleEJB-classifier-dep/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/SampleEJB-classifier-dep/pom.xml
@@ -38,6 +38,17 @@
                     <classifier>the-ejb</classifier>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>default-install</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/liberty-maven-plugin/src/it/ear-project-it/SampleEar_NonLooseApp/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/SampleEar_NonLooseApp/pom.xml
@@ -52,7 +52,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>3.0.2</version>
                 <configuration>
                     <!-- Tell Maven we are using Java EE 7 -->
                     <version>7</version>
@@ -153,7 +152,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkMode>once</forkMode>

--- a/liberty-maven-plugin/src/it/ear-project-it/helloworld-ear/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/helloworld-ear/pom.xml
@@ -35,7 +35,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>3.0.2</version>
                 <configuration>
                     <version>7</version>
                     <outputFileNameMapping>@{artifactId}@.@{extension}@</outputFileNameMapping>
@@ -106,7 +105,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -118,7 +116,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/liberty-maven-plugin/src/it/ear-project-it/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/pom.xml
@@ -83,7 +83,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.10.1</version>
+                    <version>3.11.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/liberty-maven-plugin/src/it/ear-project-it/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/pom.xml
@@ -85,6 +85,11 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.10.1</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>3.1.2</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/liberty-maven-plugin/src/it/ear-project-it/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/pom.xml
@@ -63,27 +63,27 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-ejb-plugin</artifactId>
-                    <version>2.5.1</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-ear-plugin</artifactId>
-                    <version>2.10.1</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-rar-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.6.1</version>
+                    <version>3.10.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/liberty-maven-plugin/src/it/ear-project-it/skinnywar-ear/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/skinnywar-ear/pom.xml
@@ -54,23 +54,7 @@
                     <version>7</version>
                     <defaultLibBundleDir>lib</defaultLibBundleDir>
                     <skinnyWars>true</skinnyWars>
-                    <modules>
-                        <webModule>
-                            <groupId>io.openliberty.tools.it</groupId>
-                            <artifactId>SampleWAR</artifactId>
-                            <bundleFileName>SampleWAR.war</bundleFileName>
-                        </webModule>
-                        <ejbModule>
-                            <groupId>io.openliberty.tools.it</groupId>
-                            <artifactId>SampleEJB</artifactId>
-                            <bundleFileName>SampleEJB.jar</bundleFileName>
-                        </ejbModule>
-                        <jarModule>
-                            <groupId>commons-io</groupId>
-                            <artifactId>commons-io</artifactId>
-                            <bundleFileName>commons-io.jar</bundleFileName>   
-                        </jarModule>
-                    </modules>
+                    <outputFileNameMapping>@{artifactId}@.@{extension}@</outputFileNameMapping>
                 </configuration>
             </plugin>
             <plugin>

--- a/liberty-maven-plugin/src/it/ear-project-it/skinnywar-ear/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/skinnywar-ear/pom.xml
@@ -53,9 +53,25 @@
                 <version>2.10.1</version>
                 <configuration>
                     <version>7</version>
-                    <fileNameMapping>no-version</fileNameMapping>
                     <defaultLibBundleDir>lib</defaultLibBundleDir>
                     <skinnyWars>true</skinnyWars>
+                    <modules>
+                        <webModule>
+                            <groupId>io.openliberty.tools.it</groupId>
+                            <artifactId>SampleWAR</artifactId>
+                            <bundleFileName>SampleWAR.war</bundleFileName>
+                        </webModule>
+                        <ejbModule>
+                            <groupId>io.openliberty.tools.it</groupId>
+                            <artifactId>SampleEJB</artifactId>
+                            <bundleFileName>SampleEJB.jar</bundleFileName>
+                        </ejbModule>
+                        <jarModule>
+                            <groupId>commons-io</groupId>
+                            <artifactId>commons-io</artifactId>
+                            <bundleFileName>commons-io.jar</bundleFileName>   
+                        </jarModule>
+                    </modules>
                 </configuration>
             </plugin>
             <plugin>

--- a/liberty-maven-plugin/src/it/ear-project-it/skinnywar-ear/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/skinnywar-ear/pom.xml
@@ -50,7 +50,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>2.10.1</version>
                 <configuration>
                     <version>7</version>
                     <defaultLibBundleDir>lib</defaultLibBundleDir>
@@ -111,7 +110,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -123,7 +121,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/liberty-maven-plugin/src/it/ear-project-it/skinnywar-ear/src/test/java/net/wasdev/wlp/maven/test/it/LooseConfigTestIT.java
+++ b/liberty-maven-plugin/src/it/ear-project-it/skinnywar-ear/src/test/java/net/wasdev/wlp/maven/test/it/LooseConfigTestIT.java
@@ -77,10 +77,10 @@ public class LooseConfigTestIT {
         
         expression = "/archive/archive/dir";
         nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
-        assertEquals("Number of <dir/> element ==>", 3, nodes.getLength());
+        assertEquals("Number of <dir/> element ==>", 2, nodes.getLength());
         
         expression = "/archive/archive/file";
         nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
-        assertEquals("Number of <dir/> element ==>", 1, nodes.getLength());
+        assertEquals("Number of <dir/> element ==>", 2, nodes.getLength());
     }
 }

--- a/liberty-maven-plugin/src/it/ear-project-it/skinnywar-wlp/src/test/java/net/wasdev/wlp/maven/test/it/LooseConfigTestIT.java
+++ b/liberty-maven-plugin/src/it/ear-project-it/skinnywar-wlp/src/test/java/net/wasdev/wlp/maven/test/it/LooseConfigTestIT.java
@@ -77,10 +77,10 @@ public class LooseConfigTestIT {
         
         expression = "/archive/archive/dir";
         nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
-        assertEquals("Number of <dir/> element ==>", 3, nodes.getLength());
+        assertEquals("Number of <dir/> element ==>", 2, nodes.getLength());
         
         expression = "/archive/archive/file";
         nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
-        assertEquals("Number of <dir/> element ==>", 1, nodes.getLength());
+        assertEquals("Number of <dir/> element ==>", 2, nodes.getLength());
     }
 }

--- a/liberty-maven-plugin/src/it/generate-features-it/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/pom.xml
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.2</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkCount>1</forkCount>
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/basic-dev-project/pom.xml
@@ -134,7 +134,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.3.2</version>
+        <version>3.4.0</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
           <packagingExcludes>pom.xml</packagingExcludes>
@@ -144,7 +144,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <phase>test</phase>
@@ -184,7 +184,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <phase>integration-test</phase>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/ear/pom.xml
@@ -53,7 +53,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.0</version>
                 <configuration>
                     <modules>
                         <jarModule>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/pom/pom.xml
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/pom/pom.xml
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>
@@ -77,7 +77,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <default.http.port>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/restful/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/restful/pom.xml
@@ -128,7 +128,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <packagingExcludes>pom.xml</packagingExcludes>
@@ -138,7 +138,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>3.1.2</version>
                 <executions>
                     <execution>
                         <phase>test</phase>
@@ -221,7 +221,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>3.1.2</version>
                 <executions>
                     <execution>
                         <phase>integration-test</phase>

--- a/liberty-maven-plugin/src/it/include-from-bootstrap-it/pom.xml
+++ b/liberty-maven-plugin/src/it/include-from-bootstrap-it/pom.xml
@@ -39,17 +39,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/install-apps-project-it/pom.xml
+++ b/liberty-maven-plugin/src/it/install-apps-project-it/pom.xml
@@ -39,17 +39,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-server-it/pom.xml
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/install-features-server-it/pom.xml
@@ -16,7 +16,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>copy-resources</id>

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/install-usr-feature-ext-it/pom.xml
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/install-usr-feature-ext-it/pom.xml
@@ -16,7 +16,7 @@
         <plugins>
         	<plugin>
 	            <artifactId>maven-resources-plugin</artifactId>
-	            <version>3.1.0</version>
+	            <version>3.3.1</version>
 	            <executions>
 	                <execution>
 	                    <id>copy-resource-one</id>

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/install-usr-feature-old-version/pom.xml
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/install-usr-feature-old-version/pom.xml
@@ -16,7 +16,7 @@
         <plugins>
         	<plugin>
 	            <artifactId>maven-resources-plugin</artifactId>
-	            <version>3.1.0</version>
+	            <version>3.3.1</version>
 	            <executions>
 	                <execution>
 	                    <id>copy-resource</id>

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/pom.xml
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/pom.xml
@@ -95,7 +95,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkMode>once</forkMode>
@@ -125,7 +125,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/prepare-feature-it/pom.xml
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/prepare-feature-it/pom.xml
@@ -16,7 +16,7 @@
         <plugins>
         	<plugin>
 	            <artifactId>maven-resources-plugin</artifactId>
-	            <version>3.1.0</version>
+	            <version>3.3.1</version>
 	            <executions>
 	                <execution>
 	                    <id>copy-resource-one</id>

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/prepare-multiple-features-it/pom.xml
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/prepare-multiple-features-it/pom.xml
@@ -16,7 +16,7 @@
         <plugins>
         	<plugin>
 	            <artifactId>maven-resources-plugin</artifactId>
-	            <version>3.1.0</version>
+	            <version>3.3.1</version>
 	            <executions>
 	                <execution>
 	                    <id>copy-resource-one</id>

--- a/liberty-maven-plugin/src/it/loose-config-it/pom.xml
+++ b/liberty-maven-plugin/src/it/loose-config-it/pom.xml
@@ -50,7 +50,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <packagingExcludes>pom.xml</packagingExcludes>
@@ -133,7 +133,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkMode>once</forkMode>
@@ -163,7 +163,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/liberty-maven-plugin/src/it/loose-war-ejb-it/ejb/pom.xml
+++ b/liberty-maven-plugin/src/it/loose-war-ejb-it/ejb/pom.xml
@@ -34,7 +34,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ejb-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.1</version>
                 <configuration>
                     <!-- Tell Maven we are using EJB 3.1 -->
                     <ejbVersion>3.1</ejbVersion>

--- a/liberty-maven-plugin/src/it/loose-war-ejb-it/war/pom.xml
+++ b/liberty-maven-plugin/src/it/loose-war-ejb-it/war/pom.xml
@@ -43,7 +43,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <packagingExcludes>pom.xml</packagingExcludes>
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkMode>once</forkMode>
@@ -106,7 +106,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.1.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/liberty-maven-plugin/src/it/loose-war-ejb-type-it/ejb/pom.xml
+++ b/liberty-maven-plugin/src/it/loose-war-ejb-type-it/ejb/pom.xml
@@ -34,7 +34,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ejb-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.1</version>
                 <configuration>
                     <!-- Tell Maven we are using EJB 3.1 -->
                     <ejbVersion>3.1</ejbVersion>

--- a/liberty-maven-plugin/src/it/loose-war-ejb-type-it/war/pom.xml
+++ b/liberty-maven-plugin/src/it/loose-war-ejb-type-it/war/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <packagingExcludes>pom.xml</packagingExcludes>
@@ -86,7 +86,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkMode>once</forkMode>
@@ -107,7 +107,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.1.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/liberty-maven-plugin/src/it/merge-server-env-it/pom.xml
+++ b/liberty-maven-plugin/src/it/merge-server-env-it/pom.xml
@@ -38,17 +38,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/merge-server-env-none-it/pom.xml
+++ b/liberty-maven-plugin/src/it/merge-server-env-none-it/pom.xml
@@ -33,17 +33,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </pluginManagement>

--- a/liberty-maven-plugin/src/it/package-type-config-it/pom.xml
+++ b/liberty-maven-plugin/src/it/package-type-config-it/pom.xml
@@ -48,7 +48,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <packagingExcludes>pom.xml</packagingExcludes>
@@ -78,7 +78,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkMode>once</forkMode>
@@ -108,7 +108,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -132,7 +132,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.19.1</version>
+                        <version>3.1.2</version>
                         <configuration>
                             <includes>
                                 <include>**/PackageTypeJarTest.java</include>
@@ -158,7 +158,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.19.1</version>
+                        <version>3.1.2</version>
                         <configuration>
                             <includes>
                                 <include>**/PackageTypeRunnableJarTest.java</include>
@@ -183,7 +183,7 @@
                      <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.19.1</version>
+                        <version>3.1.2</version>
                         <configuration>
                             <includes>
                                 <include>**/PackageTypeZipTest.java</include>
@@ -208,7 +208,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.19.1</version>
+                        <version>3.1.2</version>
                         <configuration>
                             <includes>
                                 <include>**/PackageTypeTarTest.java</include>
@@ -233,7 +233,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.19.1</version>
+                        <version>3.1.2</version>
                         <configuration>
                             <includes>
                                 <include>**/PackageTypeTarGzTest.java</include>

--- a/liberty-maven-plugin/src/it/preserve-usr-dir-it/pom.xml
+++ b/liberty-maven-plugin/src/it/preserve-usr-dir-it/pom.xml
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.6.0</version>
                 <configuration>
                     <artifactItems>
                         <artifactItem>

--- a/liberty-maven-plugin/src/it/preserve-usr-dir-it/pom.xml
+++ b/liberty-maven-plugin/src/it/preserve-usr-dir-it/pom.xml
@@ -39,7 +39,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/liberty-maven-plugin/src/it/server-config-props-it/pom.xml
+++ b/liberty-maven-plugin/src/it/server-config-props-it/pom.xml
@@ -74,7 +74,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <packagingExcludes>pom.xml</packagingExcludes>
@@ -122,7 +122,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.19.1</version>
+                        <version>3.1.2</version>
                         <configuration>
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <forkMode>once</forkMode>

--- a/liberty-maven-plugin/src/it/server-param-configdir-not-override-it/pom.xml
+++ b/liberty-maven-plugin/src/it/server-param-configdir-not-override-it/pom.xml
@@ -32,7 +32,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -63,7 +63,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/liberty-maven-plugin/src/it/server-param-default-it/pom.xml
+++ b/liberty-maven-plugin/src/it/server-param-default-it/pom.xml
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.5</version>
+                <version>3.1.0</version>
                 <!--  add WLP_OUTPUT_DIR envvar in server.env to change the server output directory.
                       it will override the <outputDirectory/> value and it will be tested in
                       ServerOutputDirIT. The value must be an absolute path.

--- a/liberty-maven-plugin/src/it/server-param-default-it/pom.xml
+++ b/liberty-maven-plugin/src/it/server-param-default-it/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
               <groupId>org.codehaus.mojo</groupId>
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/liberty-maven-plugin/src/it/server-param-pom-override-it/pom.xml
+++ b/liberty-maven-plugin/src/it/server-param-pom-override-it/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
@@ -80,7 +80,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.1.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/liberty-maven-plugin/src/it/setup/assembly-server/pom.xml
+++ b/liberty-maven-plugin/src/it/setup/assembly-server/pom.xml
@@ -24,12 +24,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.7</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>io.openliberty.tools</groupId>

--- a/liberty-maven-plugin/src/it/setup/test-war/pom.xml
+++ b/liberty-maven-plugin/src/it/setup/test-war/pom.xml
@@ -35,7 +35,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.3.7</version>
+                    <version>5.1.9</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/liberty-maven-plugin/src/it/setup/test-war/pom.xml
+++ b/liberty-maven-plugin/src/it/setup/test-war/pom.xml
@@ -30,7 +30,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.3.2</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>

--- a/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-apps-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-apps-it/pom.xml
@@ -132,7 +132,7 @@
 
 			<plugin>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>3.0.0-M1</version>
+				<version>3.1.2</version>
 				<configuration>
 					<runOrder>alphabetical</runOrder>
 				</configuration>

--- a/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-dropins-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-dropins-it/pom.xml
@@ -127,7 +127,7 @@
 			
 			<plugin>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>3.0.0-M1</version>
+				<version>3.1.2</version>
 				<configuration>
 				    <runOrder>alphabetical</runOrder>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>animal-sniffer-maven-plugin</artifactId>
-                        <version>1.22</version>
+                        <version>1.23</version>
                         <configuration>
                             <signature>
                                 <groupId>org.codehaus.mojo.signature</groupId>


### PR DESCRIPTION
Related to #1691 

Not a fix, but updating some of the versions of maven plugins we are using that are flagged as warnings with `-Dmaven.plugin.validation=VERBOSE` parameter set.