### PR TITLE
Enhance mulit-module conflict check for dev mode

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/ServerFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/ServerFeatureSupport.java
@@ -168,12 +168,12 @@ public abstract class ServerFeatureSupport extends BasicSupport {
                     + ". Specify the module containing the Liberty configuration that you want to use for the server by including the following parameters in the Maven command: -pl <module-with-liberty-config> -am");
         }
     }
-
+    
     /**
      * Returns whether potentialTopModule is a multi module project that has
      * potentialSubModule as one of its sub-modules.
      */
-    private static boolean isSubModule(MavenProject potentialTopModule, MavenProject potentialSubModule) {
+    protected static boolean isSubModule(MavenProject potentialTopModule, MavenProject potentialSubModule) {
         List<String> multiModules = potentialTopModule.getModules();
         if (multiModules != null) {
             for (String module : multiModules) {


### PR DESCRIPTION
With this change we are:

1. Determining the upstream and final downstream projects that are relevant to dev mode.
2. Skipping final downstream projects that are jar projects
3. Honoring the "skip" configuration in the plugin to apply to sub-modules. 