### PR TITLE
Handle Java source versions other than 8 for compile-jsp

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -53,8 +53,7 @@ jobs:
     - name: Checkout ci.ant
       uses: actions/checkout@v3
       with:
-        repository: cherylking/ci.ant
-        ref: updateCompileJsp
+        repository: OpenLiberty/ci.ant
         path: ci.ant
     - name: Set up Maven
       uses: stCarolas/setup-maven@v4.5
@@ -104,7 +103,7 @@ jobs:
       run: |
         cp -r D:/a/ci.maven/ci.maven C:/ci.maven
         git clone https://github.com/OpenLiberty/ci.common.git C:/ci.common
-        git clone https://github.com/cherylking/ci.ant.git --branch updateCompileJsp --single-branch C:/ci.ant
+        git clone https://github.com/OpenLiberty/ci.ant.git C:/ci.ant
     - name: Set up Maven
       uses: stCarolas/setup-maven@v4.5
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         RUNTIME: [ol, wlp]
-        RUNTIME_VERSION: [23.0.0.12]
+        RUNTIME_VERSION: [24.0.0.3]
         java: [21, 17, 11, 8]
         exclude:
         - java: 8
@@ -81,7 +81,7 @@ jobs:
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         RUNTIME: [ol, wlp]
-        RUNTIME_VERSION: [23.0.0.12]
+        RUNTIME_VERSION: [24.0.0.3]
         java: [21, 17, 11, 8]
         exclude:
         - java: 8

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -53,7 +53,8 @@ jobs:
     - name: Checkout ci.ant
       uses: actions/checkout@v3
       with:
-        repository: OpenLiberty/ci.ant
+        repository: cherylking/ci.ant
+        ref: updateCompileJsp
         path: ci.ant
     - name: Set up Maven
       uses: stCarolas/setup-maven@v4.5
@@ -67,7 +68,7 @@ jobs:
     # Run tests that require a minimum of Java 17 or later
     - name: Run tests that require a minimum of Java 17 or later
       if: ${{ matrix.java == '17' || matrix.java == '21'}}
-      run: ./mvnw -V verify --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -Ponline-its -D"invoker.streamLogsOnFailures"=true -D"invoker.test"="*setup*,*springboot-3-*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
+      run: ./mvnw -V verify --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -Ponline-its -D"invoker.streamLogsOnFailures"=true -D"invoker.test"="*setup*,*springboot-3-*,*compile-jsp-source-17-*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
     # Run tests
     - name: Run tests
       run: ./mvnw -V verify --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -Ponline-its -D"invoker.streamLogsOnFailures"=true -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
@@ -103,7 +104,7 @@ jobs:
       run: |
         cp -r D:/a/ci.maven/ci.maven C:/ci.maven
         git clone https://github.com/OpenLiberty/ci.common.git C:/ci.common
-        git clone https://github.com/OpenLiberty/ci.ant.git C:/ci.ant
+        git clone https://github.com/cherylking/ci.ant.git --branch updateCompileJsp --single-branch C:/ci.ant
     - name: Set up Maven
       uses: stCarolas/setup-maven@v4.5
       with:
@@ -119,7 +120,7 @@ jobs:
     # Run tests that require a minimum of Java 17 or later
     - name: Run tests that require a minimum of Java 17 or later
       if: ${{ matrix.java == '17' || matrix.java == '21'}}
-      run: .\mvnw.cmd -V verify -Ponline-its --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -D"invoker.streamLogsOnFailures"=true -D"invoker.test"="*setup*,*springboot-3-*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
+      run: .\mvnw.cmd -V verify -Ponline-its --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -D"invoker.streamLogsOnFailures"=true -D"invoker.test"="*setup*,*springboot-3-*,*compile-jsp-source-17-*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
     # Run tests
     - name: Run tests
       working-directory: C:/ci.maven

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>io.openliberty.tools</groupId>
             <artifactId>liberty-ant-tasks</artifactId>
-            <version>1.9.14</version>
+            <version>1.9.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -225,6 +225,7 @@
                                     <pomExclude>binary-scanner-it/pom.xml</pomExclude>
                                     <pomExclude>springboot-3-tests/pom.xml</pomExclude>
                                     <pomExclude>dev-container-it/pom.xml</pomExclude>
+                                    <pomExclude>compile-jsp-source-17-it/pom.xml</pomExclude>
                                 </pomExcludes>
                             </configuration>
                         </plugin>
