### PR TITLE
Conditionally write generate features file to server directory when generateToSrc=true

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/BasicSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/BasicSupport.java
@@ -22,9 +22,7 @@ import java.io.InputStream;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.zip.ZipEntry;
@@ -60,8 +58,6 @@ public abstract class BasicSupport extends AbstractLibertySupport {
     protected static final ResourceBundle messages = ResourceBundle.getBundle("io.openliberty.tools.maven.MvnMessages");
 
     protected boolean defaultOutputDirSet = false;
-
-    protected boolean skipServerConfigSetup = false;
 
     /**
      * Skips the specific goal
@@ -205,10 +201,6 @@ public abstract class BasicSupport extends AbstractLibertySupport {
         }
 
         super.init();
-
-        if (skipServerConfigSetup) {
-            return;
-        }
 
         try {
             // First check if installDirectory is set, if it is, then we can skip this

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -84,6 +84,16 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
     private boolean generateToSrc;
 
     /**
+     * The isDevMode parameter is for internal use only. It is not for users.
+     * This parameter must only be set to true when this mojo is called from dev mode and false otherwise.
+     * This parameter is added to support generateToSrc and to cause writing the generated features file
+     * to the server directory (if it exists) in stand-alone mode (not dev mode) in order to save the user
+     * having to copy it manually.
+     */
+    @Parameter(property = "isDevMode", defaultValue = "false")
+    private boolean isDevMode;
+
+    /**
      * The useTempDirAsOutput parameter is for internal use only. It is not for users.
      * The parameter is only used when generateToSrc is false meaning we generate to serverDir.
      * It is needed in dev mode because the server is running and we need to ensure the features
@@ -261,6 +271,7 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
         generatedFiles.add(GENERATED_FEATURES_FILE_NAME);
 
         Set<String> existingFeatures = getServerFeatures(servUtil, generatedFiles, optimize);
+        getLog().warn ("existingFeatures = " + existingFeatures);
         Set<String> nonCustomFeatures = new HashSet<String>(); // binary scanner only handles actual Liberty features
         for (String feature : existingFeatures) { // custom features are "usr:feature-1.0" or "myExt:feature-2.0"
             if (!feature.contains(":")) nonCustomFeatures.add(feature);
@@ -364,6 +375,20 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
         // generate the new features into an xml file in the correct context directory
         // The ServerConfigXmlDocument class will create the directories if needed.
         File generatedXmlFile = new File(generationOutputDir, GENERATED_FEATURES_FILE_PATH);
+
+        // For standalone goal (not dev mode) with generateToSrc=true, also write to server dir if it exists
+        boolean shouldWriteToServerDir = !isDevMode && generateToSrc && (serverDirectory != null) && serverDirectory.exists();
+        File serverDirXmlFile = null;
+        if (shouldWriteToServerDir) {
+            serverDirXmlFile = new File(serverDirectory, GENERATED_FEATURES_FILE_PATH);
+        }
+        getLog().warn ("!isDevMode=" + !isDevMode);
+        getLog().warn ("generateToSrc=" + generateToSrc);
+        getLog().warn ("serverDirectory=" + serverDirectory);
+        getLog().warn ("serverDirectory.exists()=" + serverDirectory.exists());
+        getLog().warn ("shouldWriteToServerDir=" + shouldWriteToServerDir);
+        getLog().warn ("serverDirXmlFile=" + serverDirXmlFile);
+
         try {
             if (missingLibertyFeatures.size() > 0) {
                 Set<String> existingGeneratedFeatures = getGeneratedFeatures(servUtil, generatedXmlFile);
@@ -381,6 +406,15 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
                     getLog().info("Generated the following features: " + missingLibertyFeatures);
                     configDocument.writeXMLDocument(generatedXmlFile);
                     getLog().debug("Created file " + generatedXmlFile.getAbsolutePath());
+
+                    // For standalone mode with generateToSrc=true, also write to server directory
+                    if (shouldWriteToServerDir) {
+                        getLog().warn ("Also creating file " + serverDirXmlFile.getAbsolutePath());
+                        if (writeToServerDir(configDocument, serverDirXmlFile, true)) {
+                            getLog().debug("Also created file " + serverDirXmlFile.getAbsolutePath());
+                            getLog().warn ("Also created file " + serverDirXmlFile.getAbsolutePath());
+                        }
+                    }
                 } else {
                     getLog().info("Regenerated the following features: " + missingLibertyFeatures);
                 }
@@ -394,16 +428,36 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
                     Element featureManagerElem = configDocument.createFeatureManager();
                     configDocument.createComment(featureManagerElem, NO_NEW_FEATURES_COMMENT);
                     configDocument.writeXMLDocument(generatedXmlFile);
+
+                    // For standalone mode with generateToSrc=true, also write to server directory
+                    if (shouldWriteToServerDir) {
+                        getLog().warn ("Also maybe rewriting file " + serverDirXmlFile.getAbsolutePath());
+                        writeToServerDir(configDocument, serverDirXmlFile, serverDirXmlFile.exists());
+                    }
                 }
             }
         } catch (ParserConfigurationException | TransformerException | IOException e) {
             getLog().debug("Exception creating the server features file", e);
-                throw new MojoExecutionException(
-                        "Automatic generation of features failed. Error attempting to create the "
-                                + GENERATED_FEATURES_FILE_NAME
-                                + ". Ensure your id has write permission to the server configuration directory.",
-                        e);
+            throw new MojoExecutionException(
+                    "Automatic generation of features failed. Error attempting to create the "
+                            + GENERATED_FEATURES_FILE_NAME
+                            + ". Ensure your id has write permission to the server configuration directory.",
+                    e);
         }
+
+    }
+
+    private boolean writeToServerDir(ServerConfigXmlDocument configDocument, File serverDirXmlFile, boolean exists) {
+        if (exists) {
+            try {
+                configDocument.writeXMLDocument(serverDirXmlFile);
+            } catch (TransformerException | IOException e) {
+                getLog().warn("Failed to write generated-features.xml to server directory: "
+                    + serverDirXmlFile.getAbsolutePath() + ". " + e.getMessage());
+                return false;
+            }
+        }
+        return true;
     }
 
     private Set<String> getServerFeatures(ServerFeatureUtil servUtil, Set<String> generatedFiles, boolean excludeGenerated) {
@@ -416,6 +470,7 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
     // Get the features from the server config and optionally exclude the specified config files from the search.
     private Set<String> getServerFeaturesPlatforms(ServerFeatureUtil servUtil, Set<String> generatedFiles, boolean excludeGenerated, boolean features) {
         servUtil.setLowerCaseFeatures(false);
+        getLog().warn (" generatedFiles="+generatedFiles+" exclu="+excludeGenerated);
         // if optimizing, ignore generated files when passing in existing features to
         // binary scanner
         FeaturesPlatforms fp = servUtil.getServerFeatures(generationContextDir, serverXmlFile,

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -394,7 +394,7 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
 
                     // For standalone mode with generateToSrc=true, also write to server directory
                     if (shouldWriteToServerDir) {
-                        if (writeToServerDir(configDocument, serverDirXmlFile, true)) {
+                        if (writeToServerDir(configDocument, serverDirXmlFile)) {
                             getLog().debug("Also created file " + serverDirXmlFile.getAbsolutePath());
                         }
                     }
@@ -413,8 +413,8 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
                     configDocument.writeXMLDocument(generatedXmlFile);
 
                     // For standalone mode with generateToSrc=true, also write to server directory
-                    if (shouldWriteToServerDir) {
-                        writeToServerDir(configDocument, serverDirXmlFile, serverDirXmlFile.exists());
+                    if (shouldWriteToServerDir && serverDirXmlFile.exists()) {
+                        writeToServerDir(configDocument, serverDirXmlFile);
                     }
                 }
             }
@@ -429,15 +429,18 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
 
     }
 
-    private boolean writeToServerDir(ServerConfigXmlDocument configDocument, File serverDirXmlFile, boolean exists) {
-        if (exists) {
-            try {
-                configDocument.writeXMLDocument(serverDirXmlFile);
-            } catch (TransformerException | IOException e) {
-                getLog().warn("Failed to write generated-features.xml to server directory: "
-                    + serverDirXmlFile.getAbsolutePath() + ". " + e.getMessage());
-                return false;
-            }
+    /*
+     * This routine writes an xml document to the specififed file and returns false if there is an exception 
+     * while writing or true otherwise.
+     */
+    private boolean writeToServerDir(ServerConfigXmlDocument configDocument, File serverDirXmlFile) {
+        try {
+            configDocument.writeXMLDocument(serverDirXmlFile);
+        } catch (TransformerException | IOException e) {
+            getLog().warn("Failed to write generated-features.xml to server directory: "
+                + serverDirXmlFile.getAbsolutePath() + ". Ensure your id has write permission to the server configuration directory. "
+                + e.getMessage());
+            return false;
         }
         return true;
     }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -423,7 +423,7 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
             throw new MojoExecutionException(
                     "Automatic generation of features failed. Error attempting to create the "
                             + generatedXmlFile.getAbsolutePath()
-                            + ". Ensure your id has write permission to the server configuration directory.",
+                            + ". Ensure your id has write permission to the directory the generated features file will be written to.",
                     e);
         }
 

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -138,16 +138,8 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
 
     @Override
     protected void init() throws MojoExecutionException {
-        // @see io.openliberty.tools.maven.BasicSupport#init()
-        // Skip server directories setup when generate features only requires
-        // the files in the src config directory.
-        // The server directories to be set up: install dir, wlp dir, outputdir, etc.
-        if (generateToSrc) {
-            this.skipServerConfigSetup = true;
-        }
-
         super.init();
-    }
+   }
 
     @Override
     public void execute() throws MojoExecutionException {
@@ -271,7 +263,6 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
         generatedFiles.add(GENERATED_FEATURES_FILE_NAME);
 
         Set<String> existingFeatures = getServerFeatures(servUtil, generatedFiles, optimize);
-        getLog().warn ("existingFeatures = " + existingFeatures);
         Set<String> nonCustomFeatures = new HashSet<String>(); // binary scanner only handles actual Liberty features
         for (String feature : existingFeatures) { // custom features are "usr:feature-1.0" or "myExt:feature-2.0"
             if (!feature.contains(":")) nonCustomFeatures.add(feature);
@@ -382,12 +373,6 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
         if (shouldWriteToServerDir) {
             serverDirXmlFile = new File(serverDirectory, GENERATED_FEATURES_FILE_PATH);
         }
-        getLog().warn ("!isDevMode=" + !isDevMode);
-        getLog().warn ("generateToSrc=" + generateToSrc);
-        getLog().warn ("serverDirectory=" + serverDirectory);
-        getLog().warn ("serverDirectory.exists()=" + serverDirectory.exists());
-        getLog().warn ("shouldWriteToServerDir=" + shouldWriteToServerDir);
-        getLog().warn ("serverDirXmlFile=" + serverDirXmlFile);
 
         try {
             if (missingLibertyFeatures.size() > 0) {
@@ -409,10 +394,8 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
 
                     // For standalone mode with generateToSrc=true, also write to server directory
                     if (shouldWriteToServerDir) {
-                        getLog().warn ("Also creating file " + serverDirXmlFile.getAbsolutePath());
                         if (writeToServerDir(configDocument, serverDirXmlFile, true)) {
                             getLog().debug("Also created file " + serverDirXmlFile.getAbsolutePath());
-                            getLog().warn ("Also created file " + serverDirXmlFile.getAbsolutePath());
                         }
                     }
                 } else {
@@ -431,7 +414,6 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
 
                     // For standalone mode with generateToSrc=true, also write to server directory
                     if (shouldWriteToServerDir) {
-                        getLog().warn ("Also maybe rewriting file " + serverDirXmlFile.getAbsolutePath());
                         writeToServerDir(configDocument, serverDirXmlFile, serverDirXmlFile.exists());
                     }
                 }
@@ -470,7 +452,6 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
     // Get the features from the server config and optionally exclude the specified config files from the search.
     private Set<String> getServerFeaturesPlatforms(ServerFeatureUtil servUtil, Set<String> generatedFiles, boolean excludeGenerated, boolean features) {
         servUtil.setLowerCaseFeatures(false);
-        getLog().warn (" generatedFiles="+generatedFiles+" exclu="+excludeGenerated);
         // if optimizing, ignore generated files when passing in existing features to
         // binary scanner
         FeaturesPlatforms fp = servUtil.getServerFeatures(generationContextDir, serverXmlFile,

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -422,7 +422,7 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
             getLog().debug("Exception creating the server features file", e);
             throw new MojoExecutionException(
                     "Automatic generation of features failed. Error attempting to create the "
-                            + GENERATED_FEATURES_FILE_NAME
+                            + generatedXmlFile.getAbsolutePath()
                             + ". Ensure your id has write permission to the server configuration directory.",
                     e);
         }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2025.
+ * (C) Copyright IBM Corporation 2014, 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -247,6 +247,7 @@ public abstract class StartDebugMojoSupport extends ServerFeatureSupport {
         if (classFiles != null) {
             config = Xpp3Dom.mergeXpp3Dom(configuration(classFiles), config);
         }
+        config.addChild(element(name("isDevMode"), "true").toDom());
         config.addChild(element(name("optimize"), Boolean.toString(optimize)).toDom());
         config.addChild(element(name("generateToSrc"), Boolean.toString(generateToSrc)).toDom());
         config.addChild(element(name("useTempDirAsOutput"), Boolean.toString(useTmpDirOut)).toDom());


### PR DESCRIPTION
Part of https://github.com/OpenLiberty/ci.maven/issues/1998

- Simple condition: shouldWriteToServerDir = !isDevMode && generateToSrc && serverDirectory.exists()

  - Only writes to server dir when NOT in dev mode
  - Only when generateToSrc=true
  - Only when server directory exists

- Error handling:

  - Source dir write failure → Goal fails (caught by outer catch block)
  - Server dir write failure → Warning logged (caught by inner try-catch)

- Behavior:

  - Standalone goal with generateToSrc=true → Writes to BOTH source and server dirs
  - Dev mode (any configuration) → Writes only to primary location (no change to dev mode behavior)
