### PR TITLE
In DevNoDuplicateCompilationTest add extra The application x updated …

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevNoDuplicateCompilationTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevNoDuplicateCompilationTest.java
@@ -70,10 +70,15 @@ public class DevNoDuplicateCompilationTest extends BaseDevTest {
         assertTrue("Class file was not recompiled", waitForCompilation(targetHelloWorld, lastModified, 10000));
         assertTrue("Source compilation message not found", 
             verifyLogMessageExists(COMPILATION_SUCCESSFUL, 10000, ++initialCompilationCount));
+        // [INFO] Source compilation was successful. ...
+        // [INFO] [AUDIT   ] CWWKZ0003I: The application dev-sample-proj-1.0-SNAPSHOT updated in 0.069 seconds.
         assertTrue("Liberty hot reload message (CWWKZ0003I) not found",
             verifyLogMessageExists(SERVER_CONFIG_SUCCESS, 10000, ++initialHotReloadCount));
 
         Thread.sleep(3000);
+        // [INFO] Running liberty:generate-features ...
+        // [INFO] [AUDIT   ] CWWKZ0003I: The application dev-sample-proj-1.0-SNAPSHOT updated in 0.053 seconds.
+        ++initialHotReloadCount;
 
         // Count final compilation messages
         int finalCompilationCount = countOccurrences(COMPILATION_SUCCESSFUL, logFile);


### PR DESCRIPTION
Update failing test case:

In `DevNoDuplicateCompilationTest.testNoDuplicateCompilation()` add extra `The application x updated` to account for the changes that the generate-features config update causes.

When the test case runs, the change to the Java causes a class change and the app to be redeployed. Then generate-features runs, updates the server config and the app is redeployed again. 