### PR TITLE
Use the correct module names in test typeJ poms

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/pom.xml
@@ -77,8 +77,8 @@
                         </jarModule>
                         <webModule>
                             <groupId>io.openliberty.guides</groupId>
-                            <artifactId>guide-maven-multimodules-war</artifactId>
-                            <uri>/guide-maven-multimodules-war-1.0-SNAPSHOT.war</uri>
+                            <artifactId>guide-maven-multimodules-war1</artifactId>
+                            <uri>/guide-maven-multimodules-war1.war</uri>
                             <!-- Set custom context root -->
                             <contextRoot>/converter1</contextRoot>
                         </webModule>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/pom.xml
@@ -77,8 +77,8 @@
                         </jarModule>
                         <webModule>
                             <groupId>io.openliberty.guides</groupId>
-                            <artifactId>guide-maven-multimodules-war</artifactId>
-                            <uri>/guide-maven-multimodules-war-1.0-SNAPSHOT.war</uri>
+                            <artifactId>guide-maven-multimodules-war2</artifactId>
+                            <uri>/guide-maven-multimodules-war2.war</uri>
                             <!-- Set custom context root -->
                             <contextRoot>/converter2</contextRoot>
                         </webModule>


### PR DESCRIPTION
This isn't a defect per se so I did not open an issue. 

I was using this project for some manual testing and I found that the Maven build failed. The test poms in the multimodule test typeJ specify in the `maven-war-plugin` a `fullName` but the `uri` specified does not match. This pull request is to fix the names to avoid any problems in the future.