### PR TITLE
Increase timeout after source change in MultipleConcurrentLibertyModulesPlTest

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleConcurrentLibertyModulesPlTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleConcurrentLibertyModulesPlTest.java
@@ -104,7 +104,7 @@ public class MultipleConcurrentLibertyModulesPlTest extends BaseMultiModuleTest 
       // test modify a Java file in an upstream module
       modifyJarClass();
 
-      Thread.sleep(5000);
+      Thread.sleep(30000); // wait for feature gen and server
 
       assertEndpointContent("http://localhost:9080/converter/heights.jsp?heightCm=3048", "200");
       assertEndpointContent("http://localhost:9081/converter/heights.jsp?heightCm=3048", "200");

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleConcurrentLibertyModulesPlTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleConcurrentLibertyModulesPlTest.java
@@ -94,12 +94,12 @@ public class MultipleConcurrentLibertyModulesPlTest extends BaseMultiModuleTest 
       Thread.sleep(5000);
 
       // check endpoints on both projects
-      assertEndpointContent("http://localhost:9080/converter", "Height Converter");
-      assertEndpointContent("http://localhost:9081/converter", "Height Converter");
+      assertEndpointContent("http://localhost:9080/converter", "Height Converter", logFile);
+      assertEndpointContent("http://localhost:9081/converter", "Height Converter", logFile2);
 
       // invoke upstream java code
-      assertEndpointContent("http://localhost:9080/converter/heights.jsp?heightCm=3048", "100");
-      assertEndpointContent("http://localhost:9081/converter/heights.jsp?heightCm=3048", "100");
+      assertEndpointContent("http://localhost:9080/converter/heights.jsp?heightCm=3048", "100", logFile);
+      assertEndpointContent("http://localhost:9081/converter/heights.jsp?heightCm=3048", "100", logFile2);
 
       // Test the modification of a Java file in an upstream module
       // the modify method only tracks one log file, we need to track the other here
@@ -111,8 +111,8 @@ public class MultipleConcurrentLibertyModulesPlTest extends BaseMultiModuleTest 
 
       Thread.sleep(5000);
 
-      assertEndpointContent("http://localhost:9080/converter/heights.jsp?heightCm=3048", "200");
-      assertEndpointContent("http://localhost:9081/converter/heights.jsp?heightCm=3048", "200");
+      assertEndpointContent("http://localhost:9080/converter/heights.jsp?heightCm=3048", "200", logFile);
+      assertEndpointContent("http://localhost:9081/converter/heights.jsp?heightCm=3048", "200", logFile2);
    }
 
    @AfterClass

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleConcurrentLibertyModulesPlTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultipleConcurrentLibertyModulesPlTest.java
@@ -101,10 +101,15 @@ public class MultipleConcurrentLibertyModulesPlTest extends BaseMultiModuleTest 
       assertEndpointContent("http://localhost:9080/converter/heights.jsp?heightCm=3048", "100");
       assertEndpointContent("http://localhost:9081/converter/heights.jsp?heightCm=3048", "100");
 
-      // test modify a Java file in an upstream module
+      // Test the modification of a Java file in an upstream module
+      // the modify method only tracks one log file, we need to track the other here
+      int appUpdatedCount2 = countOccurrences("CWWKZ0003I:", logFile2);
       modifyJarClass();
+      // the previous method waits for one app, we must wait for app ear2 to update
+      assertTrue(getLogTail(logFile2), verifyLogMessageExists("CWWKZ0003I:", 10000, logFile2, ++appUpdatedCount2));
 
-      Thread.sleep(30000); // wait for feature gen and server
+
+      Thread.sleep(5000);
 
       assertEndpointContent("http://localhost:9080/converter/heights.jsp?heightCm=3048", "200");
       assertEndpointContent("http://localhost:9081/converter/heights.jsp?heightCm=3048", "200");


### PR DESCRIPTION
Fixes #2053

Normally I would increase to 10s but with feature gen coming we'll make it 30s.