### PR TITLE
Print a message if generating to server dir and there is a generate-features.xml file in src

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -214,6 +214,19 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
         if (!generateToSrc && !serverDirectory.exists()) {
             throw new MojoExecutionException("The 'generate-features' goal requires an existing Liberty server in directory " + serverDirectory.getPath() + ". Please run the 'liberty:create' goal before 'generate-features'.");
         }
+        // Detect if there is a generate-features.xml file in src already when generating to server dir
+        if (!generateToSrc && new File(configDirectory, GENERATED_FEATURES_FILE_PATH).exists()) {
+            if (isDevMode) { // this is serious because dev mode will overwrite the generated file when copying from src
+                getLog().error("A generated-features.xml file was detected in the configured source Liberty configuration directory. " +
+                    "It will overwrite the file generated at this time. " +
+                    "You must type 's' + Enter to toggle the option to generate features to the src directory or " +
+                    "remove the generated-features.xml file in the Liberty configuration directory if you need to generate to the server directory.");
+            } else { // command line mojo just a warning that this configuration is not expected
+                getLog().warn("A generated-features.xml file was detected in the configured source Liberty configuration directory. " +
+                    "You must use the option -DgenerateToSrc=true to update the source Liberty configuration directory or " +
+                    "remove the generated-features.xml file in the source Liberty configuration directory if you intend to update the server directory.");
+            }
+        }
 
         if (useTempDirAsContext) {
             // When this parameter is true it is required that the caller has copied the config into this dir.

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/GenerateFeaturesMojo.java
@@ -217,14 +217,16 @@ public class GenerateFeaturesMojo extends PluginConfigSupport {
         // Detect if there is a generate-features.xml file in src already when generating to server dir
         if (!generateToSrc && new File(configDirectory, GENERATED_FEATURES_FILE_PATH).exists()) {
             if (isDevMode) { // this is serious because dev mode will overwrite the generated file when copying from src
-                getLog().error("A generated-features.xml file was detected in the configured source Liberty configuration directory. " +
-                    "It will overwrite the file generated at this time. " +
-                    "You must type 's' + Enter to toggle the option to generate features to the src directory or " +
-                    "remove the generated-features.xml file in the Liberty configuration directory if you need to generate to the server directory.");
+                getLog().error("A 'generated-features.xml' file was detected in the source Liberty configuration directory. " +
+                    "It will overwrite the file generated to the server directory by the automatic generation of features. " +
+                    "To continue to generate features to the server directory, you must delete the 'generated-features.xml' file " +
+                    "in the source Liberty configuration directory. To generate features to the source Liberty configuration " +
+                    "directory instead, you can type 's' + Enter.");
             } else { // command line mojo just a warning that this configuration is not expected
-                getLog().warn("A generated-features.xml file was detected in the configured source Liberty configuration directory. " +
-                    "You must use the option -DgenerateToSrc=true to update the source Liberty configuration directory or " +
-                    "remove the generated-features.xml file in the source Liberty configuration directory if you intend to update the server directory.");
+                getLog().warn("A 'generated-features.xml' file was detected in the source Liberty configuration directory. " +
+                    "To generate features to the server directory, it is recommended you delete the 'generated-features.xml' " +
+                    "file in the source Liberty configuration directory. To generate features to the source Liberty " +
+                    "configuration directory, you must use the option -DgenerateToSrc=true.");
             }
         }
 


### PR DESCRIPTION
When using dev mode print:
```
[INFO] Running liberty:generate-features
[ERROR] A generated-features.xml file was detected in the configured source Liberty configuration directory. It will 
overwrite the file generated at this time. You must type 's' + Enter to toggle the option to generate features to the src 
directory or remove the generated-features.xml file in the Liberty configuration directory if you need to generate to the 
server directory.
```

When using the command line:
```
[INFO] --- liberty:3.12.1-SNAPSHOT:generate-features (default-cli) @ demo-devmode-maven ---
[WARNING] A generated-features.xml file was detected in the configured source Liberty configuration directory. You 
must use the option -DgenerateToSrc=true to update the source Liberty configuration directory or remove the 
generated-features.xml file in the source Liberty configuration directory if you intend to update the server directory.
```

Fixes #1977