### PR TITLE
Try removing snapshot repo for binary scanner dependency

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,8 +48,7 @@ jobs:
     - name: Checkout ci.common
       uses: actions/checkout@v3
       with:
-        repository: cherylking/ci.common
-        ref: updateBinaryScannerDep
+        repository: OpenLiberty/ci.common
         path: ci.common
     - name: Checkout ci.ant
       uses: actions/checkout@v3
@@ -103,7 +102,7 @@ jobs:
     - name: Clone ci.ant and ci.common repos to github.workspace
       run: |
         echo ${{github.workspace}}
-        git clone https://github.com/cherylking/ci.common.git --branch updateBinaryScannerDep --single-branch ${{github.workspace}}/ci.common 
+        git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common 
         git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
     - name: Set up Maven
       uses: stCarolas/setup-maven@v4.5

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,7 +48,8 @@ jobs:
     - name: Checkout ci.common
       uses: actions/checkout@v3
       with:
-        repository: OpenLiberty/ci.common
+        repository: cherylking/ci.common
+        ref: updateBinaryScannerDep
         path: ci.common
     - name: Checkout ci.ant
       uses: actions/checkout@v3
@@ -102,7 +103,7 @@ jobs:
     - name: Clone ci.ant and ci.common repos to github.workspace
       run: |
         echo ${{github.workspace}}
-        git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common 
+        git clone https://github.com/cherylking/ci.common.git --branch updateBinaryScannerDep --single-branch ${{github.workspace}}/ci.common 
         git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
     - name: Set up Maven
       uses: stCarolas/setup-maven@v4.5

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project10/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project10/pom.xml
@@ -22,14 +22,14 @@
   </properties>
   <repositories>
     <!-- Sonatype repo needed to get the binary scanner jar for liberty:generate-features -->
-    <repository>
+    <!-- <repository>
         <id>oss-sonatype</id>
         <name>oss-sonatype</name>
         <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>
-    </repository>
+    </repository> -->
   </repositories>
   <dependencyManagement>
       <dependencies>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project10/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project10/pom.xml
@@ -20,17 +20,7 @@
     <!-- end::ports[] -->
     <packaging.type>usr</packaging.type>
   </properties>
-  <repositories>
-    <!-- Sonatype repo needed to get the binary scanner jar for liberty:generate-features -->
-    <!-- <repository>
-        <id>oss-sonatype</id>
-        <name>oss-sonatype</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        <snapshots>
-            <enabled>true</enabled>
-        </snapshots>
-    </repository> -->
-  </repositories>
+
   <dependencyManagement>
       <dependencies>
           <dependency>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project6/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project6/pom.xml
@@ -22,14 +22,14 @@
   </properties>
   <repositories>
     <!-- Sonatype repo needed to get the binary scanner jar for liberty:generate-features -->
-    <repository>
+    <!-- <repository>
         <id>oss-sonatype</id>
         <name>oss-sonatype</name>
         <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>
-    </repository>
+    </repository> -->
   </repositories>
   <dependencyManagement>
       <dependencies>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project6/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project6/pom.xml
@@ -20,17 +20,7 @@
     <!-- end::ports[] -->
     <packaging.type>usr</packaging.type>
   </properties>
-  <repositories>
-    <!-- Sonatype repo needed to get the binary scanner jar for liberty:generate-features -->
-    <!-- <repository>
-        <id>oss-sonatype</id>
-        <name>oss-sonatype</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        <snapshots>
-            <enabled>true</enabled>
-        </snapshots>
-    </repository> -->
-  </repositories>
+  
   <dependencyManagement>
       <dependencies>
           <dependency>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project7/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project7/pom.xml
@@ -22,14 +22,14 @@
   </properties>
   <repositories>
     <!-- Sonatype repo needed to get the binary scanner jar for liberty:generate-features -->
-    <repository>
+    <!-- <repository>
         <id>oss-sonatype</id>
         <name>oss-sonatype</name>
         <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>
-    </repository>
+    </repository> -->
   </repositories>
   <dependencyManagement>
       <dependencies>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project7/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project7/pom.xml
