### PR TITLE
Added support for maven-compiler-plugin compilerArgs in Liberty dev mode hot reload

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -98,7 +98,8 @@ jobs:
       - name: Checkout ci.common
         uses: actions/checkout@v3
         with:
-          repository: OpenLiberty/ci.common
+          repository: sajeerzeji/ci.common
+          reference: feature/MVNGH2044-compiler-args-support
           path: ci.common
       - name: Checkout ci.ant
         uses: actions/checkout@v3
@@ -206,7 +207,7 @@ jobs:
       - name: Clone ci.ant and ci.common repos to github.workspace
         run: |
           echo ${{github.workspace}}
-          git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common
+          git clone https://github.com/sajeerzeji/ci.common.git --branch feature/MVNGH2044-compiler-args-support --single-branch ${{github.workspace}}/ci.common
           git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -98,8 +98,7 @@ jobs:
       - name: Checkout ci.common
         uses: actions/checkout@v3
         with:
-          repository: sajeerzeji/ci.common
-          ref: feature/MVNGH2044-compiler-args-support
+          repository: OpenLiberty/ci.common
           path: ci.common
       - name: Checkout ci.ant
         uses: actions/checkout@v3
@@ -207,7 +206,7 @@ jobs:
       - name: Clone ci.ant and ci.common repos to github.workspace
         run: |
           echo ${{github.workspace}}
-          git clone https://github.com/sajeerzeji/ci.common.git --branch feature/MVNGH2044-compiler-args-support --single-branch ${{github.workspace}}/ci.common
+          git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common
           git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: sajeerzeji/ci.common
