### PR TITLE
Specify version 24.0.0.2 for binary scanner

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>io.openliberty.tools</groupId>
             <artifactId>ci.common</artifactId>
-            <version>1.8.37</version>
+            <version>1.8.38-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This specifies the ci.common version which references the latest binary scanner on Maven Central.

Responding to https://github.com/OpenLiberty/ci.maven/issues/1874