### PR TITLE
Fix EJB type dependency in WAR-in-EAR for skinny WAR case

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
@@ -326,7 +326,8 @@ public abstract class DeployMojoSupport extends LooseAppSupport {
             // skip the embedded library if it is included in the lib directory of the ear
             // package
             if (("compile".equals(artifact.getScope()) || "runtime".equals(artifact.getScope()))
-                    && "jar".equals(artifact.getType()) && !looseEar.isEarDependency(artifact)) {
+                    && ("jar".equals(artifact.getType()) || "jar".equals(artifact.getArtifactHandler().getExtension()))
+                    && !looseEar.isEarDependency(artifact)) {
                 addLibrary(parent, looseEar, "/WEB-INF/lib/", artifact);
             }
         }


### PR DESCRIPTION
Came across this from an internal user.

A quick test show me we can apply basically the same fix as in https://github.com/OpenLiberty/ci.maven/pull/1527 