@@ -20,17 +20,7 @@
     <!-- end::ports[] -->
     <packaging.type>usr</packaging.type>
   </properties>
-  <repositories>
-    <!-- Sonatype repo needed to get the binary scanner jar for liberty:generate-features -->
-    <!-- <repository>
-        <id>oss-sonatype</id>
-        <name>oss-sonatype</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        <snapshots>
-            <enabled>true</enabled>
-        </snapshots>
-    </repository> -->
-  </repositories>
+
   <dependencyManagement>
       <dependencies>
           <dependency>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project8/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project8/pom.xml
@@ -22,14 +22,14 @@
   </properties>
   <repositories>
     <!-- Sonatype repo needed to get the binary scanner jar for liberty:generate-features -->
-    <repository>
+    <!-- <repository>
         <id>oss-sonatype</id>
         <name>oss-sonatype</name>
         <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>
-    </repository>
+    </repository> -->
   </repositories>
   <dependencyManagement>
       <dependencies>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project8/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project8/pom.xml
@@ -20,17 +20,7 @@
     <!-- end::ports[] -->
     <packaging.type>usr</packaging.type>
   </properties>
-  <repositories>
-    <!-- Sonatype repo needed to get the binary scanner jar for liberty:generate-features -->
-    <!-- <repository>
-        <id>oss-sonatype</id>
-        <name>oss-sonatype</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        <snapshots>
-            <enabled>true</enabled>
-        </snapshots>
-    </repository> -->
-  </repositories>
+
   <dependencyManagement>
       <dependencies>
           <dependency>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project9/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project9/pom.xml
@@ -22,14 +22,14 @@
   </properties>
   <repositories>
     <!-- Sonatype repo needed to get the binary scanner jar for liberty:generate-features -->
-    <repository>
+    <!-- <repository>
         <id>oss-sonatype</id>
         <name>oss-sonatype</name>
         <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>
-    </repository>
+    </repository> -->
   </repositories>
   <dependencyManagement>
       <dependencies>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project9/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/resources/basic-dev-project9/pom.xml
@@ -20,17 +20,7 @@
     <!-- end::ports[] -->
     <packaging.type>usr</packaging.type>
   </properties>
-  <repositories>
-    <!-- Sonatype repo needed to get the binary scanner jar for liberty:generate-features -->
-    <!-- <repository>
-        <id>oss-sonatype</id>
-        <name>oss-sonatype</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        <snapshots>
-            <enabled>true</enabled>
-        </snapshots>
-    </repository> -->
-  </repositories>
+
   <dependencyManagement>
       <dependencies>
           <dependency>

--- a/liberty-maven-plugin/src/it/dev-container-it/resources/container-test-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-container-it/resources/container-test-project/pom.xml
@@ -23,7 +23,7 @@ xsi:schemaLocation=
 
     <pluginRepositories>
         <!-- Configure Sonatype OSS Maven snapshots repository -->
-        <pluginRepository>
+        <!-- <pluginRepository>
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -33,7 +33,7 @@ xsi:schemaLocation=
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </pluginRepository>
+        </pluginRepository> -->
     </pluginRepositories>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-container-it/resources/container-test-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-container-it/resources/container-test-project/pom.xml
@@ -21,21 +21,6 @@ xsi:schemaLocation=
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
 
-    <pluginRepositories>
-        <!-- Configure Sonatype OSS Maven snapshots repository -->
-        <!-- <pluginRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </pluginRepository> -->
-    </pluginRepositories>
-
     <dependencies>
 
         <!-- Provided dependencies -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-umbrella-deps/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-umbrella-deps/pom.xml
@@ -21,21 +21,6 @@
     <packaging.type>usr</packaging.type>
   </properties>
 
-  <repositories>
-      <!-- Sonatype repository used to get the latest binary scanner jar -->
-      <!-- <repository>
-          <id>oss-sonatype</id>
-          <name>oss-sonatype</name>
-          <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-          <snapshots>
-              <enabled>true</enabled>
-          </snapshots>
-          <releases>
-              <enabled>false</enabled>
-          </releases>
-      </repository> -->
-  </repositories>
-
   <dependencies>
     <dependency>
         <groupId>jakarta.platform</groupId>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-umbrella-deps/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-umbrella-deps/pom.xml
