### PR TITLE
Remove the exception message from a warning message

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -455,7 +455,7 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
             configDocument.writeXMLDocument(serverDirXmlFile);
         } catch (TransformerException | IOException e) {
             getLog().warn("Failed to write generated-features.xml to server directory: "
-                + serverDirXmlFile.getAbsolutePath() + ". Ensure your ID has write permission to the server configuration directory. ");
+                + serverDirXmlFile.getAbsolutePath() + ". Ensure your ID has write permission to the server configuration directory.");
             return false;
         }
         return true;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -455,8 +455,7 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
             configDocument.writeXMLDocument(serverDirXmlFile);
         } catch (TransformerException | IOException e) {
             getLog().warn("Failed to write generated-features.xml to server directory: "
-                + serverDirXmlFile.getAbsolutePath() + ". Ensure your ID has write permission to the server configuration directory. "
-                + e.getMessage());
+                + serverDirXmlFile.getAbsolutePath() + ". Ensure your ID has write permission to the server configuration directory. ");
             return false;
         }
         return true;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -455,7 +455,8 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
             configDocument.writeXMLDocument(serverDirXmlFile);
         } catch (TransformerException | IOException e) {
             getLog().warn("Failed to write generated-features.xml to server directory: "
-                + serverDirXmlFile.getAbsolutePath() + ". Ensure your ID has write permission to the server configuration directory.");
+                + serverDirXmlFile.getAbsolutePath() + ". Ensure your ID has write permission to the server configuration directory. "
+                + "Message from the Exception: " + e.getMessage());
             return false;
         }
         return true;


### PR DESCRIPTION
Old message:
```
[WARNING] Failed to write generated-features.xml to server directory: /Users/paulg/WASDevEx/
testing2026/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/
generated-features.xml. Ensure your ID has write permission to the server configuration directory. 
/Users/paulg/WASDevEx/testing2026/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/
configDropins/overrides/generated-features.xml
```

Now it is:
```
[WARNING] Failed to write generated-features.xml to server directory: /Users/paulg/WASDevEx/
testing2026/demo-devmode/target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/
generated-features.xml. Ensure your ID has write permission to the server configuration directory. 
```

Part of #1998