### PR TITLE
Wait for dev mode to install features before checking

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevGenerateFeaturesDependenciesTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevGenerateFeaturesDependenciesTest.java
@@ -58,7 +58,6 @@ public class DevGenerateFeaturesDependenciesTest extends BaseDevTest {
        assertTrue(verifyLogMessageExists("mpHealth-2.2", 10000, targetGeneratedFeaturesFile));
        assertTrue(verifyLogMessageExists("mpHealth-2.2", 10000)); // should appear in the message "CWWKF0012I: The server installed the following features:"
 
-       int generateFeaturesCount = countOccurrences("Running liberty:generate-features", logFile);
        assertTrue(verifyLogMessageExists("Recompile skipped for dev-sample-proj since earlier compilation is successful", 10000));
 
        // modify MicroProfile umbrella dependency in pom.xml
@@ -77,9 +76,9 @@ public class DevGenerateFeaturesDependenciesTest extends BaseDevTest {
              pom);
 
        // Dev mode should now run the generate features mojo
-       assertTrue(getLogTail(), verifyLogMessageExists("Generated the following features:", 15000, logFile, ++generateFeaturesCount)); // mojo ran
+       assertTrue(getLogTail(), verifyLogMessageExists("Generated the following features:", 15000)); // mojo ran
        // Dev mode will now install the features before copying them into the server dir. Look for server response before further checks
-       assertTrue(getLogTail(), verifyLogMessageExists("CWWKF0008I: Feature update completed", 240000, logFile, ++generateFeaturesCount)); // could take a couple minutes
+       assertTrue(getLogTail(), verifyLogMessageExists("CWWKF0008I: Feature update completed", 120000)); // could take a couple minutes
 
        assertTrue(targetGeneratedFeaturesFile.exists());
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevGenerateFeaturesDependenciesTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevGenerateFeaturesDependenciesTest.java
@@ -76,9 +76,9 @@ public class DevGenerateFeaturesDependenciesTest extends BaseDevTest {
              pom);
 
        // Dev mode should now run the generate features mojo
-       assertTrue(getLogTail(), verifyLogMessageExists("Generated the following features:", 15000)); // mojo ran
+       assertTrue(getLogTail(), verifyLogMessageExists(GENERATE_FEATURES, 15000)); // mojo ran
        // Dev mode will now install the features before copying them into the server dir. Look for server response before further checks
-       assertTrue(getLogTail(), verifyLogMessageExists("CWWKF0008I: Feature update completed", 120000)); // could take a couple minutes
+       assertTrue(getLogTail(), verifyLogMessageExists(SERVER_UPDATE_COMPLETE, 120000)); // could take a couple minutes
 
        assertTrue(targetGeneratedFeaturesFile.exists());
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevGenerateFeaturesDependenciesTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevGenerateFeaturesDependenciesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright IBM Corporation 2022, 2025
+ * (c) Copyright IBM Corporation 2022, 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,20 +78,17 @@ public class DevGenerateFeaturesDependenciesTest extends BaseDevTest {
 
        // Dev mode should now run the generate features mojo
        assertTrue(getLogTail(), verifyLogMessageExists("Generated the following features:", 15000, logFile, ++generateFeaturesCount)); // mojo ran
-       // assertTrue(generatedFeaturesFile.exists());
-       // assertTrue(getLogTail(), lastModified < generatedFeaturesFile.lastModified());
-       assertTrue(targetGeneratedFeaturesFile.exists());
-       assertTrue(getLogTail(), lastModified < targetGeneratedFeaturesFile.lastModified());
-       //assertTrue(targetGeneratedFeaturesFile.exists());
+       // Dev mode will now install the features before copying them into the server dir. Look for server response before further checks
+       assertTrue(getLogTail(), verifyLogMessageExists("CWWKF0008I: Feature update completed", 240000, logFile, ++generateFeaturesCount)); // could take a couple minutes
 
-       // verify that mpHealth-3.0 is now in the generated features file
-       // assertTrue(getLogTail(), verifyLogMessageExists("mpHealth-3.1", 10000, generatedFeaturesFile));
-       assertTrue(getLogTail(), verifyLogMessageExists("mpHealth-3.1", 10000, targetGeneratedFeaturesFile));
-       assertTrue(getLogTail(), verifyLogMessageExists("mpHealth-3.1", 10000)); // should appear in the message "CWWKF0012I: The server installed the following features:"
+       assertTrue(targetGeneratedFeaturesFile.exists());
+
+       // verify that mpHealth-3.1 is now in the generated features file
+       assertTrue(getLogTail(), verifyLogMessageExists("mpHealth-3.1", 1000, targetGeneratedFeaturesFile));
+       assertTrue(getLogTail(), verifyLogMessageExists("mpHealth-3.1", 1000)); // should appear in the message "CWWKF0012I: The server installed the following features:"
        
        // verify that mpHealth-2.2 is no longer in the generated features file
-       // assertFalse(getLogTail(), verifyLogMessageExists("mpHealth-2.2", 10000, generatedFeaturesFile));
-       assertFalse(getLogTail(), verifyLogMessageExists("mpHealth-2.2", 10000, targetGeneratedFeaturesFile));
+       assertFalse(getLogTail(), verifyLogMessageExists("mpHealth-2.2", 1000, targetGeneratedFeaturesFile));
     }
 
 }


### PR DESCRIPTION
Fixes: #2037 

The operation of generate features has changed. All the work is done in temp directories before the server is updated. Wait for the server to report that the features have changed before we start checking the generate-features.xml file in the server dir. 

Also remove the old code that was commented out.