-          reference: feature/MVNGH2044-compiler-args-support
+          ref: feature/MVNGH2044-compiler-args-support
           path: ci.common
       - name: Checkout ci.ant
         uses: actions/checkout@v3

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-compiler-args/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-compiler-args/pom.xml
@@ -1,0 +1,100 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>dev-it-tests</groupId>
+  <artifactId>dev-compiler-args-proj</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>war</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <app.name>CompilerArgsProject</app.name>
+    <testServerHttpPort>9080</testServerHttpPort>
+    <testServerHttpsPort>9443</testServerHttpsPort>
+    <packaging.type>usr</packaging.type>
+  </properties>
+
+  <dependencyManagement>
+      <dependencies>
+          <dependency>
+              <groupId>io.openliberty.features</groupId>
+              <artifactId>features-bom</artifactId>
+              <version>RUNTIME_VERSION</version>
+              <type>pom</type>
+              <scope>import</scope>
+          </dependency>
+      </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+        <groupId>io.openliberty.features</groupId>
+        <artifactId>jaxrs-2.1</artifactId>
+        <type>esa</type>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>io.openliberty.features</groupId>
+        <artifactId>cdi-2.0</artifactId>
+        <type>esa</type>
+        <scope>provided</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+            <arg>-Xlint:-processing</arg>
+            <arg>-Atest.custom.arg=compilerArgsTest</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.4.0</version>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <packagingExcludes>pom.xml</packagingExcludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.openliberty.tools</groupId>
+        <artifactId>liberty-maven-plugin</artifactId>
+        <version>SUB_VERSION</version>
+        <configuration>
+          <assemblyArtifact>
+            <groupId>io.openliberty</groupId>
+            <artifactId>openliberty-kernel</artifactId>
+            <version>RUNTIME_VERSION</version>
+            <type>zip</type>
+          </assemblyArtifact>
+          <packageName>${app.name}</packageName>
+          <include>${packaging.type}</include>
+          <bootstrapProperties>
+            <default.http.port>${testServerHttpPort}</default.http.port>
+            <default.https.port>${testServerHttpsPort}</default.https.port>
+          </bootstrapProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-compiler-args/src/main/java/com/demo/rest/HelloResource.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-compiler-args/src/main/java/com/demo/rest/HelloResource.java
@@ -1,0 +1,20 @@
+package com.demo.rest;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Simple REST resource to test compiler arguments.
+ * The -parameters flag should preserve parameter names for reflection.
+ */
+@Path("/hello")
+public class HelloResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String sayHello() {
+        return "Hello, World!";
+    }
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-compiler-args/src/main/java/com/demo/rest/RestApplication.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-compiler-args/src/main/java/com/demo/rest/RestApplication.java
@@ -1,0 +1,8 @@
+package com.demo.rest;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/api")
+public class RestApplication extends Application {
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-compiler-args/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-compiler-args/src/main/liberty/config/server.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="Sample Liberty server">
+
+    <featureManager>
+        <feature>jaxrs-2.1</feature>
+        <feature>cdi-2.0</feature>
+    </featureManager>
+
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="9080"
+                  httpsPort="9443" />
+
+    <webApplication location="dev-compiler-args-proj.war" contextRoot="/" />
+
+</server>

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevCompilerArgsTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevCompilerArgsTest.java
@@ -45,6 +45,8 @@ public class DevCompilerArgsTest extends BaseDevTest {
       
       assertTrue("Web app should be available", verifyLogMessageExists(WEB_APP_AVAILABLE, 60000));
       
+      Thread.sleep(2000);
+      
       File resourceFile = new File(tempProj, "src/main/java/com/demo/rest/HelloResource.java");
       assertTrue("HelloResource.java should exist", resourceFile.exists());
       replaceString("@Path\\(\"/hello\"\\)", "// Modified\n@Path(\"/hello\")", resourceFile);

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevCompilerArgsTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevCompilerArgsTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2026.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test that compiler arguments from maven-compiler-plugin configuration
+ * are properly passed through during Liberty dev mode hot reload.
+ */
+public class DevCompilerArgsTest extends BaseDevTest {
+
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+      setUpBeforeClass(null, "../resources/basic-dev-project-compiler-args");
+   }
+
+   @AfterClass
+   public static void cleanUpAfterClass() throws Exception {
+      BaseDevTest.cleanUpAfterClass();
+   }
+
+   @Test
+   public void compilerArgsTest() throws Exception {
+      tagLog("##compilerArgsTest start");
+      
+      assertTrue("Web app should be available", verifyLogMessageExists(WEB_APP_AVAILABLE, 60000));
+      
+      File resourceFile = new File(tempProj, "src/main/java/com/demo/rest/HelloResource.java");
+      assertTrue("HelloResource.java should exist", resourceFile.exists());
+      replaceString("@Path\\(\"/hello\"\\)", "// Modified\n@Path(\"/hello\")", resourceFile);
+
+      Thread.sleep(8000);
+      
+      assertTrue("Hot reload should show 'Recompiling with compiler options' message",
+                 verifyLogMessageExists("Recompiling with compiler options", 60000));
+      assertTrue("Hot reload should include -parameters in compiler options",
+                 verifyLogMessageExists("-parameters", 5000));
+      assertTrue("Hot reload should include -Xlint:-processing in compiler options",
+                 verifyLogMessageExists("-Xlint:-processing", 5000));
+      assertTrue("Hot reload should include custom arg -Atest.custom.arg=compilerArgsTest in compiler options",
+                 verifyLogMessageExists("-Atest.custom.arg=compilerArgsTest", 5000));
+      
+      assertTrue("Recompilation should succeed",
+                 verifyLogMessageExists(COMPILATION_SUCCESSFUL, 60000));
+      
+      tagLog("##compilerArgsTest end");
+   }
+}

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -433,7 +433,7 @@ public class DevMojo extends LooseAppSupport {
 
         @Override
         protected boolean recompileJava(Collection<File> javaFilesChanged, Set<String> artifactPaths, ThreadPoolExecutor executor, boolean tests, File outputDirectory, File testOutputDirectory, String projectName, File projectBuildFile, JavaCompilerOptions projectCompilerOptions, boolean forceSkipUTs, boolean skipRunningTests) throws PluginExecutionException {
-            if (projectCompilerOptions != null && projectCompilerOptions.getOptions() != null && !projectCompilerOptions.getOptions().isEmpty()) {
+            if (projectCompilerOptions != null && projectCompilerOptions.getOptions() != null) {
                 getLog().info("Recompiling with compiler options: " + projectCompilerOptions.getOptions());
             }
             return super.recompileJava(javaFilesChanged, artifactPaths, executor, tests, outputDirectory, testOutputDirectory, projectName, projectBuildFile, projectCompilerOptions, forceSkipUTs, skipRunningTests);

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1908,6 +1909,25 @@ public class DevMojo extends LooseAppSupport {
                         String processors = String.join(",", processorList);
                         compilerOptions.setAnnotationProcessors(processors);
                         getLog().debug("Setting annotation processors: " + processors);
+                    }
+                }
+            }
+            
+            // Extract compiler arguments from <compilerArgs> configuration
+            Xpp3Dom compilerArgsElement = configuration.getChild("compilerArgs");
+            if (compilerArgsElement != null) {
+                Xpp3Dom[] argElements = compilerArgsElement.getChildren("arg");
+                if (argElements != null && argElements.length > 0) {
+                    LinkedHashSet<String> args = new LinkedHashSet<>();
+                    for (Xpp3Dom arg : argElements) {
+                        String value = arg.getValue();
+                        if (value != null && !value.trim().isEmpty()) {
+                            args.add(value.trim());
+                        }
+                    }
+                    if (!args.isEmpty()) {
+                        compilerOptions.setCompilerArgs(new ArrayList<>(args));
+                        getLog().debug("Setting compiler args: " + args);
                     }
                 }
             }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -433,7 +433,7 @@ public class DevMojo extends LooseAppSupport {
 
         @Override
         protected boolean recompileJava(Collection<File> javaFilesChanged, Set<String> artifactPaths, ThreadPoolExecutor executor, boolean tests, File outputDirectory, File testOutputDirectory, String projectName, File projectBuildFile, JavaCompilerOptions projectCompilerOptions, boolean forceSkipUTs, boolean skipRunningTests) throws PluginExecutionException {
-            if (projectCompilerOptions != null && projectCompilerOptions.getOptions() != null) {
+            if (projectCompilerOptions != null && projectCompilerOptions.getOptions() != null && !projectCompilerOptions.getOptions().isEmpty()) {
                 getLog().info("Recompiling with compiler options: " + projectCompilerOptions.getOptions());
             }
             return super.recompileJava(javaFilesChanged, artifactPaths, executor, tests, outputDirectory, testOutputDirectory, projectName, projectBuildFile, projectCompilerOptions, forceSkipUTs, skipRunningTests);


### PR DESCRIPTION
Fixes #2044 

Fixes an issue where compilerArgs configured in maven-compiler-plugin were ignored during Liberty dev mode hot reload, causing compilation discrepancies between regular Maven builds and dev mode. This fix extracts compiler arguments from the plugin configuration using with deduplication while preserving order, then passes them to JavaCompilerOptions for use during hot reload compilation.