### PR TITLE
fixing httpclient vulnerability in integration tests

### DIFF
--- a/liberty-maven-plugin/src/it/alt-outputdir-it/pom.xml
+++ b/liberty-maven-plugin/src/it/alt-outputdir-it/pom.xml
@@ -27,9 +27,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/binary-scanner-it/pom.xml
+++ b/liberty-maven-plugin/src/it/binary-scanner-it/pom.xml
@@ -29,9 +29,9 @@
             <version>@pom.version@</version>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/config-packagefile-multi-module-runnable-it/deploy-app/pom.xml
+++ b/liberty-maven-plugin/src/it/config-packagefile-multi-module-runnable-it/deploy-app/pom.xml
@@ -21,9 +21,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/config-packagefile-multi-module-runnable-it/deploy-app/src/test/java/net/wasdev/wlp/test/servlet/it/EndpointTest.java
+++ b/liberty-maven-plugin/src/it/config-packagefile-multi-module-runnable-it/deploy-app/src/test/java/net/wasdev/wlp/test/servlet/it/EndpointTest.java
@@ -3,9 +3,12 @@ package net.wasdev.wlp.test.servlet.it;
 import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 
 public class EndpointTest {
     private static String URL;
@@ -17,20 +20,18 @@ public class EndpointTest {
 
     @Test
     public void testServlet() throws Exception {
-        HttpClient client = new HttpClient();
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet method = new HttpGet(URL);
 
-        GetMethod method = new GetMethod(URL);
+            try (CloseableHttpResponse response = client.execute(method)) {
+                int statusCode = response.getStatusLine().getStatusCode();
 
-        try {
-            int statusCode = client.executeMethod(method);
+                assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
 
-            assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
+                String responseBody = EntityUtils.toString(response.getEntity());
 
-            String response = method.getResponseBodyAsString();
-
-            assertTrue("Unexpected response body", response.contains("Hello! How are you today?"));
-        } finally {
-            method.releaseConnection();
-        }  
+                assertTrue("Unexpected response body", responseBody.contains("Hello! How are you today?"));
+            }
+        }
     }
 }

--- a/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/pom.xml
+++ b/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/pom.xml
@@ -27,9 +27,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/src/test/java/net/wasdev/wlp/test/servlet/it/EndpointTest.java
+++ b/liberty-maven-plugin/src/it/deploy-loose-config-apps-it/src/test/java/net/wasdev/wlp/test/servlet/it/EndpointTest.java
@@ -18,9 +18,12 @@ package net.wasdev.wlp.test.servlet.it;
 import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 
 public class EndpointTest {
     private static String URL;
@@ -32,20 +35,18 @@ public class EndpointTest {
 
     @Test
     public void testServlet() throws Exception {
-        HttpClient client = new HttpClient();
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet method = new HttpGet(URL);
 
-        GetMethod method = new GetMethod(URL);
+            try (CloseableHttpResponse response = client.execute(method)) {
+                int statusCode = response.getStatusLine().getStatusCode();
 
-        try {
-            int statusCode = client.executeMethod(method);
+                assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
 
-            assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
+                String responseBody = EntityUtils.toString(response.getEntity());
 
-            String response = method.getResponseBodyAsString();
-
-            assertTrue("Unexpected response body", response.contains("Hello! How are you today?"));
-        } finally {
-            method.releaseConnection();
-        }  
+                assertTrue("Unexpected response body", responseBody.contains("Hello! How are you today?"));
+            }
+        }
     }
 }

