### PR TITLE
Pass liberty feature lists to the binary scanner

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -483,7 +483,7 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
     }
 
     /*
-     * Gets the file containing the Websphere base feature list from the local cache.
+     * Gets the file containing the indicated Websphere feature list from the local cache.
      * Downloads it first from connected repositories such as Maven Central if a newer release is available than the cached version.
      * Note: Maven updates artifacts daily by default based on the last updated timestamp. Users should use 'mvn -U' to force
      * updates if needed.

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -64,7 +64,7 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
     public static final String NO_CLASSES_DIR_WARNING = "Could not find classes directory to generate features against. Liberty features will not be generated. "
             + "Ensure your project has first been compiled.";
     private static final String OPEN_LIBERTY_PRODUCT_ID = "io.openliberty";
-    private static final String CLOSED_LIBERTY_PRODUCT_ID = "com.ibm.websphere.appserver.runtime";
+    private static final String WEBSPHERE_LIBERTY_PRODUCT_ID = "com.ibm.websphere.appserver.runtime";
 
     @Parameter(property = "classFiles")
     private List<String> classFiles;
@@ -289,9 +289,9 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
             File coreFeatureListFile = null;
             String libertyGroupId = getLibertyRuntimeGroupId();
             getLog().debug("Resolve the liberty groupId used to fetch feature lists, getLibertyRuntimeGroupId()="+libertyGroupId);
-            if (CLOSED_LIBERTY_PRODUCT_ID.equals(libertyGroupId)) {
-                baseFeatureListFile = getClosedFeatureListFile(FEATURE_LIST_BASE);
-                coreFeatureListFile = getClosedFeatureListFile(FEATURE_LIST_CORE);
+            if (WEBSPHERE_LIBERTY_PRODUCT_ID.equals(libertyGroupId)) {
+                baseFeatureListFile = getWebSphereFeatureListFile(FEATURE_LIST_BASE);
+                coreFeatureListFile = getWebSphereFeatureListFile(FEATURE_LIST_CORE);
             } else if (OPEN_LIBERTY_PRODUCT_ID.equals(libertyGroupId)) {
                 // For open liberty pass the same file to each parameter
                 baseFeatureListFile = getOpenFeatureListFile();
@@ -467,7 +467,7 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
      * 
      * @return The File object of the feature list in the local cache or null if version number not available
      */
