### PR TITLE
Run war:war in ShutdownHook

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -1424,6 +1424,18 @@ public class DevMojo extends LooseAppSupport {
         }
 
         util.addShutdownHook(executor);
+
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                try {
+                    runMojoForProject("org.apache.maven.plugins", "maven-war-plugin", "war", project);
+                } catch (MojoExecutionException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+            }
+        });
         
         try {
             util.startServer();


### PR DESCRIPTION
Fixes #1476 

This is certainly not a complete solution.  Still, I wanted to nudge this along slightly.

This seems to provide a real basic solution to the problem, assuming you're running a WAR.

Some other design elements could include:
* a hotkey to package the WAR in dev mode
* a config to enable/disable this behavior.