### PR TITLE
Add the sonatype repository in some test cases

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-umbrella-deps/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-umbrella-deps/pom.xml
@@ -21,6 +21,18 @@
     <packaging.type>usr</packaging.type>
   </properties>
 
+  <repositories>
+    <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+    <repository>
+        <id>oss-sonatype</id>
+        <name>oss-sonatype</name>
+        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
         <groupId>jakarta.platform</groupId>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-umbrella-deps/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-umbrella-deps/pom.xml
@@ -24,9 +24,9 @@
   <repositories>
     <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
     <repository>
-        <id>oss-sonatype</id>
-        <name>oss-sonatype</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <id>central-portal-snapshots</id>
+        <name>Central Portal Snapshots</name>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
@@ -32,9 +32,9 @@
   <repositories>
     <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
     <repository>
-        <id>oss-sonatype</id>
-        <name>oss-sonatype</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <id>central-portal-snapshots</id>
+        <name>Central Portal Snapshots</name>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
@@ -29,6 +29,18 @@
     <custom.dir.location>customDirLocation</custom.dir.location>
   </properties>
 
+  <repositories>
+    <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+    <repository>
+        <id>oss-sonatype</id>
+        <name>oss-sonatype</name>
+        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+  </repositories>
+
   <dependencyManagement>
       <dependencies>
           <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/mp-starter-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/mp-starter-project/pom.xml
@@ -15,6 +15,18 @@
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
   
+  <repositories>
+    <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+    <repository>
+        <id>oss-sonatype</id>
+        <name>oss-sonatype</name>
+        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>org.eclipse.microprofile</groupId>

--- a/liberty-maven-plugin/src/it/dev-it/resources/mp-starter-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/mp-starter-project/pom.xml
@@ -18,9 +18,9 @@
   <repositories>
     <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
     <repository>
-        <id>oss-sonatype</id>
-        <name>oss-sonatype</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <id>central-portal-snapshots</id>
+        <name>Central Portal Snapshots</name>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear1/pom.xml
@@ -26,9 +26,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear1/pom.xml
@@ -23,6 +23,18 @@
         <!-- <skipUTs>true</skipUTs> -->
     </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- web and jar modules as dependencies -->
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear2/pom.xml
@@ -26,9 +26,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear2/pom.xml
@@ -23,6 +23,18 @@
         <!-- <skipUTs>true</skipUTs> -->
     </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- web and jar modules as dependencies -->
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear-skinny-modules/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear-skinny-modules/pom.xml
@@ -26,9 +26,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear-skinny-modules/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear-skinny-modules/pom.xml
@@ -23,6 +23,18 @@
         <!-- <skipUTs>true</skipUTs> -->
     </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- web and jar modules as dependencies -->
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear1/pom.xml
@@ -26,9 +26,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear1/pom.xml
@@ -23,6 +23,18 @@
         <!-- <skipUTs>true</skipUTs> -->
     </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- web and jar modules as dependencies -->
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear2/pom.xml
@@ -26,9 +26,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear2/pom.xml
@@ -23,6 +23,18 @@
         <!-- <skipUTs>true</skipUTs> -->
     </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- web and jar modules as dependencies -->
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-ear/pom.xml
@@ -14,6 +14,18 @@
 
     <name>EAR Module</name>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>sample</groupId>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/ejb-ear/pom.xml
@@ -17,9 +17,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/pom.xml
@@ -19,6 +19,18 @@
         <module>ear</module>
     </modules>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- For tests -->
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/pom.xml
@@ -22,9 +22,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
@@ -26,9 +26,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
@@ -23,6 +23,18 @@
         <!-- <skipUTs>true</skipUTs> -->
     </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- web and jar modules as dependencies -->
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
@@ -22,9 +22,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
@@ -19,6 +19,18 @@
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- web and jar modules as dependencies -->
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/pom.xml
@@ -18,9 +18,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/pom.xml
@@ -15,6 +15,18 @@
         <module>ear</module>
     </modules>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- SUB JUNIT -->
     </dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
@@ -26,9 +26,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
@@ -23,6 +23,18 @@
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
 
         <!-- Provided dependencies -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
@@ -20,9 +20,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
@@ -17,6 +17,18 @@
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>io.openliberty.guides</groupId>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
@@ -20,9 +20,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/pom/pom.xml
@@ -17,6 +17,18 @@
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>io.openliberty.guides</groupId>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
@@ -20,9 +20,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/pom/pom.xml
@@ -17,6 +17,18 @@
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>io.openliberty.guides</groupId>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/parent/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/parent/pom.xml
@@ -24,5 +24,17 @@
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
-    
+
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/parent/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/parent/pom.xml
@@ -28,9 +28,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent1/pom.xml
@@ -17,6 +17,18 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- SUB JUNIT -->
     </dependencies>
@@ -30,16 +42,4 @@
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
-
-    <repositories>
-        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
-        <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent1/pom.xml
@@ -30,4 +30,16 @@
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
+
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent2/pom.xml
@@ -11,6 +11,18 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- Provided dependencies -->
         <!-- SUB JAKARTAEE -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent2/pom.xml
@@ -14,9 +14,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
@@ -20,9 +20,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/pom/pom.xml
@@ -17,6 +17,18 @@
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>io.openliberty.guides</groupId>

