### PR TITLE
Improve binary scanner compatibility test for new versions

### DIFF
--- a/liberty-maven-plugin/src/it/binary-scanner-it/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/pom.xml
@@ -13,6 +13,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Scanner version e.g. 22.0.0.3 or 22.0.0.3-SNAPSHOT -->
+        <scanner.version>23.0.0.5-SNAPSHOT</scanner.version>
     </properties>
 
     <dependencies>
@@ -62,8 +64,7 @@
                     <systemPropertyVariables>
                         <mavenPluginVersion>@pom.version@</mavenPluginVersion>
                         <runtimeVersion>${runtimeVersion}</runtimeVersion>
-                        <!-- Scanner version e.g. 22.0.0.3 or 22.0.0.3-SNAPSHOT -->
-                        <scannerVersion>23.0.0.3-SNAPSHOT</scannerVersion>
+                        <scannerVersion>${scanner.version}</scannerVersion>
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/pom.xml
@@ -3,13 +3,9 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>io.openliberty.tools.it</groupId>
-        <artifactId>tests</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
-
     <artifactId>binary-scanner-it</artifactId>
+    <groupId>io.openliberty.tools.it</groupId>
+    <version>1.0</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -67,7 +63,7 @@
                         <mavenPluginVersion>@pom.version@</mavenPluginVersion>
                         <runtimeVersion>${runtimeVersion}</runtimeVersion>
                         <!-- Scanner version e.g. 22.0.0.3 or 22.0.0.3-SNAPSHOT -->
