### PR TITLE
adding alias for debug parameters

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-umbrella-deps/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-umbrella-deps/pom.xml
@@ -123,6 +123,8 @@
             <default.https.port>${testServerHttpsPort}</default.https.port>
             <com.ibm.ws.logging.message.format>json</com.ibm.ws.logging.message.format>
           </bootstrapProperties>
+          <libertyDebug>true</libertyDebug>
+          <libertyDebugPort>8077</libertyDebugPort>
         </configuration>
       </plugin>
       <!-- Plugin to run functional tests -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
@@ -202,6 +202,8 @@
             <param>-Xms512m</param>
          </jvmOptions>
           <!-- ADDITIONAL_CONFIGURATION -->
+            <debug>true</debug>
+            <debugPort>7077</debugPort>
         </configuration>
       </plugin>
       <!-- Plugin to run functional tests -->

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevGenerateFeaturesDependenciesTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevGenerateFeaturesDependenciesTest.java
@@ -41,6 +41,8 @@ public class DevGenerateFeaturesDependenciesTest extends BaseDevTest {
 
     @Test
     public void updateDependencyTest() throws Exception {
+       //debugPort set as 8077
+       assertTrue(verifyLogMessageExists("Listening for transport dt_socket at address: 8077", 20000) || verifyLogMessageExists("The debug port 8077 is not available.",20000));
        assertTrue(verifyLogMessageExists("Liberty is running in dev mode.", 10000));
 
        File generatedFeaturesFile = getGeneratedFeaturesFile();

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevHotTestingTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevHotTestingTest.java
@@ -34,6 +34,8 @@ public class DevHotTestingTest extends BaseDevTest {
 
    @Test
    public void autoTestsInvocationTest() throws Exception {
+      //debugPort set as 7077
+      assertTrue(verifyLogMessageExists("Listening for transport dt_socket at address: 7077", 20000) || verifyLogMessageExists("The debug port 7077 is not available.",20000));
       assertTrue(verifyLogMessageExists("Recompile skipped for dev-sample-proj since earlier compilation is successful", 20000));
       assertTrue(verifyLogMessageExists("Tests will run automatically", 20000));
    

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -126,10 +126,10 @@ public class DevMojo extends LooseAppSupport {
     @Parameter(property = "skipInstallFeature", defaultValue = "false")
     protected boolean skipInstallFeature;
  
-    @Parameter(property = "debug", defaultValue = "true")
+    @Parameter(property = "debug", defaultValue = "true", alias = "debug")
     private boolean libertyDebug;
 
-    @Parameter(property = "debugPort", defaultValue = "7777")
+    @Parameter(property = "debugPort", defaultValue = "7777", alias = "debugPort")
     private int libertyDebugPort;
 
     @Parameter(property = "container", defaultValue = "false")


### PR DESCRIPTION
Fixes #963 

Both debug,debugPort and libertyDebug,libertyDebugPort options are visible now in <configuration>

<img width="2343" height="1259" alt="image" src="https://github.com/user-attachments/assets/e57cb036-32e9-47f5-a087-f66c87c94c24" />

tested with debugPort=8888, working fine
<img width="2261" height="1415" alt="image" src="https://github.com/user-attachments/assets/ffb5918c-9542-4d6b-9cae-0a36fbc37ce7" />
 Tested with libertyDebugPort as well, its working fine
 
<img width="2259" height="1334" alt="image" src="https://github.com/user-attachments/assets/3ee753a6-19f2-4615-967d-5de3ac2615b1" />