@@ -23,7 +23,7 @@
 
   <repositories>
       <!-- Sonatype repository used to get the latest binary scanner jar -->
-      <repository>
+      <!-- <repository>
           <id>oss-sonatype</id>
           <name>oss-sonatype</name>
           <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -33,7 +33,7 @@
           <releases>
               <enabled>false</enabled>
           </releases>
-      </repository>
+      </repository> -->
   </repositories>
 
   <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
@@ -22,21 +22,6 @@
     <packaging.type>usr</packaging.type>
   </properties>
 
-  <repositories>
-      <!-- Sonatype repository used to get the latest binary scanner jar -->
-      <!-- <repository>
-        <id>oss-sonatype</id>
-        <name>oss-sonatype</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-          <snapshots>
-              <enabled>true</enabled>
-          </snapshots>
-          <releases>
-              <enabled>false</enabled>
-          </releases>
-      </repository> -->
-  </repositories>
-
   <dependencyManagement>
       <dependencies>
           <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
@@ -24,7 +24,7 @@
 
   <repositories>
       <!-- Sonatype repository used to get the latest binary scanner jar -->
-      <repository>
+      <!-- <repository>
         <id>oss-sonatype</id>
         <name>oss-sonatype</name>
         <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -34,7 +34,7 @@
           <releases>
               <enabled>false</enabled>
           </releases>
-      </repository>
+      </repository> -->
   </repositories>
 
   <dependencyManagement>

--- a/liberty-maven-plugin/src/it/dev-it/resources/mp-starter-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/mp-starter-project/pom.xml
@@ -14,20 +14,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
-  <repositories>
-    <!-- Sonatype repo needed to get the binary scanner jar for liberty:generate-features -->
-    <!-- <repository>
-        <id>oss-sonatype</id>
-        <name>oss-sonatype</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        <snapshots>
-            <enabled>true</enabled>
-        </snapshots>
-        <releases>
-            <enabled>false</enabled>
-        </releases>
-    </repository> -->
-  </repositories>
+  
   <dependencies>
     <dependency>
       <groupId>org.eclipse.microprofile</groupId>

--- a/liberty-maven-plugin/src/it/dev-it/resources/mp-starter-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/mp-starter-project/pom.xml
@@ -16,7 +16,7 @@
   </properties>
   <repositories>
     <!-- Sonatype repo needed to get the binary scanner jar for liberty:generate-features -->
-    <repository>
+    <!-- <repository>
         <id>oss-sonatype</id>
         <name>oss-sonatype</name>
         <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -26,7 +26,7 @@
         <releases>
             <enabled>false</enabled>
         </releases>
-    </repository>
+    </repository> -->
   </repositories>
   <dependencies>
     <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear1/pom.xml
@@ -22,20 +22,6 @@
         <!-- <skipITs>true</skipITs> -->
         <!-- <skipUTs>true</skipUTs> -->
     </properties>
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
 
     <dependencies>
         <!-- web and jar modules as dependencies -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear1/pom.xml
@@ -24,7 +24,7 @@
     </properties>
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -34,7 +34,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear2/pom.xml
@@ -22,20 +22,6 @@
         <!-- <skipITs>true</skipITs> -->
         <!-- <skipUTs>true</skipUTs> -->
     </properties>
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
 
     <dependencies>
         <!-- web and jar modules as dependencies -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear2/pom.xml
@@ -24,7 +24,7 @@
     </properties>
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -34,7 +34,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear-skinny-modules/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear-skinny-modules/pom.xml
@@ -22,20 +22,6 @@
         <!-- <skipITs>true</skipITs> -->
         <!-- <skipUTs>true</skipUTs> -->
     </properties>
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-           <id>oss-sonatype</id>
-           <name>oss-sonatype</name>
-           <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-           <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
 
     <dependencies>
         <!-- web and jar modules as dependencies -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear-skinny-modules/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear-skinny-modules/pom.xml