@@ -266,6 +267,7 @@
                                     <pomExclude>binary-scanner-it/pom.xml</pomExclude>
                                     <pomExclude>springboot-3-tests/pom.xml</pomExclude>
                                     <pomExclude>dev-container-it/pom.xml</pomExclude>
+                                    <pomExclude>compile-jsp-source-17-it/pom.xml</pomExclude>
                                 </pomExcludes>
                             </configuration>
                         </plugin>
@@ -306,6 +308,7 @@
                                     <pomExclude>generate-features-it/pom.xml</pomExclude>
                                     <pomExclude>binary-scanner-it/pom.xml</pomExclude>
                                     <pomExclude>springboot-3-tests/pom.xml</pomExclude>
+                                    <pomExclude>compile-jsp-source-17-it/pom.xml</pomExclude>
                                 </pomExcludes>
                             </configuration>
                         </plugin>
@@ -351,6 +354,7 @@
                                     <pomExclude>generate-features-it/pom.xml</pomExclude>
                                     <pomExclude>binary-scanner-it/pom.xml</pomExclude>
                                     <pomExclude>springboot-3-tests/pom.xml</pomExclude>
+                                    <pomExclude>compile-jsp-source-17-it/pom.xml</pomExclude>
                                 </pomExcludes>
                             </configuration>
                         </plugin>

--- a/liberty-maven-plugin/src/it/compile-jsp-it/pom.xml
+++ b/liberty-maven-plugin/src/it/compile-jsp-it/pom.xml
@@ -28,8 +28,6 @@
   </dependencies>
   
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 

--- a/liberty-maven-plugin/src/it/compile-jsp-it/pom.xml
+++ b/liberty-maven-plugin/src/it/compile-jsp-it/pom.xml
@@ -30,7 +30,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
   <build>

--- a/liberty-maven-plugin/src/it/compile-jsp-it/src/test/java/net/wasdev/wlp/maven/test/app/CompileJSPTest.java
+++ b/liberty-maven-plugin/src/it/compile-jsp-it/src/test/java/net/wasdev/wlp/maven/test/app/CompileJSPTest.java
@@ -75,7 +75,7 @@ public class CompileJSPTest {
             if (nodes.item(0) instanceof Element) {
                 Element child = (Element) nodes.item(0);
                 String nodeValue = child.getAttribute("javaSourceLevel");
-                Assert.assertTrue("Unexpected javaSourceLevel ==>"+nodeValue, nodeValue.equals("18"));
+                Assert.assertTrue("Unexpected javaSourceLevel ==>"+nodeValue, nodeValue.equals("8"));
             }
         }
     }

--- a/liberty-maven-plugin/src/it/compile-jsp-source-17-it/pom.xml
+++ b/liberty-maven-plugin/src/it/compile-jsp-source-17-it/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>compile-jsp-it</artifactId>
+  <artifactId>compile-jsp-source-17-it</artifactId>
   <packaging>war</packaging>
 
   <dependencies>
@@ -30,7 +30,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <build>
@@ -136,8 +136,8 @@
                     <goal>clean</goal>
                 </goals>
                 <configuration>
-                    <cleanDropins>true</cleanDropins>
-                    <cleanApps>true</cleanApps>
+                    <cleanDropins>false</cleanDropins>
+                    <cleanApps>false</cleanApps>
                     <cleanLogs>false</cleanLogs>
                     <cleanWorkarea>false</cleanWorkarea>
                 </configuration>

--- a/liberty-maven-plugin/src/it/compile-jsp-source-17-it/src/test/java/net/wasdev/wlp/maven/test/app/CompileJSPTest.java
+++ b/liberty-maven-plugin/src/it/compile-jsp-source-17-it/src/test/java/net/wasdev/wlp/maven/test/app/CompileJSPTest.java
@@ -75,7 +75,7 @@ public class CompileJSPTest {
             if (nodes.item(0) instanceof Element) {
                 Element child = (Element) nodes.item(0);
                 String nodeValue = child.getAttribute("javaSourceLevel");
-                Assert.assertTrue("Unexpected javaSourceLevel ==>"+nodeValue, nodeValue.equals("18"));
+                Assert.assertTrue("Unexpected javaSourceLevel ==>"+nodeValue, nodeValue.equals("17"));
             }
         }
     }

--- a/liberty-maven-plugin/src/it/compile-jsp-source-17-it/src/test/resources/server.xml
+++ b/liberty-maven-plugin/src/it/compile-jsp-source-17-it/src/test/resources/server.xml
@@ -1,0 +1,5 @@
+<server description="default server">
+    <featureManager>    
+        <feature>jsp-2.3</feature>
+    </featureManager>     
+</server>