-    public static String OPEN_LIBERTY_FEATURE_LIST_START = "25.0.0.7";
+    private static String OPEN_LIBERTY_FEATURE_LIST_START = "25.0.0.7";
     private File getOpenFeatureListFile() throws MojoExecutionException {
         String libertyVersion = getLibertyRuntimeVersion();
         if (libertyVersion == null) {
@@ -483,19 +483,19 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
     }
 
     /*
-     * Gets the file containing the Websphere or Open Liberty base feature list from the local cache.
+     * Gets the file containing the Websphere base feature list from the local cache.
      * Downloads it first from connected repositories such as Maven Central if a newer release is available than the cached version.
      * Note: Maven updates artifacts daily by default based on the last updated timestamp. Users should use 'mvn -U' to force
      * updates if needed.
      * 
      * @return The File object of the feature list in the local cache.
      */
-    private static String CLOSED_LIBERTY_FEATURE_LIST_START1 = "25.0.0.7";
-    private static String CLOSED_LIBERTY_FEATURE_LIST_START2 = "25.0.0.10";
-    private static String CLOSED_LIBERTY_FEATURE_LIST_END = "25.0.0.12";
+    private static String WEBSPHERE_LIBERTY_FEATURE_LIST_START = "25.0.0.7";
+    private static String WEBSPHERE_LIBERTY_FEATURE_LIST_CONTINUE = "25.0.0.10";
+    private static String WEBSPHERE_LIBERTY_FEATURE_LIST_END = "25.0.0.12";
     private static String FEATURE_LIST_BASE = "base";
     private static String FEATURE_LIST_CORE = "core";
-    private File getClosedFeatureListFile(String featureListVar) throws MojoExecutionException {
+    private File getWebSphereFeatureListFile(String featureListVar) throws MojoExecutionException {
         // Feature lists are only available for 25.0.0.7 and 25.0.0.10-25.0.0.12.
         // For releases earlier than 25.0.0.10 use 25.0.0.7, for releases after 25.0.0.12 use 25.0.0.12.
         String libertyGroupId, libertyArtifactId;
@@ -505,14 +505,14 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
         }
         // There is a value for 25.0.0.7 but not for 25.0.0.8 or 25.0.0.9 and none for <25.0.0.7
         // so for any liberty <25.0.0.10 use the 07 values
-        if (VersionUtility.compareArtifactVersion(libertyVersion, CLOSED_LIBERTY_FEATURE_LIST_START2, true) < 0) {
+        if (VersionUtility.compareArtifactVersion(libertyVersion, WEBSPHERE_LIBERTY_FEATURE_LIST_CONTINUE, true) < 0) {
             libertyGroupId = WS1_FEATURELIST_GROUP_ID;
-            libertyVersion = CLOSED_LIBERTY_FEATURE_LIST_START1;
+            libertyVersion = WEBSPHERE_LIBERTY_FEATURE_LIST_START;
         } else { // 25.0.0.10 and up
             libertyGroupId = WS2_FEATURELIST_GROUP_ID;
             // if >25.0.0.12 just use 25.0.0.12
-            if (VersionUtility.compareArtifactVersion(libertyVersion, CLOSED_LIBERTY_FEATURE_LIST_END, true) > 0) {
-                libertyVersion = CLOSED_LIBERTY_FEATURE_LIST_END;
+            if (VersionUtility.compareArtifactVersion(libertyVersion, WEBSPHERE_LIBERTY_FEATURE_LIST_END, true) > 0) {
+                libertyVersion = WEBSPHERE_LIBERTY_FEATURE_LIST_END;
             } // else liberty version is 25.0.0.10-25.0.0.12
         }
         if (featureListVar.equals(FEATURE_LIST_BASE)) {
@@ -521,7 +521,7 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
             libertyArtifactId = WSCORE_FEATURELIST_ARTIFACT_ID;
         }
         libertyVersion = "[" + libertyVersion + "]"; // Maven syntax to specify an exact version, not a range
-        getLog().debug("Closed liberty feature list coordinates, libertyGroupId="+libertyGroupId+" libertyArtifactId="+libertyArtifactId+" WS_FEATURELIST_TYPE="+WS_FEATURELIST_TYPE+" libertyVersion="+libertyVersion);
+        getLog().debug("WebSphere Liberty feature list coordinates, libertyGroupId="+libertyGroupId+" libertyArtifactId="+libertyArtifactId+" WS_FEATURELIST_TYPE="+WS_FEATURELIST_TYPE+" libertyVersion="+libertyVersion);
         return getArtifact(libertyGroupId, libertyArtifactId, WS_FEATURELIST_TYPE, libertyVersion).getFile();
     }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -479,7 +479,7 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
             libertyVersion = OPEN_LIBERTY_FEATURE_LIST_START;
         }
         libertyVersion = "[" + libertyVersion + "]"; // Maven syntax to specify an exact version, not a range
-        return getArtifact(OLBASE_FEATURELIST_GROUP_ID, OLBASE_FEATURELIST_ARTIFACT_ID, OLBASE_FEATURELIST_TYPE, libertyVersion).getFile();
+        return getArtifact(OL_FEATURELIST_GROUP_ID, OL_FEATURELIST_ARTIFACT_ID, OL_FEATURELIST_TYPE, libertyVersion).getFile();
     }
 
     /*

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -460,7 +460,7 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
     }
 
     /*
-     * Gets the file containing the Open Liberty base feature list from the local cache.
+     * Gets the file containing the Open Liberty feature list from the local cache.
      * Downloads it first from connected repositories such as Maven Central if a newer release is available than the cached version.
      * Note: Maven updates artifacts daily by default based on the last updated timestamp. Users should use 'mvn -U' to force
      * updates if needed.

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -61,9 +61,6 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
     public static final String NO_CLASSES_DIR_WARNING = "Could not find classes directory to generate features against. Liberty features will not be generated. "
             + "Ensure your project has first been compiled.";
 
-    // The executable file used to scan binaries for the Liberty features they use.
-    private File binaryScanner;
-
     @Parameter(property = "classFiles")
     private List<String> classFiles;
 
@@ -220,11 +217,12 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
         // When using dev mode we always generate to a temporary directory so we can call install before writing to server dir.
         generationOutputDir = useTempDirAsOutput ? getGeneratedFeaturesTempDir() : generationContextDir;
 
-        binaryScanner = getBinaryScannerJarFromRepository();
-        BinaryScannerHandler binaryScannerHandler = new BinaryScannerHandler(binaryScanner);
+        // The executable file used to scan binaries for the Liberty features they use.
+        File binaryScannerJar = getBinaryScannerJarFromRepository();
+        BinaryScannerHandler binaryScannerHandler = new BinaryScannerHandler(binaryScannerJar);
 
         getLog().debug("--- Generate Features values ---");
-        getLog().debug("Binary scanner jar: " + binaryScanner.getName());
+        getLog().debug("Binary scanner jar: " + binaryScannerJar.getName());
         getLog().debug("optimize generate features: " + optimize);
         getLog().debug("useTempDirAsOutput (dev mode only): " + useTempDirAsOutput);
         getLog().debug("useTempDirAsContext (dev mode only): " + useTempDirAsContext);
@@ -282,7 +280,10 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
             String logLocation = project.getBuild().getDirectory();
             String eeVersionArg = composeEEVersion(eeVersion);
             String mpVersionArg = composeMPVersion(mpVersion);
-            scannedFeatureList = binaryScannerHandler.runBinaryScanner(nonCustomFeatures, classFiles, directories, logLocation, eeVersionArg, mpVersionArg, optimize);
+            File baseFeatureListFile = getBaseFeatureListFileFromRepository();
+            File coreFeatureListFile = getBaseFeatureListFileFromRepository();
+            scannedFeatureList = binaryScannerHandler.runBinaryScanner(nonCustomFeatures, classFiles, directories, logLocation, 
+                eeVersionArg, mpVersionArg, baseFeatureListFile, coreFeatureListFile, optimize);
         } catch (BinaryScannerUtil.NoRecommendationException noRecommendation) {
             throw new MojoExecutionException(String.format(BinaryScannerUtil.BINARY_SCANNER_CONFLICT_MESSAGE3, noRecommendation.getConflicts()));
         } catch (BinaryScannerUtil.FeatureModifiedException featuresModified) {
@@ -440,6 +441,32 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
                     + BINARY_SCANNER_MAVEN_GROUP_ID + "." + BINARY_SCANNER_MAVEN_ARTIFACT_ID
                     + ".jar configured in your pom.xml.",
                     e);
+        }
+    }
+
+    /**
+     * Gets the file containing the Websphere or Open Liberty base feature list from the local cache.
+     * Downloads it first from connected repositories such as Maven Central if a newer release is available than the cached version.
+     * Note: Maven updates artifacts daily by default based on the last updated timestamp. Users should use 'mvn -U' to force updates if needed.
+     * 
+     * @return The File object of the feature list in the local cache.
+     * @throws PluginExecutionException
+     */
+    private File getBaseFeatureListFileFromRepository() throws PluginExecutionException {
+        try {
+            getLog().warn ("retrieve the artifact " + OLBASE_FEATURELIST_GROUP_ID + "."
+                    + OLBASE_FEATURELIST_ARTIFACT_ID + "." + OLBASE_FEATURELIST_TYPE + "." + OLBASE_FEATURELIST_VERSION
+                    + " needed for liberty:generate-features. Ensure you have a connection to Maven Central or another repository that contains the "
+                    + OLBASE_FEATURELIST_GROUP_ID + "." + OLBASE_FEATURELIST_ARTIFACT_ID
+                    + " configured in your pom.xml.");
+            return getArtifact(OLBASE_FEATURELIST_GROUP_ID, OLBASE_FEATURELIST_ARTIFACT_ID, OLBASE_FEATURELIST_TYPE, OLBASE_FEATURELIST_VERSION).getFile();
+        } catch (Exception e) {
+            getLog().debug("Could not retrieve the artifact " + OLBASE_FEATURELIST_GROUP_ID + "."
+                    + OLBASE_FEATURELIST_ARTIFACT_ID + "." + OLBASE_FEATURELIST_TYPE + "." + OLBASE_FEATURELIST_VERSION
+                    + " needed for liberty:generate-features. Ensure you have a connection to Maven Central or another repository that contains the "
+                    + OLBASE_FEATURELIST_GROUP_ID + "." + OLBASE_FEATURELIST_ARTIFACT_ID
+                    + " configured in your pom.xml.");
+            return null;
         }
     }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -26,6 +26,8 @@ import java.util.Set;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 
+import org.apache.maven.Maven;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.ProjectDependencyGraph;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -216,7 +218,9 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
         }
         // When using dev mode we always generate to a temporary directory so we can call install before writing to server dir.
         generationOutputDir = useTempDirAsOutput ? getGeneratedFeaturesTempDir() : generationContextDir;
