### PR TITLE
Detect multiple platforms in server.xml 

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -682,13 +682,10 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
             Set<String> platformVersions = new HashSet<String>();
             // Gather all Jakarta EE platform versions
             platformVersions.addAll(getAllPlatformVersions(JAKARTA_PLATFORM_NAME, servUtil));
-            getLog().warn("platformVersions="+platformVersions);
             // Gather all Java EE platform versions
             platformVersions.addAll(getAllPlatformVersions(JAVAEE_PLATFORM_NAME, servUtil));
-            getLog().warn("platformVersions="+platformVersions);
             // Find the maximum version from all platforms
             eeVersion = findMaxVersion(platformVersions);
-            getLog().warn("eeVersion="+eeVersion);
         }
         return eeVersion;
     }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -679,10 +679,16 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
         // if the dependencies do not indicate the Jakarta version then reference the platform specified in server.xml
         // E.g. pom may specify jakarta.persistence:jakarta.persistence-api:2.2.3 to compile but does not specify Jakarta 9.1
         if (eeVersion == null) {
-            eeVersion = getPlatformVersion(JAKARTA_PLATFORM_NAME, servUtil);
-        }
-        if (eeVersion == null) {
-            eeVersion = getPlatformVersion(JAVAEE_PLATFORM_NAME, servUtil);
+            Set<String> platformVersions = new HashSet<String>();
+            // Gather all Jakarta EE platform versions
+            platformVersions.addAll(getAllPlatformVersions(JAKARTA_PLATFORM_NAME, servUtil));
+            getLog().warn("platformVersions="+platformVersions);
+            // Gather all Java EE platform versions
+            platformVersions.addAll(getAllPlatformVersions(JAVAEE_PLATFORM_NAME, servUtil));
+            getLog().warn("platformVersions="+platformVersions);
+            // Find the maximum version from all platforms
+            eeVersion = findMaxVersion(platformVersions);
+            getLog().warn("eeVersion="+eeVersion);
         }
         return eeVersion;
     }
@@ -774,7 +780,7 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
             }
         }
         if (mpVersion == null) {
-            mpVersion = getPlatformVersion(MP_PLATFORM_NAME, servUtil);
+            mpVersion = findMaxVersion(getAllPlatformVersions(MP_PLATFORM_NAME, servUtil));
         }
         return mpVersion;
     }
@@ -804,18 +810,20 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
         return null;
     }
 
-    // Retrieve all platforms from the server.xml and related files and look for the platform specified.
-    // Platforms have the format jakartaee-10.0 or microProfile-7.1. Just return the version number (10.0 or 7.1 in these examples).
-    private String getPlatformVersion(String platformName, ServerFeatureUtil servUtil) {
+    // Retrieve all platforms from the server.xml and related files that match the platform specified.
+    // Platforms have the format jakartaee-10.0 or microProfile-7.1. Return all version numbers (10.0, 7.1, etc.) that match.
+    private Set<String> getAllPlatformVersions(String platformName, ServerFeatureUtil servUtil) {
+        Set<String> platformVersions = new HashSet<String>();
         Set<String> platforms = getServerPlatforms(servUtil, null, false);
         for (String p : platforms) {
-            getLog().debug("GenerateFeaturesMojo.getPlatformVersion, searching for platform:" + platformName + " platform=" + p);
+            getLog().debug("GenerateFeaturesMojo.getAllPlatformVersions, searching for platform:" + platformName + " platform=" + p);
             if (p.startsWith(platformName)) {
-                return p.substring(platformName.length());
+                platformVersions.add(p.substring(platformName.length()));
             }
         }
-        return null;
+        return platformVersions;
     }
+
 
     // Define the logging functions of the binary scanner handler and make it available in this plugin
     private class BinaryScannerHandler extends BinaryScannerUtil {


### PR DESCRIPTION
Detect all the EE related platforms (Jakarta EE and Java EE) and choose the highest version. 

It is not supported to specify conflicting platforms so this is error recovery.

Related to #2000 