### PR TITLE
Add ServerStatusUtil check for liberty:deploy

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojoSupport.java
@@ -45,6 +45,7 @@ import io.openliberty.tools.common.plugins.config.LooseApplication;
 import io.openliberty.tools.common.plugins.config.LooseConfigData;
 import io.openliberty.tools.common.plugins.util.DevUtil;
 import io.openliberty.tools.common.plugins.util.OSUtil;
+import io.openliberty.tools.common.plugins.util.ServerStatusUtil;
 
 /**
  * Support for installing and deploying applications to a Liberty server.
@@ -301,11 +302,7 @@ public abstract class DeployMojoSupport extends LooseAppSupport {
     }
 
     private boolean shouldValidateAppStart() throws MojoExecutionException {
-        try {
-            return new File(serverDirectory.getCanonicalPath()  + "/workarea/.sRunning").exists();
-        } catch (IOException ioe) {
-            throw new MojoExecutionException("Could not get the server directory to determine the state of the server.");
-        }
+        return ServerStatusUtil.isServerRunning(installDirectory, outputDirectory, serverName);
     }
 
     protected void verifyAppStarted(String appFile) throws MojoExecutionException {


### PR DESCRIPTION
Fixes #1696 by using the same approach that is used by https://github.com/OpenLiberty/ci.maven/issues/591 (the ServerStatusUtil).

Note, the check here is not really as robust as it would seem to be, since it will report a CWWKZ0001I from a previous execution as a successful deployment.

If this were important, we would need to use a "mark" or checkpoint within the messages.log.  I didn't try to address this.