### PR TITLE
Handle bundle packaging type

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/LooseAppSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/LooseAppSupport.java
@@ -56,12 +56,13 @@ public abstract class LooseAppSupport extends PluginConfigSupport {
             name += "-" + classifier;
         }
 
-        if (project.getPackaging().equals("liberty-assembly")) {
+        String packagingType = project.getPackaging();
+        if (packagingType.equals("liberty-assembly")) {
             name += ".war";
-        } else if (project.getPackaging().equals("ejb")) {
+        } else if (packagingType.equals("ejb") || packagingType.equals("bundle")) {
             name += ".jar";
         } else {
-            name += "." + project.getPackaging();
+            name += "." + packagingType;
         }
 
         return name;


### PR DESCRIPTION
Fixes #1700 

There are two other places in the code that checks the packaging type that I wonder if needs to be changed?

https://github.com/OpenLiberty/ci.maven/blob/main/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java#L344

https://github.com/OpenLiberty/ci.maven/blob/main/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/MavenProjectUtil.java#L66