### PR TITLE
Add cleanup script and config to IT parent pom, fix pom errors

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -182,6 +182,7 @@
                             </profiles>
                             <streamLogsOnFailures>true</streamLogsOnFailures>
                             <mavenOpts>-Dfile.encoding=UTF-8</mavenOpts>
+                            <postBuildHookScript>cleanTest</postBuildHookScript>
                         </configuration>
                         <executions>
                             <execution>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/pom.xml
@@ -3,9 +3,13 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.openliberty.tools.it</groupId>
+    <parent>
+        <groupId>io.openliberty.tools.it</groupId>
+        <artifactId>tests</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
     <artifactId>binary-scanner-it</artifactId>
-    <version>1.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/liberty-maven-plugin/src/it/config-packagefile-multi-module-runnable-it/pom.xml
+++ b/liberty-maven-plugin/src/it/config-packagefile-multi-module-runnable-it/pom.xml
@@ -3,9 +3,13 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.openliberty.tools.it</groupId>
+    <parent>
+        <groupId>io.openliberty.tools.it</groupId>
+        <artifactId>tests</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
     <artifactId>multi-module-package-it</artifactId>
-    <version>1.0</version>
     <packaging>pom</packaging>
 
     <name>Deploy app on Liberty and package server</name>

--- a/liberty-maven-plugin/src/it/ear-project-it/AppXmlEAR/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/AppXmlEAR/pom.xml
@@ -79,7 +79,7 @@
                         <id>stop-server-before-clean</id>
                         <phase>pre-clean</phase>
                         <goals>
-                            <goal>stop-server</goal>
+                            <goal>stop</goal>
                         </goals>
                     </execution>
                     <execution>

--- a/liberty-maven-plugin/src/it/ear-project-it/SampleEAR/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/SampleEAR/pom.xml
@@ -97,7 +97,7 @@
                         <id>stop-server-before-clean</id>
                         <phase>pre-clean</phase>
                         <goals>
-                            <goal>stop-server</goal>
+                            <goal>stop</goal>
                         </goals>
                     </execution>
                     <execution>

--- a/liberty-maven-plugin/src/it/ear-project-it/SampleEar_NonLooseApp/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/SampleEar_NonLooseApp/pom.xml
@@ -97,7 +97,7 @@
                         <id>stop-server-before-clean</id>
                         <phase>pre-clean</phase>
                         <goals>
-                            <goal>stop-server</goal>
+                            <goal>stop</goal>
                         </goals>
                     </execution>
                     <execution>

--- a/liberty-maven-plugin/src/it/ear-project-it/helloworld-ear/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/helloworld-ear/pom.xml
@@ -61,7 +61,7 @@
                         <id>stop-server-before-clean</id>
                         <phase>pre-clean</phase>
                         <goals>
-                            <goal>stop-server</goal>
+                            <goal>stop</goal>
                         </goals>
                     </execution>
                     <execution>

--- a/liberty-maven-plugin/src/it/generate-features-it/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/pom.xml
@@ -3,9 +3,13 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.openliberty.tools.it</groupId>
+    <parent>
+        <groupId>io.openliberty.tools.it</groupId>
+        <artifactId>tests</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    
     <artifactId>generate-features-it</artifactId>
-    <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/restful/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/restful/pom.xml
@@ -202,7 +202,7 @@
                         <id>stop-server</id>
                         <phase>post-integration-test</phase>
                         <goals>
-                            <goal>stop-server</goal>
+                            <goal>stop</goal>
                         </goals>
                     </execution>
                     <execution>

--- a/liberty-maven-plugin/src/it/loose-war-ejb-it/pom.xml
+++ b/liberty-maven-plugin/src/it/loose-war-ejb-it/pom.xml
@@ -3,9 +3,13 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <groupId>io.openliberty.tools.it</groupId>
+    <parent>
+        <groupId>io.openliberty.tools.it</groupId>
+        <artifactId>tests</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
     <artifactId>ejb-war-test</artifactId>
-    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modelVersion>4.0.0</modelVersion>

--- a/liberty-maven-plugin/src/it/loose-war-ejb-type-it/pom.xml
+++ b/liberty-maven-plugin/src/it/loose-war-ejb-type-it/pom.xml
@@ -3,9 +3,13 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <groupId>io.openliberty.tools.it</groupId>
+    <parent>
+        <groupId>io.openliberty.tools.it</groupId>
+        <artifactId>tests</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
     <artifactId>ejb-type-war-test</artifactId>