-                        <scannerVersion>23.0.0.1-SNAPSHOT</scannerVersion>
+                        <scannerVersion>23.0.0.3-SNAPSHOT</scannerVersion>
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project10/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project10/pom.xml
@@ -1,0 +1,220 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>binary-scanner-it-tests</groupId>
+  <artifactId>dev-sample-proj</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>war</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <app.name>LibertyProject</app.name>
+    <!-- tag::ports[] -->
+    <testServerHttpPort>9080</testServerHttpPort>
+    <testServerHttpsPort>9443</testServerHttpsPort>
+    <!-- end::ports[] -->
+    <packaging.type>usr</packaging.type>
+  </properties>
+  <repositories>
+    <!-- Sonatype repo needed to get the binary scanner jar for liberty:generate-features -->
+    <repository>
+        <id>oss-sonatype</id>
+        <name>oss-sonatype</name>
+        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+  </repositories>
+  <dependencyManagement>
+      <dependencies>
+          <dependency>
+              <groupId>io.openliberty.features</groupId>
+              <artifactId>features-bom</artifactId>
+              <version>RUNTIME_VERSION</version>
+              <type>pom</type>
+              <scope>import</scope>
+          </dependency>
+      </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- Umbrella features -->
+    <dependency>
+        <groupId>jakarta.platform</groupId>
+        <artifactId>jakarta.jakartaee-api</artifactId>
+        <version>10.0.0</version>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.eclipse.microprofile</groupId>
+        <artifactId>microprofile</artifactId>
+        <version>6.0</version>
+        <type>pom</type>
+        <scope>provided</scope>
+    </dependency>
+    <!-- For tests -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-rs-client</artifactId>
+      <version>3.2.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-rs-extension-providers</artifactId>
+      <version>3.2.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.json</artifactId>
+      <version>1.0.4</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Java utility classes -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.0</version>
+    </dependency>
+    <!-- Support for JDK 9 and above-->
+    <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.3.1</version>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-core</artifactId>
+        <version>2.3.0.1</version>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>javax.activation</groupId>
+        <artifactId>activation</artifactId>
+        <version>1.1.1</version>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>javax.batch</groupId>
+        <artifactId>javax.batch-api</artifactId>
+        <version>1.0.1</version>
+        <scope>provided</scope>
+    </dependency>
+    <!-- Test runtime dependency for run goal -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.25</version>
+    </dependency>
+   <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
+      <scope>runtime</scope>
+    </dependency>
+    <!-- ADDITIONAL_DEPENDENCIES -->
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.3.2</version>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <packagingExcludes>pom.xml</packagingExcludes>
+        </configuration>
+      </plugin>
+      <!-- Plugin to run unit tests -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M1</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <id>default-test</id>
+            <configuration>
+              <excludes>
+                <exclude>**/it/**</exclude>
+              </excludes>
+              <reportsDirectory>${project.build.directory}/test-reports/unit</reportsDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Enable liberty-maven plugin -->
+      <plugin>
+        <groupId>io.openliberty.tools</groupId>
+        <artifactId>liberty-maven-plugin</artifactId>
+        <version>SUB_VERSION</version>
+        <configuration>
+          <assemblyArtifact>
+            <groupId>io.openliberty</groupId>
+            <artifactId>openliberty-kernel</artifactId>
+            <version>RUNTIME_VERSION</version>
+            <type>zip</type>
+          </assemblyArtifact>
+          <packageName>${app.name}</packageName>
+          <include>${packaging.type}</include>
+          <bootstrapProperties>
+            <default.http.port>${testServerHttpPort}</default.http.port>
+            <default.https.port>${testServerHttpsPort}</default.https.port>
+            <com.ibm.ws.logging.message.format>json</com.ibm.ws.logging.message.format>
+          </bootstrapProperties>
+          <!-- ADDITIONAL_CONFIGURATION -->
+        </configuration>
+      </plugin>
+      <!-- Plugin to run functional tests -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.0.0-M1</version>
+        <executions>
+          <execution>
+            <phase>integration-test</phase>
+            <id>integration-test</id>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>**/it/**/*.java</include>
+              </includes>
+              <!-- tag::system-props[] -->
+              <systemPropertyVariables>
+                <liberty.test.port>${testServerHttpPort}</liberty.test.port>
+              </systemPropertyVariables>
+              <!-- end::system-props[] -->
+            </configuration>
+          </execution>
+          <execution>
+            <id>verify-results</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <summaryFile>${project.build.directory}/test-reports/it/failsafe-summary.xml</summaryFile>
+          <reportsDirectory>${project.build.directory}/test-reports/it</reportsDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project10/src/main/java/com/demo/HelloLogger.java
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project10/src/main/java/com/demo/HelloLogger.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2020.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.demo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
+
+@Path("/show-log")
+public class HelloLogger {
+    private static final Logger log = LoggerFactory.getLogger(HelloLogger.class);
+
+    @GET
+    @Produces(TEXT_PLAIN)
+    public String showLog() {
+        log.info("Here is the Log");
+        return "Log has been shown";
+    }
+}

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project10/src/main/java/com/demo/HelloServlet.java
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project10/src/main/java/com/demo/HelloServlet.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.demo;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@WebServlet(urlPatterns="/servlet")
+public class HelloServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger log = LoggerFactory.getLogger(HelloLogger.class);
+
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        log.info("SLF4J Logger is ready for messages.");
+        response.getWriter().append("hello world");
+    }
+}

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project10/src/main/java/com/demo/HelloWorld.java
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project10/src/main/java/com/demo/HelloWorld.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.demo;
+
+import org.eclipse.microprofile.health.Liveness;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+
+@Liveness
+public class HelloWorld implements HealthCheck {
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse
+            .named("liveness check")
+            .build();
+    }
+
+    public String helloWorld() {
+        return "helloWorld";
+    }
+}

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project10/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project10/src/main/liberty/config/server.xml
@@ -1,0 +1,5 @@
+<server description="Sample Liberty server">
+  <!--replaceable-->
+  <httpEndpoint host="*" httpPort="${default.http.port}"
+    httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+</server>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/run-binary-scanner-it
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/run-binary-scanner-it
@@ -1,7 +1,8 @@
 # Manually cd to ci.maven to begin.
 # Run mvn clean install to build the current plugin.
+# Ensure you are running a version of Maven supported by liberty-maven-plugin (e.g. Maven 3.8.6 for plugin 3.9)
 # Edit liberty-maven-plugin/src/it/binary-scanner-it/pom.xml and add the version of
