### PR TITLE
Added annotation processor support for dev mode hot reload

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -98,8 +98,7 @@ jobs:
       - name: Checkout ci.common
         uses: actions/checkout@v3
         with:
-          repository: sajeerzeji/ci.common
-          ref: GHMAVEN2021-annotation_processor_paths_issue
+          repository: OpenLiberty/ci.common
           path: ci.common
       - name: Checkout ci.ant
         uses: actions/checkout@v3
@@ -207,7 +206,7 @@ jobs:
       - name: Clone ci.ant and ci.common repos to github.workspace
         run: |
           echo ${{github.workspace}}
-          git clone https://github.com/sajeerzeji/ci.common.git --branch GHMAVEN2021-annotation_processor_paths_issue --single-branch ${{github.workspace}}/ci.common
+          git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common
           git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -98,7 +98,8 @@ jobs:
       - name: Checkout ci.common
         uses: actions/checkout@v3
         with:
-          repository: OpenLiberty/ci.common
+          repository: sajeerzeji/ci.common
+          ref: GHMAVEN2021-annotation_processor_paths_issue
           path: ci.common
       - name: Checkout ci.ant
         uses: actions/checkout@v3
@@ -206,7 +207,7 @@ jobs:
       - name: Clone ci.ant and ci.common repos to github.workspace
         run: |
           echo ${{github.workspace}}
-          git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common
+          git clone https://github.com/sajeerzeji/ci.common.git --branch GHMAVEN2021-annotation_processor_paths_issue --single-branch ${{github.workspace}}/ci.common
           git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.30</version>
+      <version>1.18.36</version>
       <scope>provided</scope>
     </dependency>
     
@@ -70,9 +70,12 @@
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
-              <version>1.18.30</version>
+              <version>1.18.36</version>
             </path>
           </annotationProcessorPaths>
+          <annotationProcessors>
+            <annotationProcessor>lombok.launch.AnnotationProcessorHider$AnnotationProcessor</annotationProcessor>
+          </annotationProcessors>
         </configuration>
       </plugin>
       <plugin>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/pom.xml
@@ -1,0 +1,108 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>dev-it-tests</groupId>
+  <artifactId>dev-lombok-proj</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>war</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven.compiler.release>17</maven.compiler.release>
+    <app.name>LombokProject</app.name>
+    <testServerHttpPort>9080</testServerHttpPort>
+    <testServerHttpsPort>9443</testServerHttpsPort>
+    <packaging.type>usr</packaging.type>
+  </properties>
+
+  <dependencyManagement>
+      <dependencies>
+          <dependency>
+              <groupId>io.openliberty.features</groupId>
+              <artifactId>features-bom</artifactId>
+              <version>RUNTIME_VERSION</version>
+              <type>pom</type>
+              <scope>import</scope>
+          </dependency>
+      </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+        <groupId>io.openliberty.features</groupId>
+        <artifactId>jaxrs-2.1</artifactId>
+        <type>esa</type>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>io.openliberty.features</groupId>
+        <artifactId>cdi-2.0</artifactId>
+        <type>esa</type>
+        <scope>provided</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.30</version>
+      <scope>provided</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>1.18.30</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.4.0</version>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <packagingExcludes>pom.xml</packagingExcludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.openliberty.tools</groupId>
+        <artifactId>liberty-maven-plugin</artifactId>
+        <version>SUB_VERSION</version>
+        <configuration>
+          <assemblyArtifact>
+            <groupId>io.openliberty</groupId>
+            <artifactId>openliberty-kernel</artifactId>
+            <version>RUNTIME_VERSION</version>
+            <type>zip</type>
+          </assemblyArtifact>
+          <packageName>${app.name}</packageName>
+          <include>${packaging.type}</include>
+          <bootstrapProperties>
+            <default.http.port>${testServerHttpPort}</default.http.port>
+            <default.https.port>${testServerHttpsPort}</default.https.port>
+          </bootstrapProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/pom.xml
@@ -11,7 +11,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <app.name>LombokProject</app.name>
     <testServerHttpPort>9080</testServerHttpPort>
     <testServerHttpsPort>9443</testServerHttpsPort>
@@ -47,7 +48,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.36</version>
+      <version>1.18.42</version>
       <scope>provided</scope>
     </dependency>
     