-    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modelVersion>4.0.0</modelVersion>

--- a/liberty-maven-plugin/src/it/server-param-configdir-not-override-it/pom.xml
+++ b/liberty-maven-plugin/src/it/server-param-configdir-not-override-it/pom.xml
@@ -84,7 +84,7 @@
                             <id>stop-server-before-clean</id>
                             <phase>pre-clean</phase>
                             <goals>
-                                <goal>stop-server</goal>
+                                <goal>stop</goal>
                             </goals>
                         </execution>
                         <execution>

--- a/liberty-maven-plugin/src/it/server-param-default-it/pom.xml
+++ b/liberty-maven-plugin/src/it/server-param-default-it/pom.xml
@@ -126,7 +126,7 @@
                             <id>stop-server-before-clean</id>
                             <phase>pre-clean</phase>
                             <goals>
-                                <goal>stop-server</goal>
+                                <goal>stop</goal>
                             </goals>
                         </execution>
                         <execution>

--- a/liberty-maven-plugin/src/it/setup/test-parent/pom.xml
+++ b/liberty-maven-plugin/src/it/setup/test-parent/pom.xml
@@ -14,6 +14,43 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
-    
-</project>
 
+    <profiles>
+        <profile>
+            <id>test-cleanup</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>3.3.1</version>
+                        <executions>
+                            <execution>
+                                <id>copy-resources</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${basedir}</outputDirectory>
+                                    <resources>          
+                                        <resource>
+                                            <!-- Relative to test project in ci.maven/target/it -->
+                                            <!-- Path to resource dir containing cleanTest.bsh -->
+                                            <directory>../../../src/test/resources</directory>
+                                            <filtering>true</filtering>
+                                        </resource>
+                                    </resources>              
+                                </configuration>            
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/liberty-maven-plugin/src/it/springboot-tests/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-tests/pom.xml
@@ -1,26 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-	xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>io.openliberty.tools.it</groupId>
-	<artifactId>springboot-tests</artifactId>
-	<packaging>pom</packaging>
-	<version>1.0-SNAPSHOT</version>
+    <parent>
+        <groupId>io.openliberty.tools.it</groupId>
+        <artifactId>tests</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
 
-    	<properties>
-        	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        	<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        	<maven.compiler.source>1.7</maven.compiler.source>
-        	<maven.compiler.target>1.7</maven.compiler.target>
-    	</properties>
+    <artifactId>springboot-tests</artifactId>
+    <packaging>pom</packaging>
 
-	<modules>
-		<module>springboot-appsdirectory-apps-it</module>
-		<module>springboot-appsdirectory-dropins-it</module>
-	</modules>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+
+    <modules>
+        <module>springboot-appsdirectory-apps-it</module>
+        <module>springboot-appsdirectory-dropins-it</module>
+    </modules>
 
 </project>

--- a/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-apps-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-apps-it/pom.xml
@@ -93,7 +93,7 @@
 						<id>stop-server-before-clean</id>
 						<phase>pre-clean</phase>
 						<goals>
-							<goal>stop-server</goal>
+							<goal>stop</goal>
 						</goals>
 					</execution>
 					<execution>

--- a/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-dropins-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-dropins-it/pom.xml
@@ -89,7 +89,7 @@
                             <id>stop-server-before-clean</id>
                             <phase>pre-clean</phase>
                             <goals>
-                                <goal>stop-server</goal>
+                                <goal>stop</goal>
                             </goals>
                         </execution>
                         <execution>

--- a/liberty-maven-plugin/src/test/resources/cleanTest.bsh
+++ b/liberty-maven-plugin/src/test/resources/cleanTest.bsh
@@ -1,0 +1,4 @@
+//Runs clean in the test project directory
+Runtime.getRuntime().exec("../../../../mvnw clean", null, basedir);
+System.out.println("Cleaned target dir(s) for " + basedir);
+return true;


### PR DESCRIPTION
Added a profile to the IT parent pom that will activate for our Linux tests. It will copy a script file to each IT test project and will run through maven-invoker after a test build finishes successfully. It will execute a clean on the project using the Maven wrapper. All target directories should be cleaned. No issues if the script is not present for runs on another OS or any other reasons. This won't affect Mac or Windows builds unless we want to add profiles for those as well.

Updated some test projects to use the test parent pom and fixed old pom config issues.