--- a/liberty-maven-plugin/src/it/compile-jsp-source-17-it/webapp/index.jsp
+++ b/liberty-maven-plugin/src/it/compile-jsp-source-17-it/webapp/index.jsp
@@ -1,0 +1,10 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+  <head>
+      <title>Maven test install artifact</title>
+  </head>
+  <body>
+      <h2>Successful installation of war</h2>
+      <p>Maven test war has been successfully installed into the server.</p>
+  </body>
+</html>

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/jsp/CompileJspMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/jsp/CompileJspMojo.java
@@ -18,6 +18,7 @@ package io.openliberty.tools.maven.jsp;
 import java.io.File;
 import java.text.MessageFormat;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -83,15 +84,28 @@ public class CompileJspMojo extends InstallFeatureSupport {
         // don't delete temporary server dir
         compile.setCleanup(false);
 
+        boolean sourceSet = false;
+
         List<Plugin> plugins = getProject().getBuildPlugins();
         for (Plugin plugin : plugins) {
             if ("org.apache.maven.plugins:maven-compiler-plugin".equals(plugin.getKey())) {
                 Object config = plugin.getConfiguration();
                 if (config instanceof Xpp3Dom) {
                     Xpp3Dom dom = (Xpp3Dom) config;
-                    Xpp3Dom val = dom.getChild("source");
-                    if (val != null) {
-                        compile.setSource(val.getValue());
+                    Xpp3Dom child = dom.getChild("release");
+                    if (child != null && child.getValue() != null) {
+                        String value = child.getValue();
+                        getLog().debug("compile-jsp using maven.compiler.release value: "+value+" for javaSourceLevel.");
+                        compile.setSource(value);
+                        sourceSet = true;    
+                    } else {
+                        child = dom.getChild("source");
+                        if (child != null && child.getValue() != null) {
+                            String value = child.getValue();
+                            getLog().debug("compile-jsp using maven.compiler.source value: "+value+" for javaSourceLevel.");
+                            compile.setSource(value);
+                            sourceSet = true;    
+                        }
                     }
                 }
                 break;
@@ -103,6 +117,26 @@ public class CompileJspMojo extends InstallFeatureSupport {
                     if (val != null) {
                         compile.setSrcdir(new File(val.getValue()));
                     }
+                }
+            }
+        }
+
+        if (!sourceSet) {
+            // look for Maven properties
+            Properties props = getProject().getProperties();
+            if (props.containsKey("maven.compiler.release")) {
+                String value = props.getProperty("maven.compiler.release");
+                if (value != null) {
+                    getLog().debug("compile-jsp using maven.compiler.release value: "+value+" for javaSourceLevel.");
+                    compile.setSource(value);
+                    sourceSet = true;
+                }  
+            } else if (props.containsKey("maven.compiler.source")) {
+                String value = props.getProperty("maven.compiler.release");
+                if (value != null) {
+                    getLog().debug("compile-jsp using maven.compiler.source value: "+value+" for javaSourceLevel.");
+                    compile.setSource(value);
+                    sourceSet = true;
                 }
             }
         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/jsp/CompileJspMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/jsp/CompileJspMojo.java
@@ -132,7 +132,7 @@ public class CompileJspMojo extends InstallFeatureSupport {
                     sourceSet = true;
                 }  
             } else if (props.containsKey("maven.compiler.source")) {
-                String value = props.getProperty("maven.compiler.release");
+                String value = props.getProperty("maven.compiler.source");
                 if (value != null) {
                     getLog().debug("compile-jsp using maven.compiler.source value: "+value+" for javaSourceLevel.");
                     compile.setSource(value);


### PR DESCRIPTION
Fixes #1812 

- requires PR https://github.com/OpenLiberty/ci.ant/pull/171 in order to `setSource` for versions later than Java 8.

This PR does the minimum necessary to fix the issue:

- Checks for and uses the `release` parameter for `setSource` if it is specified in the project `maven-compiler-plugin` config
- If that is not found, checks for and uses the `source` parameter for `setSource` if it is specified in the project `maven-compiler-plugin` config
- If neither of those are found, check for and use `maven.compiler.release` Maven property or `maven.compiler.source` Maven property if specified.
- If neither are found, the Ant task defaults to using the System property `java.specification.version`
- The ant task will also use `javaSourceLevel` if the version of Liberty is `24.0.0.1` or later and the value used for `source` is Java 8 or later. Otherwise, it will still use `jdkSourceLevel` for older versions of Liberty.