### PR TITLE
Update the feature generator acceptance test case to account for the generateToSrc option

### DIFF
--- a/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project10/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project10/pom.xml
@@ -11,8 +11,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <app.name>LibertyProject</app.name>
     <!-- tag::ports[] -->
     <testServerHttpPort>9080</testServerHttpPort>

--- a/liberty-maven-plugin/src/it/feature-generator-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseGeneratorTest.java
+++ b/liberty-maven-plugin/src/it/feature-generator-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseGeneratorTest.java
@@ -58,7 +58,7 @@ import org.w3c.dom.NodeList;
 
 public class BaseGeneratorTest {
 
-    static File tempProj;
+    static File workingProj;
     static File basicProj;
     static File logFile;
     static BufferedWriter writer;
@@ -70,7 +70,7 @@ public class BaseGeneratorTest {
     static File serverXmlFile;
 
     static final String GENERATED_FEATURES_FILE_NAME = "generated-features.xml";
-    static final String GENERATED_FEATURES_FILE_PATH = "/src/main/liberty/config/configDropins/overrides/" + GENERATED_FEATURES_FILE_NAME;
+    static final String GENERATED_FEATURES_FILE_PATH = "/target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/" + GENERATED_FEATURES_FILE_NAME;
     static final String TARGET_EE_NULL = "targetJavaEE: null";
     static final String TARGET_MP_NULL = "targetMicroP: null";
     static final String EE8_UMBRELLA = "<dependency>\n" +
@@ -150,28 +150,28 @@ public class BaseGeneratorTest {
 
     protected static void setUpBeforeTest(String projectRoot) throws IOException, InterruptedException {
         basicProj = new File(projectRoot);
-        tempProj = Files.createTempDirectory("temp").toFile();
-        assertTrue(tempProj.exists());
+        workingProj = Files.createTempDirectory("temp").toFile();
+        assertTrue(workingProj.exists());
         assertTrue(basicProj.exists());
 
-        FileUtils.copyDirectory(basicProj, tempProj);
-        assertTrue(tempProj.listFiles().length > 0);
+        FileUtils.copyDirectory(basicProj, workingProj);
+        assertTrue(workingProj.listFiles().length > 0);
         logFile = new File(basicProj, "logFile.txt");
         logFile.delete();
         assertTrue(logFile.createNewFile());
 
-        newFeatureFile = new File(tempProj, GENERATED_FEATURES_FILE_PATH);
-        pom = new File(tempProj, "pom.xml");
+        newFeatureFile = new File(workingProj, GENERATED_FEATURES_FILE_PATH);
+        pom = new File(workingProj, "pom.xml");
         assertTrue(pom.exists());
-        replaceVersion(tempProj);
+        replaceVersion(workingProj);
 
-        serverXmlFile = new File(tempProj, "src/main/liberty/config/server.xml");
-        targetDir = new File(tempProj, "target");
+        serverXmlFile = new File(workingProj, "src/main/liberty/config/server.xml");
+        targetDir = new File(workingProj, "target");
     }
 
     protected static void cleanUpAfterTest() throws Exception {
-        if (tempProj != null && tempProj.exists()) {
-            FileUtils.deleteDirectory(tempProj);
+        if (workingProj != null && workingProj.exists()) {
+            FileUtils.deleteDirectory(workingProj);
         }
         if (logFile != null && logFile.exists()) {
             assertTrue(logFile.delete());
@@ -185,7 +185,7 @@ public class BaseGeneratorTest {
      * @param command - command to run
      */
     protected static void runProcess(String processCommand) throws IOException, InterruptedException {
-        StringBuilder command = new StringBuilder("mvn " + processCommand);
+        StringBuilder command = new StringBuilder("mvn ").append(processCommand);
         ProcessBuilder builder = buildProcess(command.toString());
         builder.redirectOutput(logFile);
         builder.redirectError(logFile);
@@ -206,7 +206,7 @@ public class BaseGeneratorTest {
 
     protected static ProcessBuilder buildProcess(String processCommand) {
         ProcessBuilder builder = new ProcessBuilder();
-        builder.directory(tempProj);
+        builder.directory(workingProj);
 
         String os = System.getProperty("os.name");
         if (os != null && os.toLowerCase().startsWith("windows")) {
@@ -319,7 +319,7 @@ public class BaseGeneratorTest {
         runCompileAndGenerateFeatures("");
     }
     protected void runCompileAndGenerateFeatures(String args) throws IOException, InterruptedException {
-        runProcess("compile liberty:generate-features " + args);
+        runProcess("compile liberty:create liberty:generate-features " + args);
     }
 
     protected void runGenerateFeaturesGoal() throws IOException, InterruptedException {

--- a/liberty-maven-plugin/src/it/feature-generator-it/src/test/java/net/wasdev/wlp/test/dev/it/GeneratorTest.java
+++ b/liberty-maven-plugin/src/it/feature-generator-it/src/test/java/net/wasdev/wlp/test/dev/it/GeneratorTest.java
@@ -338,7 +338,7 @@ public class GeneratorTest extends BaseGeneratorTest {
             String newUmbrella = MP4_UMBRELLA.replace("<version>4.1", "<version>" + mpVersion);
             replaceString(oldUmbrella, newUmbrella, pom);
             // @Liveness not supported for these low version numbers, change to @Health
-            File codeFile = new File(tempProj, EE8_CODE_FILENAME);
+            File codeFile = new File(workingProj, EE8_CODE_FILENAME);
             replaceString(EE8_CODE_FIX1b, EE8_CODE_FIX1a, codeFile);
             replaceString(EE8_CODE_FIX2b, EE8_CODE_FIX2a, codeFile);
             // Compile, generate and check results


### PR DESCRIPTION
Account for the fact the generateToSrc option is off by default. Since we are generating to the server dir., create the server and verify the file is there.

Also rename the working project directory from `tempProj` to something easier to understand.

Need to update the test case that tries to use Java 1.7 because it is no longer supported by one tool.