@@ -24,7 +24,7 @@
     </properties>
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
            <id>oss-sonatype</id>
            <name>oss-sonatype</name>
            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -34,7 +34,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear1/pom.xml
@@ -24,7 +24,7 @@
     </properties>
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+       <!--  <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -34,7 +34,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear1/pom.xml
@@ -22,20 +22,6 @@
         <!-- <skipITs>true</skipITs> -->
         <!-- <skipUTs>true</skipUTs> -->
     </properties>
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-       <!--  <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
 
     <dependencies>
         <!-- web and jar modules as dependencies -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear2/pom.xml
@@ -22,20 +22,6 @@
         <!-- <skipITs>true</skipITs> -->
         <!-- <skipUTs>true</skipUTs> -->
     </properties>
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
 
     <dependencies>
         <!-- web and jar modules as dependencies -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear2/pom.xml
@@ -24,7 +24,7 @@
     </properties>
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -34,7 +34,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-ear/pom.xml
@@ -15,7 +15,7 @@
     <name>EAR Module</name>
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -25,7 +25,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
     <dependencies>
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-ear/pom.xml
@@ -13,20 +13,7 @@
     <packaging>ear</packaging>
 
     <name>EAR Module</name>
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>sample</groupId>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/pom.xml
@@ -19,21 +19,6 @@
         <module>ear</module>
     </modules>
 
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
-
     <dependencies>
         <!-- For tests -->
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/pom.xml
@@ -21,7 +21,7 @@
 
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -31,7 +31,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
@@ -25,7 +25,7 @@
 
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -35,7 +35,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
     <dependencies>
         <!-- web and jar modules as dependencies -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
@@ -23,20 +23,6 @@
         <!-- <skipUTs>true</skipUTs> -->
     </properties>
 
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
     <dependencies>
         <!-- web and jar modules as dependencies -->
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
@@ -18,20 +18,7 @@
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
+
     <dependencies>
         <!-- web and jar modules as dependencies -->
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
@@ -20,7 +20,7 @@
     </properties>
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -30,7 +30,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
     <dependencies>
         <!-- web and jar modules as dependencies -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/pom.xml
@@ -17,7 +17,7 @@
 
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -27,7 +27,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/pom.xml
@@ -15,21 +15,6 @@
         <module>ear</module>
     </modules>
 
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
-
     <dependencies>
         <!-- SUB JUNIT -->
     </dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
@@ -25,7 +25,7 @@
 
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -35,7 +35,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
@@ -23,21 +23,6 @@
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
 
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
-
     <dependencies>
 
         <!-- Provided dependencies -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
@@ -17,21 +17,6 @@
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
 
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>io.openliberty.guides</groupId>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
@@ -19,7 +19,7 @@
 
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -29,7 +29,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
@@ -16,20 +16,6 @@
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
 
     <dependencies>
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
@@ -18,7 +18,7 @@
     </properties>
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -28,7 +28,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
@@ -17,21 +17,6 @@
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
 
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>io.openliberty.guides</groupId>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
@@ -19,7 +19,7 @@
 
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -29,7 +29,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/parent/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/parent/pom.xml
@@ -24,20 +24,5 @@
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
-
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
     
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/parent/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/parent/pom.xml
@@ -27,7 +27,7 @@
 
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -37,7 +37,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
     
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent1/pom.xml
@@ -30,18 +30,4 @@
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent1/pom.xml
@@ -32,7 +32,7 @@
     </properties>
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -42,6 +42,6 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent2/pom.xml
@@ -12,7 +12,7 @@
     <packaging>pom</packaging>
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -22,7 +22,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent2/pom.xml
@@ -10,20 +10,6 @@
     <artifactId>guide-maven-multimodules-parent2</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-           <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
 
     <dependencies>
         <!-- Provided dependencies -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