+//
 
+//
         // The executable file used to scan binaries for the Liberty features they use.
         File binaryScannerJar = getBinaryScannerJarFromRepository();
         BinaryScannerHandler binaryScannerHandler = new BinaryScannerHandler(binaryScannerJar);
@@ -468,6 +472,30 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
                     + " configured in your pom.xml.");
             return null;
         }
+    }
+
+    /*
+     * Gets the file containing the Websphere or Open Liberty base feature list from the local cache.
+     * Downloads it first from connected repositories such as Maven Central if a newer release is available than the cached version.
+     * Note: Maven updates artifacts daily by default based on the last updated timestamp. Users should use 'mvn -U' to force updates if needed.
+     * 
+     * @return The File object of the feature list in the local cache.
+     */
+    private void getFeatureListFiles(File baseFeatureListFile, File coreFeatureListFile) {
+        String libertyVersion = null;
+
+        // Check if libertyRuntimeVersion property is set (highest priority)
+        if (libertyRuntimeVersion != null && !libertyRuntimeVersion.isEmpty()) {
+            libertyVersion = libertyRuntimeVersion;
+        } else if (assemblyArtifact != null) {
+            // Resolve the artifact to get its version
+            Artifact artifact = getResolvedArtifact(assemblyArtifact);
+            if (artifact != null) {
+                libertyVersion = artifact.getVersion();
+            }
+        }
+        getLog().warn ("--- libertyVersion=" + libertyVersion);
+        
     }
 
     // Return a list containing the classes directory of the Maven projects (upstream projects and main project)

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -44,6 +44,7 @@ import static io.openliberty.tools.common.plugins.util.BinaryScannerUtil.*;
 import io.openliberty.tools.common.plugins.util.PluginExecutionException;
 import io.openliberty.tools.common.plugins.util.ServerFeatureUtil;
 import io.openliberty.tools.common.plugins.util.ServerFeatureUtil.FeaturesPlatforms;