@@ -70,7 +71,7 @@
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
-              <version>1.18.36</version>
+              <version>1.18.42</version>
             </path>
           </annotationProcessorPaths>
           <annotationProcessors>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/src/main/java/com/demo/rest/Pojo.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/src/main/java/com/demo/rest/Pojo.java
@@ -1,0 +1,10 @@
+package com.demo.rest;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class Pojo {
+    private final String name;
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/src/main/java/com/demo/rest/PojoResource.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/src/main/java/com/demo/rest/PojoResource.java
@@ -1,0 +1,17 @@
+package com.demo.rest;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/pojo")
+public class PojoResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getPojo() {
+        Pojo pojo = new Pojo("test");
+        return "Pojo name: " + pojo.getName();
+    }
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/src/main/java/com/demo/rest/RestApplication.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/src/main/java/com/demo/rest/RestApplication.java
@@ -1,0 +1,8 @@
+package com.demo.rest;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/api")
+public class RestApplication extends Application {
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/src/main/liberty/config/server.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="Sample Liberty server">
+
+    <featureManager>
+        <feature>jaxrs-2.1</feature>
+        <feature>cdi-2.0</feature>
+    </featureManager>
+
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="9080"
+                  httpsPort="9443" />
+
+    <webApplication location="dev-lombok-proj.war" contextRoot="/" />
+
+</server>

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevAnnotationProcessorTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevAnnotationProcessorTest.java
@@ -41,15 +41,18 @@ public class DevAnnotationProcessorTest extends BaseDevTest {
       
       assertTrue("Web app should be available", verifyLogMessageExists(WEB_APP_AVAILABLE, 60000));
       
+      assertFalse("Should not have compilation errors during startup",
+                  verifyLogMessageExists("variable name not initialized", 2000));
+      
       File pojoFile = new File(tempProj, "src/main/java/com/demo/rest/Pojo.java");
       assertTrue("Pojo.java should exist", pojoFile.exists());
       replaceString("@RequiredArgsConstructor", "// Modified\n@RequiredArgsConstructor", pojoFile);
 
-      Thread.sleep(5000);
+      Thread.sleep(8000);
       
-      assertTrue("Recompilation should succeed with annotation processor", 
+      assertTrue("Recompilation should succeed with annotation processor",
                  verifyLogMessageExists(COMPILATION_SUCCESSFUL, 60000));
-      assertFalse("Should not have compilation errors", 
+      assertFalse("Should not have compilation errors",
                   verifyLogMessageExists("variable name not initialized", 5000));
       
       tagLog("##annotationProcessorTest end");

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevAnnotationProcessorTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevAnnotationProcessorTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2026.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DevAnnotationProcessorTest extends BaseDevTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      setUpBeforeClass(null, "../resources/basic-dev-project-lombok");
+   }
+
+   @AfterClass
+   public static void cleanUpAfterClass() throws Exception {
+      BaseDevTest.cleanUpAfterClass();
+   }
+
+   @Test
+   public void annotationProcessorTest() throws Exception {
+      tagLog("##annotationProcessorTest start");
+      
+      assertTrue("Web app should be available", verifyLogMessageExists(WEB_APP_AVAILABLE, 60000));
+      
+      File pojoFile = new File(tempProj, "src/main/java/com/demo/rest/Pojo.java");
+      assertTrue("Pojo.java should exist", pojoFile.exists());
+      replaceString("@RequiredArgsConstructor", "// Modified\n@RequiredArgsConstructor", pojoFile);
+
+      Thread.sleep(5000);
+      
+      assertTrue("Recompilation should succeed with annotation processor", 
+                 verifyLogMessageExists(COMPILATION_SUCCESSFUL, 60000));
+      assertFalse("Should not have compilation errors", 
+                  verifyLogMessageExists("variable name not initialized", 5000));
+      
+      tagLog("##annotationProcessorTest end");
+   }
+}

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -1891,6 +1891,26 @@ public class DevMojo extends LooseAppSupport {
                     }
                 }
             }
+            
+            // Extract annotation processors (comma separated list of processor class names)
+            Xpp3Dom annotationProcessors = configuration.getChild("annotationProcessors");
+            if (annotationProcessors != null) {
+                Xpp3Dom[] processorElements = annotationProcessors.getChildren("annotationProcessor");
+                if (processorElements != null && processorElements.length > 0) {
+                    List<String> processorList = new ArrayList<>();
+                    for (Xpp3Dom processor : processorElements) {
+                        String processorClass = processor.getValue();
+                        if (processorClass != null && !processorClass.trim().isEmpty()) {
+                            processorList.add(processorClass.trim());
+                        }
+                    }
+                    if (!processorList.isEmpty()) {
+                        String processors = String.join(",", processorList);
+                        compilerOptions.setAnnotationProcessors(processors);
+                        getLog().debug("Setting annotation processors: " + processors);
+                    }
+                }
+            }
         }
 
         return compilerOptions;

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -64,6 +64,10 @@ import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingResult;
 import org.apache.maven.rtinfo.RuntimeInformation;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
 import org.twdata.maven.mojoexecutor.MojoExecutor.Element;
 
 import io.openliberty.tools.ant.ServerTask;
