### PR TITLE
Resolves transitive dependencies of annotationProcessorPaths entries during hot reload recompilation

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/pom.xml
@@ -73,6 +73,11 @@
               <artifactId>lombok</artifactId>
               <version>1.18.42</version>
             </path>
+            <path>
+              <groupId>org.mapstruct</groupId>
+              <artifactId>mapstruct-processor</artifactId>
+              <version>1.5.5.Final</version>
+            </path>
           </annotationProcessorPaths>
           <annotationProcessors>
             <annotationProcessor>lombok.launch.AnnotationProcessorHider$AnnotationProcessor</annotationProcessor>

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevAnnotationProcessorTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevAnnotationProcessorTest.java
@@ -55,8 +55,8 @@ public class DevAnnotationProcessorTest extends BaseDevTest {
       assertFalse("Should not have compilation errors",
                   verifyLogMessageExists("variable name not initialized", 5000));
 
-      assertTrue("Transitive dependency 'mapstruct' should be resolved and included in the processor path",
-                 verifyLogMessageExists("mapstruct-", 5000));
+      assertTrue("MapStruct processor should be resolved and included in the processor path during dev mode recompilation",
+                 verifyLogMessageExists("Adding annotation processor artifact to processor path: org.mapstruct:mapstruct-processor:", 5000));
       
       tagLog("##annotationProcessorTest end");
    }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevAnnotationProcessorTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevAnnotationProcessorTest.java
@@ -54,6 +54,9 @@ public class DevAnnotationProcessorTest extends BaseDevTest {
                  verifyLogMessageExists(COMPILATION_SUCCESSFUL, 60000));
       assertFalse("Should not have compilation errors",
                   verifyLogMessageExists("variable name not initialized", 5000));
+
+      assertTrue("Transitive dependency 'mapstruct' should be resolved and included in the processor path",
+                 verifyLogMessageExists("mapstruct-", 5000));
       
       tagLog("##annotationProcessorTest end");
    }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -65,9 +65,14 @@ import org.apache.maven.project.ProjectBuildingResult;
 import org.apache.maven.rtinfo.RuntimeInformation;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.resolution.ArtifactRequest;
-import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.aether.util.artifact.JavaScopes;
+import org.eclipse.aether.util.filter.DependencyFilterUtils;
 import org.twdata.maven.mojoexecutor.MojoExecutor.Element;
 
 import io.openliberty.tools.ant.ServerTask;
@@ -1858,26 +1863,32 @@ public class DevMojo extends LooseAppSupport {
                             
                             if (groupId != null && artifactId != null && version != null) {
                                 try {
-                                    // Use Maven's artifact resolution to resolve annotation processor artifacts
+                                    // Create artifact for the annotation processor
                                     org.eclipse.aether.artifact.Artifact aetherArtifact =
                                         new DefaultArtifact(groupId, artifactId, "jar", version);
                                     
-                                    ArtifactRequest req =
-                                        new ArtifactRequest()
-                                            .setRepositories(this.repositories)
-                                            .setArtifact(aetherArtifact);
+                                    org.eclipse.aether.graph.Dependency dependency = new org.eclipse.aether.graph.Dependency(aetherArtifact, JavaScopes.COMPILE); // Compile scope for processors
+                                    CollectRequest collectRequest = new CollectRequest();
+                                    collectRequest.setRoot(dependency);
+                                    collectRequest.setRepositories(this.repositories);
+                                    DependencyFilter filter = DependencyFilterUtils.classpathFilter(JavaScopes.COMPILE, JavaScopes.RUNTIME); // Filter for compile/runtime scope
                                     
-                                    ArtifactResult result =
-                                        this.repositorySystem.resolveArtifact(this.repoSession, req);
+                                    DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, filter);
+                                    DependencyResult result = this.repositorySystem.resolveDependencies(this.repoSession, dependencyRequest); // Includes transitive dependencies
                                     
-                                    if (result.isResolved() && result.getArtifact().getFile() != null) {
-                                        File file = result.getArtifact().getFile();
-                                        resolvedPaths.add(file.getAbsolutePath());
-                                        getLog().debug("Resolved annotation processor " + groupId + ":" + artifactId +
-                                                     ":" + version + " to " + file.getAbsolutePath());
+                                    // Add all resolved artifacts (root + transitives) using the flat ArtifactResults list
+                                    for (ArtifactResult artifactResult : result.getArtifactResults()) {
+                                        if (artifactResult.isResolved() && artifactResult.getArtifact().getFile() != null) {
+                                            String resolvedPath = artifactResult.getArtifact().getFile().getAbsolutePath();
+                                            if (!resolvedPaths.contains(resolvedPath)) {
+                                                resolvedPaths.add(resolvedPath);
+                                                getLog().debug("Resolved annotation processor artifact: " + resolvedPath);
+                                            }
+                                        }
                                     }
-                                } catch (ArtifactResolutionException e) {
-                                    getLog().warn("Failed to resolve annotation processor artifact " +
+                                    
+                                } catch (DependencyResolutionException e) {
+                                    getLog().warn("Failed to resolve annotation processor artifact with dependencies " +
                                                 groupId + ":" + artifactId + ":" + version + ": " + e.getMessage());
                                 }
                             }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1850,7 +1851,7 @@ public class DevMojo extends LooseAppSupport {
             if (annotationProcessorPaths != null) {
                 Xpp3Dom[] pathElements = annotationProcessorPaths.getChildren("path");
                 if (pathElements != null && pathElements.length > 0) {
-                    List<String> resolvedPaths = new ArrayList<>();
+                    LinkedHashSet<String> resolvedPaths = new LinkedHashSet();
                     for (Xpp3Dom path : pathElements) {
                         Xpp3Dom groupIdElement = path.getChild("groupId");
                         Xpp3Dom artifactIdElement = path.getChild("artifactId");
@@ -1879,10 +1880,12 @@ public class DevMojo extends LooseAppSupport {
                                     // Add all resolved artifacts (root + transitives) using the flat ArtifactResults list
                                     for (ArtifactResult artifactResult : result.getArtifactResults()) {
                                         if (artifactResult.isResolved() && artifactResult.getArtifact().getFile() != null) {
-                                            String resolvedPath = artifactResult.getArtifact().getFile().getAbsolutePath();
-                                            if (!resolvedPaths.contains(resolvedPath)) {
-                                                resolvedPaths.add(resolvedPath);
-                                                getLog().debug("Resolved annotation processor artifact: " + resolvedPath);
+                                            org.eclipse.aether.artifact.Artifact resolved = artifactResult.getArtifact();
+                                            String resolvedPath = resolved.getFile().getAbsolutePath();
+                                            if (resolvedPaths.add(resolvedPath)) {
+                                                getLog().info("Adding annotation processor artifact to processor path: "
+                                                    + resolved.getGroupId() + ":" + resolved.getArtifactId() + ":" + resolved.getVersion()
+                                                    + " (" + resolvedPath + ")");
                                             }
                                         }
                                     }


### PR DESCRIPTION
Fixes #2021

Resolved the issue where annotation processors with transitive dependencies (such as the EclipseLink JPA metamodel generator) failed during liberty:dev hot reload recompilation because only the declared processor JAR was placed on the processorpath. It now replaces the singleartifact resolution with a full transitive dependency resolution, so all transitive dependencies of each <annotationProcessorPaths> entry are automatically resolved and included on the processor path.

Before:


https://github.com/user-attachments/assets/8efe8ae6-882b-458e-9ac5-51def45da93d

After:


https://github.com/user-attachments/assets/2a6bd8c9-9b52-4329-91b9-014bcb3e2fc7