+import io.openliberty.tools.common.plugins.util.VersionUtility;
 
 /**
  * This mojo generates the features required in the featureManager element in
@@ -62,6 +63,8 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
     public static final String NO_NEW_FEATURES_COMMENT = "No additional features generated";
     public static final String NO_CLASSES_DIR_WARNING = "Could not find classes directory to generate features against. Liberty features will not be generated. "
             + "Ensure your project has first been compiled.";
+    private static final String OPEN_LIBERTY_PRODUCT_ID = "io.openliberty";
+    private static final String CLOSED_LIBERTY_PRODUCT_ID = "com.ibm.websphere.appserver.runtime";
 
     @Parameter(property = "classFiles")
     private List<String> classFiles;
@@ -284,8 +287,18 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
             String logLocation = project.getBuild().getDirectory();
             String eeVersionArg = composeEEVersion(eeVersion);
             String mpVersionArg = composeMPVersion(mpVersion);
-            File baseFeatureListFile = getBaseFeatureListFileFromRepository();
-            File coreFeatureListFile = getBaseFeatureListFileFromRepository();
+            File baseFeatureListFile = null;
+            File coreFeatureListFile = null;
+            String libertyGroupId = getLibertyRuntimeGroupId();
+            getLog().debug("Resolve the liberty groupId used to fetch feature lists, getLibertyRuntimeGroupId()="+libertyGroupId);
+            if (CLOSED_LIBERTY_PRODUCT_ID.equals(libertyGroupId)) {
+                baseFeatureListFile = getClosedFeatureListFile(FEATURE_LIST_BASE);
+                coreFeatureListFile = getClosedFeatureListFile(FEATURE_LIST_CORE);
+            } else if (OPEN_LIBERTY_PRODUCT_ID.equals(libertyGroupId)) {
+                // For open liberty pass the same file to each parameter
+                baseFeatureListFile = getOpenFeatureListFile();
+                coreFeatureListFile = baseFeatureListFile;
+            } // else should not happen, just pass null values
             scannedFeatureList = binaryScannerHandler.runBinaryScanner(nonCustomFeatures, classFiles, directories, logLocation, 
                 eeVersionArg, mpVersionArg, baseFeatureListFile, coreFeatureListFile, optimize);
         } catch (BinaryScannerUtil.NoRecommendationException noRecommendation) {
@@ -448,54 +461,100 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
         }
     }
 
-    /**
-     * Gets the file containing the Websphere or Open Liberty base feature list from the local cache.
+    /*
+     * Gets the file containing the Open Liberty base feature list from the local cache.
      * Downloads it first from connected repositories such as Maven Central if a newer release is available than the cached version.
-     * Note: Maven updates artifacts daily by default based on the last updated timestamp. Users should use 'mvn -U' to force updates if needed.
+     * Note: Maven updates artifacts daily by default based on the last updated timestamp. Users should use 'mvn -U' to force
+     * updates if needed.
      * 
-     * @return The File object of the feature list in the local cache.
-     * @throws PluginExecutionException
+     * @return The File object of the feature list in the local cache or null if version number not available
      */