@@ -1833,6 +1837,60 @@ public class DevMojo extends LooseAppSupport {
         if (encoding != null) {
             getLog().debug("Setting compiler encoding to " + encoding);
             compilerOptions.setEncoding(encoding);
+        }
+
+        // Extract and resolve annotation processor paths
+        if (configuration != null) {
+            Xpp3Dom annotationProcessorPaths = configuration.getChild("annotationProcessorPaths");
+            if (annotationProcessorPaths != null) {
+                Xpp3Dom[] pathElements = annotationProcessorPaths.getChildren("path");
+                if (pathElements != null && pathElements.length > 0) {
+                    List<String> resolvedPaths = new ArrayList<>();
+                    for (Xpp3Dom path : pathElements) {
+                        Xpp3Dom groupIdElement = path.getChild("groupId");
+                        Xpp3Dom artifactIdElement = path.getChild("artifactId");
+                        Xpp3Dom versionElement = path.getChild("version");
+                        
+                        if (groupIdElement != null && artifactIdElement != null && versionElement != null) {
+                            String groupId = groupIdElement.getValue();
+                            String artifactId = artifactIdElement.getValue();
+                            String version = versionElement.getValue();
+                            
+                            if (groupId != null && artifactId != null && version != null) {
+                                try {
+                                    // Use Maven's artifact resolution to resolve annotation processor artifacts
+                                    org.eclipse.aether.artifact.Artifact aetherArtifact =
+                                        new DefaultArtifact(groupId, artifactId, "jar", version);
+                                    
+                                    ArtifactRequest req =
+                                        new ArtifactRequest()
+                                            .setRepositories(this.repositories)
+                                            .setArtifact(aetherArtifact);
+                                    
+                                    ArtifactResult result =
+                                        this.repositorySystem.resolveArtifact(this.repoSession, req);
+                                    
+                                    if (result.isResolved() && result.getArtifact().getFile() != null) {
+                                        File file = result.getArtifact().getFile();
+                                        resolvedPaths.add(file.getAbsolutePath());
+                                        getLog().debug("Resolved annotation processor " + groupId + ":" + artifactId +
+                                                     ":" + version + " to " + file.getAbsolutePath());
+                                    }
+                                } catch (ArtifactResolutionException e) {
+                                    getLog().warn("Failed to resolve annotation processor artifact " +
+                                                groupId + ":" + artifactId + ":" + version + ": " + e.getMessage());
+                                }
+                            }
+                        }
+                    }
+                    
+                    if (!resolvedPaths.isEmpty()) {
+                        String processorPath = String.join(File.pathSeparator, resolvedPaths);
+                        compilerOptions.setAnnotationProcessorPath(processorPath);
+                        getLog().debug("Setting annotation processor path: " + processorPath);
+                    }
+                }
+            }
         }
 
         return compilerOptions;


### PR DESCRIPTION
Fixes #2021 

- Enhanced JavaCompilerOptions (ci.common)
Added annotationProcessorPath field and methods to support the -processorpath compiler option
- Updated DevMojo.getMavenCompilerOptions()
Extracts annotationProcessorPaths from maven-compiler-plugin configuration and resolves artifacts
- Added integration test
Created DevAnnotationProcessorTest with a Lombok-based test project to verify annotation processors work correctly during recompilation

Before:

https://github.com/user-attachments/assets/aaa08bb7-1f91-4932-a941-b39e72d325ca

After

https://github.com/user-attachments/assets/6262b66a-f703-4107-9fda-ad52f685b3ba

