### PR TITLE
Pass the correct parent directory to installFeaturesToTempDir

### DIFF
--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -1131,7 +1131,7 @@ public class DevMojo extends LooseAppSupport {
                     // always optimize generate features on dependency change
                     // If generateToSrc is false then we must copy (below) new generated features file from temp dir to server dir
                     generateFeaturesSuccess = optimizeGenerateFeatures(!generateToSrc, false);
-                    util.installFeaturesToTempDir(generateFeaturesFile, configDirectory, null, generateFeaturesSuccess);
+                    util.installFeaturesToTempDir(generateFeaturesFile, generateFeaturesOutputDir, null, generateFeaturesSuccess);
                     if (!generateFeaturesSuccess) {
                         installFeature = false; // skip installing features if generate features fails
                     }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -801,7 +801,7 @@ public class DevMojo extends LooseAppSupport {
                             generateFeaturesSuccess = optimizeGenerateFeatures(!generateToSrc, false);
                             // install new generated features because deploy will copy config files to server dir.
                             // It will not trigger install-feature if the feature list has not changed
-                            util.installFeaturesToTempDir(generateFeaturesFile, configDirectory, null, generateFeaturesSuccess);
+                            util.installFeaturesToTempDir(generateFeaturesFile, generateFeaturesOutputDir, null, generateFeaturesSuccess);
                             // When generating to the src dir, mojo deploy will copy the files from src to the server.
                             // When not generating to the src dir, we must copy the generated features file here.
                             if (!generateToSrc) {


### PR DESCRIPTION
Fixes #1976 

Need to pass the correct parent directory or else the generated features file gets written to some random other temp dir. 