### PR TITLE
Reduce log size and free up disk space on Linux

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -72,7 +72,7 @@ jobs:
         ./mvnw -V clean install -f ci.common --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false
     # Run tests
     - name: Run tests
-      run: ./mvnw -V verify --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -Ponline-its -D"invoker.streamLogs"=true -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
+      run: ./mvnw -V verify --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -Ponline-its -D"invoker.streamLogsOnFailures"=true -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
 
 # WINDOWS BUILD
   build-windows:
@@ -127,4 +127,4 @@ jobs:
     # Run tests
     - name: Run tests
       working-directory: C:/ci.maven
-      run: .\mvnw.cmd -V verify -Ponline-its --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -D"invoker.streamLogs"=true -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
+      run: .\mvnw.cmd -V verify -Ponline-its --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -D"invoker.streamLogsOnFailures"=true -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -40,6 +40,11 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
         cache: 'maven'
+    - name: Free disk space ubuntu
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        large-packages: false
     - name: Checkout ci.common
       uses: actions/checkout@v3
       with:

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -141,7 +141,7 @@
                             <profiles>
                                 <profile>offline-its</profile>
                             </profiles>
-                            <streamLogs>true</streamLogs>
+                            <streamLogsOnFailures>true</streamLogsOnFailures>
                         </configuration>
                         <executions>
                             <execution>
@@ -177,11 +177,10 @@
                                 <runtimeKernelId>${runtimeKernelId}</runtimeKernelId>
                                 <runtimeVersion>${runtimeVersion}</runtimeVersion>
                             </properties>
-                            <streamLogs>true</streamLogs>
                             <profiles>
                                 <profile>online-its</profile>
                             </profiles>
-                            <streamLogs>true</streamLogs>
+                            <streamLogsOnFailures>true</streamLogsOnFailures>
                             <mavenOpts>-Dfile.encoding=UTF-8</mavenOpts>
                         </configuration>
                         <executions>


### PR DESCRIPTION
Recently we began running out of disk space on at least half the Linux jobs in each GHA build.

1) Changed `streamLogs` to `streamLogsOnFailures` to reduce log size.
2) Used GHA action `jlumbroso/free-disk-space@main` to free up some disk space before each job runs on Ubuntu.


I checked one of the Linux jobs and saw that the free-disk-space action freed up 18 GB. It started with 21 GB free and had 39 GB free after the action ran.