@@ -16,20 +16,6 @@
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
 
     <dependencies>
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
@@ -18,7 +18,7 @@
     </properties>
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -28,7 +28,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-skip-install-feature-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-skip-install-feature-it/resources/basic-dev-project/pom.xml
@@ -23,7 +23,7 @@
 
   <repositories>
       <!-- Sonatype repository used to get the latest binary scanner jar -->
-      <repository>
+      <!-- <repository>
           <id>oss-sonatype</id>
           <name>oss-sonatype</name>
           <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -33,7 +33,7 @@
           <releases>
               <enabled>false</enabled>
           </releases>
-      </repository>
+      </repository> -->
   </repositories>
 
   <dependencyManagement>

--- a/liberty-maven-plugin/src/it/dev-skip-install-feature-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-skip-install-feature-it/resources/basic-dev-project/pom.xml
@@ -21,21 +21,6 @@
     <packaging.type>usr</packaging.type>
   </properties>
 
-  <repositories>
-      <!-- Sonatype repository used to get the latest binary scanner jar -->
-      <!-- <repository>
-          <id>oss-sonatype</id>
-          <name>oss-sonatype</name>
-          <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-          <snapshots>
-              <enabled>true</enabled>
-          </snapshots>
-          <releases>
-              <enabled>false</enabled>
-          </releases>
-      </repository> -->
-  </repositories>
-
   <dependencyManagement>
       <dependencies>
           <dependency>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/basic-dev-project/pom.xml
@@ -22,14 +22,14 @@
   </properties>
   <repositories>
     <!-- Sonatype repo needed to get the binary scanner jar for liberty:generate-features -->
-    <repository>
+    <!-- <repository>
         <id>oss-sonatype</id>
         <name>oss-sonatype</name>
         <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>
-    </repository>
+    </repository> -->
   </repositories>
   <dependencyManagement>
       <dependencies>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/basic-dev-project/pom.xml
@@ -20,17 +20,7 @@
     <!-- end::ports[] -->
     <packaging.type>usr</packaging.type>
   </properties>
-  <repositories>
-    <!-- Sonatype repo needed to get the binary scanner jar for liberty:generate-features -->
-    <!-- <repository>
-        <id>oss-sonatype</id>
-        <name>oss-sonatype</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        <snapshots>
-            <enabled>true</enabled>
-        </snapshots>
-    </repository> -->
-  </repositories>
+
   <dependencyManagement>
       <dependencies>
           <dependency>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/pom/pom.xml
@@ -17,13 +17,6 @@
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
 
-    <repositories>
-        <!-- <repository>
-            <id>sonatype</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </repository> -->
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>io.openliberty.guides</groupId>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/pom/pom.xml
@@ -18,10 +18,10 @@
     </properties>
 
     <repositories>
-        <repository>
+        <!-- <repository>
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </repository>
+        </repository> -->
     </repositories>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/restful/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/restful/pom.xml
@@ -19,21 +19,6 @@
         <packaging.type>usr</packaging.type>
     </properties>
 
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/restful/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/restful/pom.xml
@@ -21,7 +21,7 @@
 
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -31,7 +31,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
 
     <dependencyManagement>

--- a/liberty-maven-plugin/src/it/server-config-props-it/pom.xml
+++ b/liberty-maven-plugin/src/it/server-config-props-it/pom.xml
@@ -22,21 +22,6 @@
         <app.name>${project.artifactId}</app.name>
     </properties>
 
-    <repositories>
-        <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <!-- <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository> -->
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/liberty-maven-plugin/src/it/server-config-props-it/pom.xml
+++ b/liberty-maven-plugin/src/it/server-config-props-it/pom.xml
@@ -24,7 +24,7 @@
 
     <repositories>
         <!-- Sonatype repository used to get the latest binary scanner jar -->
-        <repository>
+        <!-- <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -34,7 +34,7 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository>
+        </repository> -->
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
After modifying ci.common to use the latest release (not snapshot) for the binary scanner, I was able to remove the snapshot repo config from all the test case pom.xml files. The ci.common PR is [here](https://github.com/OpenLiberty/ci.common/pull/484).