--- a/liberty-maven-plugin/src/it/deploy-loose-config-apps-with-toolchain-it/pom.xml
+++ b/liberty-maven-plugin/src/it/deploy-loose-config-apps-with-toolchain-it/pom.xml
@@ -27,9 +27,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/deploy-loose-config-apps-with-toolchain-it/src/test/java/net/wasdev/wlp/test/servlet/it/EndpointTest.java
+++ b/liberty-maven-plugin/src/it/deploy-loose-config-apps-with-toolchain-it/src/test/java/net/wasdev/wlp/test/servlet/it/EndpointTest.java
@@ -18,9 +18,12 @@ package net.wasdev.wlp.test.servlet.it;
 import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 
 public class EndpointTest {
     private static String URL;
@@ -32,20 +35,18 @@ public class EndpointTest {
 
     @Test
     public void testServlet() throws Exception {
-        HttpClient client = new HttpClient();
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet method = new HttpGet(URL);
 
-        GetMethod method = new GetMethod(URL);
+            try (CloseableHttpResponse response = client.execute(method)) {
+                int statusCode = response.getStatusLine().getStatusCode();
 
-        try {
-            int statusCode = client.executeMethod(method);
+                assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
 
-            assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
+                String responseBody = EntityUtils.toString(response.getEntity());
 
-            String response = method.getResponseBodyAsString();
-
-            assertTrue("Unexpected response body", response.contains("Hello! How are you today?"));
-        } finally {
-            method.releaseConnection();
-        }  
+                assertTrue("Unexpected response body", responseBody.contains("Hello! How are you today?"));
+            }
+        }
     }
 }

--- a/liberty-maven-plugin/src/it/deploy-loose-config-it/pom.xml
+++ b/liberty-maven-plugin/src/it/deploy-loose-config-it/pom.xml
@@ -27,9 +27,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/deploy-loose-config-it/src/test/java/net/wasdev/wlp/test/servlet/it/EndpointTest.java
+++ b/liberty-maven-plugin/src/it/deploy-loose-config-it/src/test/java/net/wasdev/wlp/test/servlet/it/EndpointTest.java
@@ -18,9 +18,12 @@ package net.wasdev.wlp.test.servlet.it;
 import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 
 public class EndpointTest {
     private static String URL;
@@ -32,20 +35,18 @@ public class EndpointTest {
 
     @Test
     public void testServlet() throws Exception {
-        HttpClient client = new HttpClient();
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet method = new HttpGet(URL);
 
-        GetMethod method = new GetMethod(URL);
+            try (CloseableHttpResponse response = client.execute(method)) {
+                int statusCode = response.getStatusLine().getStatusCode();
 
-        try {
-            int statusCode = client.executeMethod(method);
+                assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
 
-            assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
+                String responseBody = EntityUtils.toString(response.getEntity());
 
-            String response = method.getResponseBodyAsString();
-
-            assertTrue("Unexpected response body", response.contains("Hello! How are you today?"));
-        } finally {
-            method.releaseConnection();
-        }  
+                assertTrue("Unexpected response body", responseBody.contains("Hello! How are you today?"));
+            }
+        }
     }
 }

--- a/liberty-maven-plugin/src/it/dev-container-it/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-container-it/pom.xml
@@ -27,9 +27,9 @@
             <version>@pom.version@</version>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/pom.xml
@@ -27,9 +27,9 @@
             <version>@pom.version@</version>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-ear/pom.xml
@@ -28,9 +28,9 @@
             <type>war</type>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-ear/src/test/java/wasdev/ejb/it/EndpointIT.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-ear/src/test/java/wasdev/ejb/it/EndpointIT.java
@@ -18,9 +18,12 @@ package wasdev.ejb.it;
 import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 
 public class EndpointIT {
     private static String URL;
@@ -32,20 +35,18 @@ public class EndpointIT {
 
     @Test
     public void testServlet() throws Exception {
-        HttpClient client = new HttpClient();
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet method = new HttpGet(URL);
 
-        GetMethod method = new GetMethod(URL);
+            try (CloseableHttpResponse response = client.execute(method)) {
+                int statusCode = response.getStatusLine().getStatusCode();
 
-        try {
-            int statusCode = client.executeMethod(method);
+                assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
 
-            assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
+                String responseBody = EntityUtils.toString(response.getEntity());
 
-            String response = method.getResponseBodyAsString(1000);
-
-            assertTrue("Unexpected response body", response.contains("Hello EJB World."));
-        } finally {
-            method.releaseConnection();
-        }  
+                assertTrue("Unexpected response body", responseBody.contains("Hello EJB World."));
+            }
+        }
     }
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
@@ -26,10 +26,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -115,24 +117,23 @@ public class BaseMultiModuleTest extends BaseDevTest {
       }
    }
 
