### PR TITLE
Fix intermittent failure in DevToolchainTest

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevToolchainTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevToolchainTest.java
@@ -25,6 +25,11 @@ public class DevToolchainTest extends BaseDevTest {
             assertTrue(verifyLogMessageExists("Maven compiler plugin is not configured with a jdkToolchain. Using Liberty Maven Plugin jdkToolchain configuration for Java compiler options.", 120000));
             assertTrue(verifyLogMessageExists("Setting compiler source to toolchain JDK version 11", 120000));
 
+            // Wait for the application to be available and for dev mode to finish its initial
+            // compilation/watcher setup before modifying source files, avoiding intermittent races.
+            assertTrue("Web app should be available", verifyLogMessageExists(WEB_APP_AVAILABLE, 60000));
+            Thread.sleep(2000);
+
             // Trigger a recompile by modifying a Java source file
             File javaFile = new File(tempProj, "src/main/java/com/demo/HelloWorld.java");
             String originalContent = "public String helloWorld() {\n\t\treturn \"helloWorld\";\n\t}";
@@ -32,6 +37,9 @@ public class DevToolchainTest extends BaseDevTest {
             String fileContent = FileUtils.readFileToString(javaFile, "UTF-8");
             String newContent = fileContent.replace(originalContent, modifiedContent);
             FileUtils.writeStringToFile(javaFile, newContent, "UTF-8");
+
+            // Allow the recompile to start before checking the logs.
+            Thread.sleep(8000);
 
             // Verify that recompilation used compiler options
             assertTrue(verifyLogMessageExists("Recompiling with compiler options:", 120000));

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevToolchainTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevToolchainTest.java
@@ -38,11 +38,8 @@ public class DevToolchainTest extends BaseDevTest {
             String newContent = fileContent.replace(originalContent, modifiedContent);
             FileUtils.writeStringToFile(javaFile, newContent, "UTF-8");
 
-            // Allow the recompile to start before checking the logs.
-            Thread.sleep(8000);
-
             // Verify that recompilation used compiler options
-            assertTrue(verifyLogMessageExists("Recompiling with compiler options:", 120000));
+            assertTrue(verifyLogMessageExists("Recompiling with compiler options:", 128000));
             assertTrue(verifyLogMessageExists("-source, 11", 120000));
             assertTrue(verifyLogMessageExists("-target, 11", 120000));
         } finally {


### PR DESCRIPTION
Fixes #2057

Fixes intermittent failure in `libertyToolchainWithoutCompilerToolchainLogsInfoAndUsesToolchainVersion` (`DevToolchainTest`).

### Root cause
In `DevMojo.doDevMode()`, the `"Liberty is running in dev mode."` message is printed (via `runHotkeyReaderThread`) *before* `watchFiles()` registers the source directories with the `WatchService`. If a test modifies a source file too soon after that message (or after earlier startup log messages), the `WatchService` may not yet be watching the directory, so the file-change event is missed entirely, no error, no recompile triggered.

### Fix
Added a synchronization wait in `DevToolchainTest` before and after modifying `HelloWorld.java`, mirroring the existing pattern in `DevCompilerArgsTest`:
- Wait for `WEB_APP_AVAILABLE` and a short delay before editing the source file.
- A short delay after editing the file before asserting the recompile log messages.