-# binary scanner you expect in <scannerVersion>.
+# binary scanner you expect in <scanner.version>.
 # Edit the loop below to specify the versions of the plugin you want to test:
 #   for i in 3.7 3.7.1 <--change 3.7 to the current version
 # Execute the following command in the current directory ci.maven:
@@ -10,7 +11,11 @@
 # five minutes for each test.
 cd liberty-maven-plugin/
 cp src/it/binary-scanner-it/pom.xml /tmp
-for i in 3.8 3.8.1 3.8.2
+restorePOM () {
+    cp /tmp/pom.xml src/it/binary-scanner-it/pom.xml
+}
+trap restorePOM SIGINT
+for i in 3.9
 do
 echo !!
 echo !! About to test using Liberty Maven Plugin version $i.
@@ -24,4 +29,4 @@ read j
 sed "s/@pom.version@/$i/g" </tmp/pom.xml >src/it/binary-scanner-it/pom.xml
 mvn install verify -Ponline-its -Dinvoker.streamLogs=true -Druntime=ol -DruntimeVersion=23.0.0.1 -Dinvoker.test=binary-scanner-it
 done
-cp /tmp/pom.xml src/it/binary-scanner-it/pom.xml
+restorePOM

--- a/liberty-maven-plugin/src/it/binary-scanner-it/run-binary-scanner-it
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/run-binary-scanner-it
@@ -10,14 +10,18 @@
 # five minutes for each test.
 cd liberty-maven-plugin/
 cp src/it/binary-scanner-it/pom.xml /tmp
-for i in 3.7 3.7.1
+for i in 3.8 3.8.1 3.8.2
 do
-sed "s/@pom.version@/$i/g" </tmp/pom.xml >src/it/binary-scanner-it/pom.xml
-mvn install verify -Ponline-its -Dinvoker.streamLogs=true -Druntime=ol -DruntimeVersion=23.0.0.1 -Dinvoker.test=binary-scanner-it
 echo !!
+echo !! About to test using Liberty Maven Plugin version $i.
+echo !! Each test runs for 5-10 minutes and then pauses here
+echo !! so you can check the results.
+echo !! You should already have followed the instructions in
+echo !! the comments at the top of this script. 
 echo !! PRESS ENTER TO CONTINUE
 echo !!
-# Allow time to inspect the pass/fail status before continuing.
 read j
+sed "s/@pom.version@/$i/g" </tmp/pom.xml >src/it/binary-scanner-it/pom.xml
+mvn install verify -Ponline-its -Dinvoker.streamLogs=true -Druntime=ol -DruntimeVersion=23.0.0.1 -Dinvoker.test=binary-scanner-it
 done
 cp /tmp/pom.xml src/it/binary-scanner-it/pom.xml

--- a/liberty-maven-plugin/src/it/binary-scanner-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseScannerTest.java
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseScannerTest.java
@@ -180,7 +180,7 @@ public class BaseScannerTest {
 
     /**
      * Runs process and waits for it to finish
-     * Times out after 20 seconds
+     * Times out after 30 seconds
      * 
      * @param command - command to run
      */
@@ -194,8 +194,8 @@ public class BaseScannerTest {
 
         OutputStream stdin = process.getOutputStream();
         writer = new BufferedWriter(new OutputStreamWriter(stdin));
-        // wait for process to finish max 20 seconds
-        process.waitFor(20, TimeUnit.SECONDS);
+        // wait for process to finish max 30 seconds
+        process.waitFor(30, TimeUnit.SECONDS);
         assertFalse(process.isAlive());
 
         // save and print process output


### PR DESCRIPTION
You do need to read the comments at the top of the script to execute the tests properly so I changed the output of the script to point this out to a new person. It also prints the version of the LMP in use.
Also, I ran these tests on a new machine and they did not work. I think they work on my current machine because I've run the full IT in the past. I updated the POM to run on a new machine.