--- a/liberty-maven-plugin/src/it/dev-skip-install-feature-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-skip-install-feature-it/resources/basic-dev-project/pom.xml
@@ -24,9 +24,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/dev-skip-install-feature-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-skip-install-feature-it/resources/basic-dev-project/pom.xml
@@ -21,6 +21,18 @@
     <packaging.type>usr</packaging.type>
   </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
   <dependencyManagement>
       <dependencies>
           <dependency>

--- a/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project10/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project10/pom.xml
@@ -24,9 +24,9 @@
   <repositories>
     <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
     <repository>
-        <id>oss-sonatype</id>
-        <name>oss-sonatype</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <id>central-portal-snapshots</id>
+        <name>Central Portal Snapshots</name>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>

--- a/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project10/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project10/pom.xml
@@ -21,6 +21,18 @@
     <packaging.type>usr</packaging.type>
   </properties>
 
+  <repositories>
+    <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+    <repository>
+        <id>oss-sonatype</id>
+        <name>oss-sonatype</name>
+        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+  </repositories>
+
   <dependencyManagement>
       <dependencies>
           <dependency>

--- a/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project6/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project6/pom.xml
@@ -21,6 +21,18 @@
     <packaging.type>usr</packaging.type>
   </properties>
   
+  <repositories>
+    <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+    <repository>
+        <id>oss-sonatype</id>
+        <name>oss-sonatype</name>
+        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+  </repositories>
+
   <dependencyManagement>
       <dependencies>
           <dependency>

--- a/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project6/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project6/pom.xml
@@ -24,9 +24,9 @@
   <repositories>
     <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
     <repository>
-        <id>oss-sonatype</id>
-        <name>oss-sonatype</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <id>central-portal-snapshots</id>
+        <name>Central Portal Snapshots</name>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>

--- a/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project7/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project7/pom.xml
@@ -24,9 +24,9 @@
   <repositories>
     <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
     <repository>
-        <id>oss-sonatype</id>
-        <name>oss-sonatype</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <id>central-portal-snapshots</id>
+        <name>Central Portal Snapshots</name>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>

--- a/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project7/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project7/pom.xml
@@ -21,6 +21,18 @@
     <packaging.type>usr</packaging.type>
   </properties>
 
+  <repositories>
+    <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+    <repository>
+        <id>oss-sonatype</id>
+        <name>oss-sonatype</name>
+        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+  </repositories>
+
   <dependencyManagement>
       <dependencies>
           <dependency>

--- a/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project8/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project8/pom.xml
@@ -24,9 +24,9 @@
   <repositories>
     <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
     <repository>
-        <id>oss-sonatype</id>
-        <name>oss-sonatype</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <id>central-portal-snapshots</id>
+        <name>Central Portal Snapshots</name>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>

--- a/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project8/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project8/pom.xml
@@ -21,6 +21,18 @@
     <packaging.type>usr</packaging.type>
   </properties>
 
+  <repositories>
+    <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+    <repository>
+        <id>oss-sonatype</id>
+        <name>oss-sonatype</name>
+        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+  </repositories>
+
   <dependencyManagement>
       <dependencies>
           <dependency>

--- a/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project9/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project9/pom.xml
@@ -24,9 +24,9 @@
   <repositories>
     <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
     <repository>
-        <id>oss-sonatype</id>
-        <name>oss-sonatype</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <id>central-portal-snapshots</id>
+        <name>Central Portal Snapshots</name>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>

--- a/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project9/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project9/pom.xml
@@ -21,6 +21,18 @@
     <packaging.type>usr</packaging.type>
   </properties>
 
+  <repositories>
+    <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+    <repository>
+        <id>oss-sonatype</id>
+        <name>oss-sonatype</name>
+        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+  </repositories>
+
   <dependencyManagement>
       <dependencies>
           <dependency>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/basic-dev-project/pom.xml
@@ -24,9 +24,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/basic-dev-project/pom.xml
@@ -21,6 +21,18 @@
     <packaging.type>usr</packaging.type>
   </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
   <dependencyManagement>
       <dependencies>
           <dependency>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/pom/pom.xml
@@ -20,9 +20,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/pom/pom.xml
@@ -17,6 +17,18 @@
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
     </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>io.openliberty.guides</groupId>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/restful/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/restful/pom.xml
@@ -22,9 +22,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/restful/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/restful/pom.xml
@@ -19,6 +19,18 @@
         <packaging.type>usr</packaging.type>
     </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/liberty-maven-plugin/src/it/server-config-props-it/pom.xml
+++ b/liberty-maven-plugin/src/it/server-config-props-it/pom.xml
@@ -22,6 +22,18 @@
         <app.name>${project.artifactId}</app.name>
     </properties>
 
+    <repositories>
+        <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/liberty-maven-plugin/src/it/server-config-props-it/pom.xml
+++ b/liberty-maven-plugin/src/it/server-config-props-it/pom.xml
@@ -25,9 +25,9 @@
     <repositories>
         <!-- Sonatype repo needed to get the feature-gen jar for liberty:generate-features -->
         <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>


### PR DESCRIPTION
Added the same sonatype specification to each test case even though originally they differed slightly.

Updated just the classes affected by https://github.com/OpenLiberty/ci.maven/pull/1921
except for the dev-container-it test case which doesn't seem to be a feature gen test case.