### PR TITLE
Update to newer versions

### DIFF
--- a/liberty-maven-plugin/src/it/assembly-archive-update-it/invoker.properties
+++ b/liberty-maven-plugin/src/it/assembly-archive-update-it/invoker.properties
@@ -1,3 +1,3 @@
-invoker.goals.1 = install -Dliberty.runtime.version=19.0.0.9
-invoker.goals.2 = install -Dliberty.runtime.version=19.0.0.10
-invoker.goals.3 = install -Dliberty.runtime.version=19.0.0.9
+invoker.goals.1 = install -Dliberty.runtime.version=23.0.0.6
+invoker.goals.2 = install -Dliberty.runtime.version=23.0.0.7
+invoker.goals.3 = install -Dliberty.runtime.version=23.0.0.6


### PR DESCRIPTION
Updating this test case to use newer versions due to recent strange error the `assembly-archive-update-it` started receiving on multiple builds.

```
Error: [ERROR] Failed to execute goal io.openliberty.tools:liberty-maven-plugin:3.8.3-SNAPSHOT:install-feature (install-server-features) on project assembly-archive-update-it: Error installing features for server test: CWWKF1287E: The com.ibm.websphere.appserver.jsp-2.3 feature cannot be installed because the com.ibm.ws.jsp_1.0.32.jar file inside of the Enterprise Subsystem Archive (ESA) file is not a bundle file. The ESA root must contain only bundle files and directories. If you created the ESA file, verify that the file contents are correct.
```