-   public void assertEndpointContent(String url, String assertResponseContains) throws IOException, HttpException {
-      assertEndpointContent(url, assertResponseContains, logFile); 
+   public void assertEndpointContent(String url, String assertResponseContains) throws IOException {
+      assertEndpointContent(url, assertResponseContains, logFile);
    }
 
-   public void assertEndpointContent(String url, String assertResponseContains, File log) throws IOException, HttpException {
-      HttpClient client = new HttpClient();
+   public void assertEndpointContent(String url, String assertResponseContains, File log) throws IOException {
+      try (CloseableHttpClient client = HttpClients.createDefault()) {
+         HttpGet method = new HttpGet(url);
+         
+         try (CloseableHttpResponse response = client.execute(method)) {
+            int statusCode = response.getStatusLine().getStatusCode();
 
-      GetMethod method = new GetMethod(url);
-      try {
-         int statusCode = client.executeMethod(method);
+            assertEquals("HTTP GET failed. " + getLogTail(log), HttpStatus.SC_OK, statusCode);
 
-         assertEquals("HTTP GET failed. " + getLogTail(log), HttpStatus.SC_OK, statusCode);
+            String responseBody = EntityUtils.toString(response.getEntity());
 
-         String response = method.getResponseBodyAsString();
-
-         assertTrue("Unexpected response body: " + response + ". " + getLogTail(), response.contains(assertResponseContains));
-      } finally {
-         method.releaseConnection();
+            assertTrue("Unexpected response body: " + responseBody + ". " + getLogTail(), responseBody.contains(assertResponseContains));
+         }
       }
    }
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunInstallEarTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunInstallEarTest.java
@@ -20,10 +20,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunTest.java
@@ -19,10 +19,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleSkipFlagsIntegrationTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleSkipFlagsIntegrationTest.java
@@ -19,10 +19,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleSkipFlagsUnitTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleSkipFlagsUnitTest.java
@@ -19,10 +19,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleConcurrentLibertyModulesPlTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleConcurrentLibertyModulesPlTest.java
@@ -19,10 +19,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleLibertyModulesPlTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleLibertyModulesPlTest.java
@@ -19,10 +19,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleLibertyModulesSkinnyModulesTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleLibertyModulesSkinnyModulesTest.java
@@ -19,10 +19,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleLibertyModulesSkipConflictsTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleLibertyModulesSkipConflictsTest.java
@@ -19,10 +19,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleLibertyModulesTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleLibertyModulesTest.java
@@ -19,10 +19,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/RunTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/RunTest.java
@@ -24,9 +24,12 @@ import java.io.File;
 import java.io.FileWriter;
 import java.nio.file.Files;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
@@ -45,21 +48,20 @@ public class RunTest extends BaseDevTest {
 
    @Test
    public void endpointTest() throws Exception {
-         HttpClient client = new HttpClient();
+         try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet method = new HttpGet(URL);
+            
+            try (CloseableHttpResponse response = client.execute(method)) {
+               int statusCode = response.getStatusLine().getStatusCode();
 
-        GetMethod method = new GetMethod(URL);
-         try {
-            int statusCode = client.executeMethod(method);
+               assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
 
-            assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
+               String responseBody = EntityUtils.toString(response.getEntity());
 
-            String response = method.getResponseBodyAsString();
-
-            assertTrue("Unexpected response body", response.contains("hello world"));
-            assertFalse(verifyLogMessageExists("SLF4J: Failed to load class", 2000));
-            assertTrue(verifyLogMessageExists("SLF4J Logger is ready for messages.", 2000));
-         } finally {
-            method.releaseConnection();
+               assertTrue("Unexpected response body", responseBody.contains("hello world"));
+               assertFalse(verifyLogMessageExists("SLF4J: Failed to load class", 2000));
+               assertTrue(verifyLogMessageExists("SLF4J Logger is ready for messages.", 2000));
+            }
          }
    }
 

--- a/liberty-maven-plugin/src/it/dev-skip-install-feature-it/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-skip-install-feature-it/pom.xml
@@ -27,9 +27,9 @@
             <version>@pom.version@</version>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/ear-project-it/AppXmlEAR/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/AppXmlEAR/pom.xml
@@ -29,9 +29,9 @@
             <type>war</type>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/ear-project-it/SampleEAR-classifier-app/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/SampleEAR-classifier-app/pom.xml
@@ -30,9 +30,9 @@
             <type>war</type>
         </dependency>
       <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/ear-project-it/SampleEAR-classifier-app/src/test/java/net/wasdev/wlp/maven/test/it/EndpointIT.java
+++ b/liberty-maven-plugin/src/it/ear-project-it/SampleEAR-classifier-app/src/test/java/net/wasdev/wlp/maven/test/it/EndpointIT.java
@@ -18,9 +18,12 @@ package net.wasdev.wlp.maven.test.it;
 import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 
 public class EndpointIT {
     private static String URL;
@@ -32,20 +35,18 @@ public class EndpointIT {
     
     @Test
     public void testServlet() throws Exception {
-        HttpClient client = new HttpClient();
-        
-        GetMethod method = new GetMethod(URL);
-        
-        try {
-            int statusCode = client.executeMethod(method);
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet method = new HttpGet(URL);
             
-            assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
-            
-            String response = method.getResponseBodyAsString(1000);
-            
-            assertTrue("Unexpected response body", response.contains("Hello classifier test World."));
-        } finally {
-            method.releaseConnection();
+            try (CloseableHttpResponse response = client.execute(method)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                
+                assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
+                
+                String responseBody = EntityUtils.toString(response.getEntity());
+                
+                assertTrue("Unexpected response body", responseBody.contains("Hello classifier test World."));
+            }
         }
     }
 }

--- a/liberty-maven-plugin/src/it/ear-project-it/SampleEAR/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/SampleEAR/pom.xml
@@ -35,9 +35,9 @@
             <type>war</type>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/ear-project-it/SampleEAR/src/test/java/net/wasdev/wlp/maven/test/it/EndpointIT.java
+++ b/liberty-maven-plugin/src/it/ear-project-it/SampleEAR/src/test/java/net/wasdev/wlp/maven/test/it/EndpointIT.java
@@ -18,9 +18,12 @@ package net.wasdev.wlp.maven.test.it;
 import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 
 public class EndpointIT {
     private static String URL;
@@ -32,20 +35,18 @@ public class EndpointIT {
     
     @Test
     public void testServlet() throws Exception {
-        HttpClient client = new HttpClient();
-        
-        GetMethod method = new GetMethod(URL);
-        
-        try {
-            int statusCode = client.executeMethod(method);
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet method = new HttpGet(URL);
             
-            assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
-            
-            String response = method.getResponseBodyAsString(1000);
-            
-            assertTrue("Unexpected response body", response.contains("Hello EJB World."));
-        } finally {
-            method.releaseConnection();
+            try (CloseableHttpResponse response = client.execute(method)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                
+                assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
+                
+                String responseBody = EntityUtils.toString(response.getEntity());
+                
+                assertTrue("Unexpected response body", responseBody.contains("Hello EJB World."));
+            }
         }
     }
 }

--- a/liberty-maven-plugin/src/it/ear-project-it/SampleEar_NonLooseApp/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/SampleEar_NonLooseApp/pom.xml
@@ -35,9 +35,9 @@
             <type>war</type>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/ear-project-it/SampleWLP/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/SampleWLP/pom.xml
@@ -27,9 +27,9 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/liberty-maven-plugin/src/it/ear-project-it/SampleWLP/src/test/java/net/wasdev/wlp/maven/test/it/EndpointIT.java
+++ b/liberty-maven-plugin/src/it/ear-project-it/SampleWLP/src/test/java/net/wasdev/wlp/maven/test/it/EndpointIT.java
@@ -18,9 +18,12 @@ package net.wasdev.wlp.maven.test.it;
 import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 
 public class EndpointIT {
     private static String URL;
@@ -32,20 +35,18 @@ public class EndpointIT {
     
     @Test
     public void testServlet() throws Exception {
-        HttpClient client = new HttpClient();
-        
-        GetMethod method = new GetMethod(URL);
-        
-        try {
-            int statusCode = client.executeMethod(method);
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet method = new HttpGet(URL);
             
-            assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
-            
-            String response = method.getResponseBodyAsString(1000);
-            
-            assertTrue("Unexpected response body", response.contains("Hello EJB World."));
-        } finally {
-            method.releaseConnection();
+            try (CloseableHttpResponse response = client.execute(method)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                
+                assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
+                
+                String responseBody = EntityUtils.toString(response.getEntity());
+                
+                assertTrue("Unexpected response body", responseBody.contains("Hello EJB World."));
+            }
         }
     }
 }

--- a/liberty-maven-plugin/src/it/ear-project-it/skinnywar-ear/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/skinnywar-ear/pom.xml
@@ -33,9 +33,9 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/ear-project-it/skinnywar-wlp/pom.xml
+++ b/liberty-maven-plugin/src/it/ear-project-it/skinnywar-wlp/pom.xml
@@ -27,9 +27,9 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/liberty-maven-plugin/src/it/generate-features-it/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/pom.xml
@@ -31,9 +31,9 @@
             <version>@pom.version@</version>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/loose-config-it/pom.xml
+++ b/liberty-maven-plugin/src/it/loose-config-it/pom.xml
@@ -27,9 +27,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/loose-config-it/src/test/java/net/wasdev/wlp/test/servlet/it/EndpointTest.java
+++ b/liberty-maven-plugin/src/it/loose-config-it/src/test/java/net/wasdev/wlp/test/servlet/it/EndpointTest.java
@@ -18,9 +18,12 @@ package net.wasdev.wlp.test.servlet.it;
 import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 
 public class EndpointTest {
     private static String URL;
@@ -32,20 +35,18 @@ public class EndpointTest {
 
     @Test
     public void testServlet() throws Exception {
-        HttpClient client = new HttpClient();
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet method = new HttpGet(URL);
 
-        GetMethod method = new GetMethod(URL);
+            try (CloseableHttpResponse response = client.execute(method)) {
+                int statusCode = response.getStatusLine().getStatusCode();
 
-        try {
-            int statusCode = client.executeMethod(method);
+                assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
 
-            assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
+                String responseBody = EntityUtils.toString(response.getEntity());
 
-            String response = method.getResponseBodyAsString();
-
-            assertTrue("Unexpected response body", response.contains("Hello! How are you today?"));
-        } finally {
-            method.releaseConnection();
-        }  
+                assertTrue("Unexpected response body", responseBody.contains("Hello! How are you today?"));
+            }
+        }
     }
 }

--- a/liberty-maven-plugin/src/it/package-type-config-it/pom.xml
+++ b/liberty-maven-plugin/src/it/package-type-config-it/pom.xml
@@ -25,9 +25,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/package-type-config-new-posix-it/pom.xml
+++ b/liberty-maven-plugin/src/it/package-type-config-new-posix-it/pom.xml
@@ -25,9 +25,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/server-config-props-it/pom.xml
+++ b/liberty-maven-plugin/src/it/server-config-props-it/pom.xml
@@ -30,9 +30,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/toolchain-run-it/pom.xml
+++ b/liberty-maven-plugin/src/it/toolchain-run-it/pom.xml
@@ -27,9 +27,9 @@
             <version>@pom.version@</version>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
fixing httpclient vulnerability in integration tests

Changes tests to use httpclient 4.5 , and referred official documentation quickstart examples 
https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html


- Replaced commons-httpclient:commons-httpclient:3.1 with org.apache.httpcomponents:httpclient:4.5.14 in all integration test POMs where httpclient is referenced.

- Updated imports and API usage from commons-httpclient 3.x to Apache HttpComponents 4.x