-    private File getBaseFeatureListFileFromRepository() throws PluginExecutionException {
-        try {
-            getLog().warn ("retrieve the artifact " + OLBASE_FEATURELIST_GROUP_ID + "."
-                    + OLBASE_FEATURELIST_ARTIFACT_ID + "." + OLBASE_FEATURELIST_TYPE + "." + OLBASE_FEATURELIST_VERSION
-                    + " needed for liberty:generate-features. Ensure you have a connection to Maven Central or another repository that contains the "
-                    + OLBASE_FEATURELIST_GROUP_ID + "." + OLBASE_FEATURELIST_ARTIFACT_ID
-                    + " configured in your pom.xml.");
-            return getArtifact(OLBASE_FEATURELIST_GROUP_ID, OLBASE_FEATURELIST_ARTIFACT_ID, OLBASE_FEATURELIST_TYPE, OLBASE_FEATURELIST_VERSION).getFile();
-        } catch (Exception e) {
-            getLog().debug("Could not retrieve the artifact " + OLBASE_FEATURELIST_GROUP_ID + "."
-                    + OLBASE_FEATURELIST_ARTIFACT_ID + "." + OLBASE_FEATURELIST_TYPE + "." + OLBASE_FEATURELIST_VERSION
-                    + " needed for liberty:generate-features. Ensure you have a connection to Maven Central or another repository that contains the "
-                    + OLBASE_FEATURELIST_GROUP_ID + "." + OLBASE_FEATURELIST_ARTIFACT_ID
-                    + " configured in your pom.xml.");
+    public static String OPEN_LIBERTY_FEATURE_LIST_START = "25.0.0.7";
+    private File getOpenFeatureListFile() throws MojoExecutionException {
+        String libertyVersion = getLibertyRuntimeVersion();
+        if (libertyVersion == null) {
             return null;
         }
+        // Feature lists were first published for 25.0.0.7. For liberty releases prior to this simply use the
+        // earliest available feature list, 25.0.0.7.
+        if (VersionUtility.compareArtifactVersion(libertyVersion, OPEN_LIBERTY_FEATURE_LIST_START, true) < 0) {
+            libertyVersion = OPEN_LIBERTY_FEATURE_LIST_START;
+        }
+        libertyVersion = "[" + libertyVersion + "]"; // Maven syntax to specify an exact version, not a range
+        return getArtifact(OLBASE_FEATURELIST_GROUP_ID, OLBASE_FEATURELIST_ARTIFACT_ID, OLBASE_FEATURELIST_TYPE, libertyVersion).getFile();
     }
 
     /*
      * Gets the file containing the Websphere or Open Liberty base feature list from the local cache.
      * Downloads it first from connected repositories such as Maven Central if a newer release is available than the cached version.
-     * Note: Maven updates artifacts daily by default based on the last updated timestamp. Users should use 'mvn -U' to force updates if needed.
+     * Note: Maven updates artifacts daily by default based on the last updated timestamp. Users should use 'mvn -U' to force
+     * updates if needed.
      * 
      * @return The File object of the feature list in the local cache.
      */
-    private void getFeatureListFiles(File baseFeatureListFile, File coreFeatureListFile) {
-        String libertyVersion = null;
+    private static String CLOSED_LIBERTY_FEATURE_LIST_START1 = "25.0.0.7";
+    private static String CLOSED_LIBERTY_FEATURE_LIST_START2 = "25.0.0.10";
+    private static String CLOSED_LIBERTY_FEATURE_LIST_END = "25.0.0.12";
+    private static String FEATURE_LIST_BASE = "base";
+    private static String FEATURE_LIST_CORE = "core";
+    private File getClosedFeatureListFile(String featureListVar) throws MojoExecutionException {
+        // Feature lists are only available for 25.0.0.7 and 25.0.0.10-25.0.0.12.
+        // For releases earlier than 25.0.0.10 use 25.0.0.7, for releases after 25.0.0.12 use 25.0.0.12.
+        String libertyGroupId, libertyArtifactId;
+        String libertyVersion = getLibertyRuntimeVersion();
+        if (libertyVersion == null) {
+            return null;
+        }
+        // There is a value for 25.0.0.7 but not for 25.0.0.8 or 25.0.0.9 and none for <25.0.0.7
+        // so for any liberty <25.0.0.10 use the 07 values
+        if (VersionUtility.compareArtifactVersion(libertyVersion, CLOSED_LIBERTY_FEATURE_LIST_START2, true) < 0) {
+            libertyGroupId = WS1_FEATURELIST_GROUP_ID;
+            libertyVersion = CLOSED_LIBERTY_FEATURE_LIST_START1;
+        } else { // 25.0.0.10 and up
+            libertyGroupId = WS2_FEATURELIST_GROUP_ID;
+            // if >25.0.0.12 just use 25.0.0.12
+            if (VersionUtility.compareArtifactVersion(libertyVersion, CLOSED_LIBERTY_FEATURE_LIST_END, true) > 0) {
+                libertyVersion = CLOSED_LIBERTY_FEATURE_LIST_END;
+            } // else liberty version is 25.0.0.10-25.0.0.12
+        }
+        if (featureListVar.equals(FEATURE_LIST_BASE)) {
+            libertyArtifactId = WSBASE_FEATURELIST_ARTIFACT_ID;
+        } else {
+            libertyArtifactId = WSCORE_FEATURELIST_ARTIFACT_ID;
+        }
+        libertyVersion = "[" + libertyVersion + "]"; // Maven syntax to specify an exact version, not a range
+        getLog().debug("Closed liberty feature list coordinates, libertyGroupId="+libertyGroupId+" libertyArtifactId="+libertyArtifactId+" WS_FEATURELIST_TYPE="+WS_FEATURELIST_TYPE+" libertyVersion="+libertyVersion);
+        return getArtifact(libertyGroupId, libertyArtifactId, WS_FEATURELIST_TYPE, libertyVersion).getFile();
+    }
 
+    // resolve the Liberty version from one of the sources
+    private String getLibertyRuntimeVersion() throws MojoExecutionException {
         // Check if libertyRuntimeVersion property is set (highest priority)
         if (libertyRuntimeVersion != null && !libertyRuntimeVersion.isEmpty()) {
-            libertyVersion = libertyRuntimeVersion;
+            return libertyRuntimeVersion;
         } else if (assemblyArtifact != null) {
             // Resolve the artifact to get its version
             Artifact artifact = getResolvedArtifact(assemblyArtifact);
             if (artifact != null) {
-                libertyVersion = artifact.getVersion();
+                return artifact.getVersion();
             }
         }
-        getLog().warn ("--- libertyVersion=" + libertyVersion);
-        
+        return null;
+    }
+
+    // resolve the Liberty GroupId from one of the sources
+    private String getLibertyRuntimeGroupId() throws MojoExecutionException {
+        // Check if libertyRuntimeGroupId property is set (highest priority)
+        if (libertyRuntimeGroupId != null && !libertyRuntimeGroupId.isEmpty()) {
+            return libertyRuntimeGroupId;
+        } else if (assemblyArtifact != null) {
+            // Resolve the artifact to get its values
+            Artifact artifact = getResolvedArtifact(assemblyArtifact);
+            if (artifact != null) {
+                return artifact.getGroupId();
+            }
+        }
+        return null;
     }
 
     // Return a list containing the classes directory of the Maven projects (upstream projects and main project)

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -221,9 +221,7 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
         }
         // When using dev mode we always generate to a temporary directory so we can call install before writing to server dir.
         generationOutputDir = useTempDirAsOutput ? getGeneratedFeaturesTempDir() : generationContextDir;
-//
 
-//
         // The executable file used to scan binaries for the Liberty features they use.
         File binaryScannerJar = getBinaryScannerJarFromRepository();
         BinaryScannerHandler binaryScannerHandler = new BinaryScannerHandler(binaryScannerJar);


### PR DESCRIPTION
Download feature lists for base and core versions of Liberty and pass them to the binary scanner. There are a lot of rules that apply and they are implemented in this code.

Related to #1981