### PR TITLE
Add apply-ifix goal for WebSphere Liberty iFix application

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The Liberty Maven Plugin provides the following goals.
 
 | Goal | Description |
 | --------- | ------------ |
+| [apply-ifix](docs/apply-ifix.md#apply-ifix) | Apply WebSphere Liberty iFix JAR files to the Liberty runtime installation. Only supported when `runtimeArtifact` groupId is `com.ibm.websphere.appserver.runtime`. |
 | [clean](docs/clean.md#clean) | Deletes every file in the `${outputDirectory}/logs`, `${outputDirectory}/workarea`, `${userDirectory}/dropins` or `${userDirectory}/apps`. |
 | [compile-jsp](docs/compile-jsp.md#compile-jsps) | Compile JSPs in the src/main/webapp into the target/classes directory |
 | [create](docs/create.md#create) | Create a Liberty server. |
@@ -206,7 +207,7 @@ The `liberty-assembly` default lifecycle includes:
 | process-test-resources | maven-resources-plugin:testResources |
 | test-compile | maven-compiler-plugin:testCompile |
 | test | maven-surefire-plugin:test |
-| prepare-package | liberty:create, liberty:prepare-feature, liberty:install-feature |
+| prepare-package | liberty:create, liberty:prepare-feature, liberty:install-feature, liberty:apply-ifix |
 | package | liberty:deploy, liberty:package|
 | pre-integration-test | liberty:test-start|
 | integration-test | maven-failsafe-plugin:integration-test |

--- a/docs/apply-ifix.md
+++ b/docs/apply-ifix.md
@@ -1,0 +1,114 @@
+#### apply-ifix
+---
+Applies WebSphere Liberty iFix JAR files to the Liberty runtime installation.
+
+This goal reads iFix JAR files from the directory specified by `libertyifixDir` (default:
+`${project.basedir}/src/main/liberty/ifixes`) and applies each one to the Liberty runtime by
+executing `java -jar <ifix>.jar --installLocation <installDirectory>`.
+
+**Important:** This goal only supports WebSphere Liberty (i.e. `runtimeArtifact` with
+`groupId` set to `com.ibm.websphere.appserver.runtime`). It will not run against Open Liberty
+or other runtimes.
+
+iFix processing is **disabled by default**. Set `<applyLibertyiFix>true</applyLibertyiFix>`
+in the plugin `<configuration>` to enable it.
+
+This goal is automatically invoked during the `prepare-package` phase of the
+`liberty-assembly` lifecycle after `install-feature`.
+
+#### Parameters
+
+| Parameter | Description | Required | Default |
+| --------- | ----------- | -------- | ------- |
+| `applyLibertyiFix` | Set to `true` to enable iFix application. When `false`, the goal exits immediately without performing any work. | No | `false` |
+| `libertyifixDir` | Directory containing the iFix JAR files to apply. All `*.jar` files in this directory are treated as iFix archives. | No | `${project.basedir}/src/main/liberty/ifixes` |
+| `stopOniFixApplyError` | When `true`, any error during iFix processing (wrong runtime, missing files, version mismatch, or non-zero exit code) causes the build to fail with an error. When `false`, errors are reported as warnings and the build continues. | No | `true` |
+
+The following [common parameters](common-parameters.md#common-parameters) are also supported:
+`runtimeArtifact`, `runtimeInstallDirectory`, `installDirectory`, `libertyRuntimeGroupId`,
+`libertyRuntimeArtifactId`, `libertyRuntimeVersion`.
+
+#### iFix JAR naming convention
+
+iFix JARs supplied by IBM follow the naming pattern:
+
+```
+{YYMMNN}-wlp-archive-{APAR_ID}.jar
+```
+
+For example: `250012-wlp-archive-IFPH69485.jar` targets WebSphere Liberty 25.0.0.12 and
+resolves APAR PH69485.
+
+The goal validates each iFix against the installed Liberty version by reading the
+`Applies-To` attribute from the JAR's `META-INF/MANIFEST.MF`:
+
+```
+Applies-To: io.openliberty; productVersion=25.0.0.12; productInstallType=Archive
+```
+
+If the `productVersion` does not match the installed Liberty version the behaviour is
+controlled by `stopOniFixApplyError`.
+
+#### Examples
+
+1. Enable iFix application via `<configuration>`:
+
+    Place iFix JAR files in `src/main/liberty/ifixes/` and add the following to the plugin
+    configuration:
+
+    ```xml
+    <plugin>
+        <groupId>io.openliberty.tools</groupId>
+        <artifactId>liberty-maven-plugin</artifactId>
+        <configuration>
+            <runtimeArtifact>
+                <groupId>com.ibm.websphere.appserver.runtime</groupId>
+                <artifactId>wlp-webProfile10</artifactId>
+                <version>25.0.0.12</version>
+                <type>zip</type>
+            </runtimeArtifact>
+            <applyLibertyiFix>true</applyLibertyiFix>
+        </configuration>
+    </plugin>
+    ```
+
+2. Specify a custom iFix directory and continue on errors:
+
+    ```xml
+    <plugin>
+        <groupId>io.openliberty.tools</groupId>
+        <artifactId>liberty-maven-plugin</artifactId>
+        <configuration>
+            <runtimeArtifact>
+                <groupId>com.ibm.websphere.appserver.runtime</groupId>
+                <artifactId>wlp-webProfile10</artifactId>
+                <version>25.0.0.12</version>
+                <type>zip</type>
+            </runtimeArtifact>
+            <applyLibertyiFix>true</applyLibertyiFix>
+            <libertyifixDir>${project.basedir}/ifixes</libertyifixDir>
+            <stopOniFixApplyError>false</stopOniFixApplyError>
+        </configuration>
+    </plugin>
+    ```
+
+3. Run the goal explicitly (outside the `liberty-assembly` lifecycle):
+
+    ```xml
+    <plugin>
+        <groupId>io.openliberty.tools</groupId>
+        <artifactId>liberty-maven-plugin</artifactId>
+        <executions>
+            <execution>
+                <id>apply-ifix</id>
+                <phase>prepare-package</phase>
+                <goals>
+                    <goal>apply-ifix</goal>
+                </goals>
+                <configuration>
+                    <applyLibertyiFix>true</applyLibertyiFix>
+                </configuration>
+            </execution>
+        </executions>
+    </plugin>
+    ```

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/ApplyIfixMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/ApplyIfixMojo.java
@@ -1,0 +1,257 @@
+/**
+ * (C) Copyright IBM Corporation 2025.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.tools.maven.server;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.tools.ant.taskdefs.Java;
+import org.apache.tools.ant.types.Commandline.Argument;
+
+import io.openliberty.tools.common.plugins.util.InstallFeatureUtil;
+import io.openliberty.tools.common.plugins.util.InstallFeatureUtil.ProductProperties;
+import io.openliberty.tools.common.plugins.util.PluginExecutionException;
+
+/**
+ * Apply WebSphere Liberty iFix JAR files to the Liberty runtime installation.
+ */
+@Mojo(name = "apply-ifix", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+public class ApplyIfixMojo extends PluginConfigSupport {
+
+    private static final String WAS_RUNTIME_GROUP_ID = "com.ibm.websphere.appserver.runtime";
+    private static final String APPLIES_TO_ATTRIBUTE = "Applies-To";
+    private static final Pattern PRODUCT_VERSION_PATTERN = Pattern.compile("productVersion=([^;\\s]+)");
+    /** productId stored in lib/versions/*.properties for WebSphere Liberty */
+    private static final String WAS_PRODUCT_ID = "com.ibm.websphere.appserver";
+
+    /**
+     * Whether to apply iFix JAR files to the Liberty runtime.
+     * When set to {@code true}, the Mojo will look for iFix JAR files in
+     * {@code libertyifixDir} and apply each one to the Liberty installation.
+     * Defaults to {@code false} — no iFix processing is performed unless explicitly enabled.
+     */
+    @Parameter(property = "applyLibertyiFix", defaultValue = "false")
+    private boolean applyLibertyiFix;
+
+    /**
+     * Directory containing the iFix JAR files to apply.
+     * Each {@code *.jar} file in this directory is treated as an iFix archive and
+     * executed with {@code java -jar <file> --installLocation <installDirectory>}.
+     * Defaults to {@code ${project.basedir}/src/main/liberty/ifixes}.
+     */
+    @Parameter(property = "libertyifixDir", defaultValue = "${project.basedir}/src/main/liberty/ifixes")
+    private File libertyifixDir;
+
+    /**
+     * Whether to fail the build when an iFix cannot be applied.
+     * When {@code true} (the default), any error during iFix processing causes a
+     * {@link MojoExecutionException} and stops the build.
+     * When {@code false}, errors are reported as warnings and the build continues.
+     */
+    @Parameter(property = "stopOniFixApplyError", defaultValue = "true")
+    private boolean stopOniFixApplyError;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        if (!applyLibertyiFix) {
+            getLog().debug("applyLibertyiFix is false. Skipping apply-ifix goal.");
+            return;
+        }
+
+        init();
+
+        if (skip) {
+            getLog().info("\nSkipping apply-ifix goal.\n");
+            return;
+        }
+
+        doApplyiFix();
+    }
+
+    private void doApplyiFix() throws MojoExecutionException {
+        // Validate that runtimeArtifact is WebSphere Liberty
+        if (assemblyArtifact == null) {
+            handleError("The apply-ifix goal requires a runtimeArtifact to be specified. "
+                    + "Direct installDirectory configuration is not supported. "
+                    + "Please configure <runtimeArtifact> with groupId '"
+                    + WAS_RUNTIME_GROUP_ID + "'.");
+            return;
+        }
+
+        String groupId = assemblyArtifact.getGroupId();
+        if (!WAS_RUNTIME_GROUP_ID.equals(groupId)) {
+            handleError("The apply-ifix goal only supports WebSphere Liberty (groupId '"
+                    + WAS_RUNTIME_GROUP_ID + "'). "
+                    + "Found groupId: '" + groupId + "'. "
+                    + "iFix application is not supported for this runtime.");
+            return;
+        }
+
+        // Collect iFix JAR files
+        if (!libertyifixDir.exists() || !libertyifixDir.isDirectory()) {
+            handleError("The libertyifixDir '" + libertyifixDir.getAbsolutePath()
+                    + "' does not exist or is not a directory. "
+                    + "No iFix files can be applied.");
+            return;
+        }
+
+        File[] ifixJars = libertyifixDir.listFiles(
+                (dir, name) -> name.toLowerCase().endsWith(".jar"));
+
+        if (ifixJars == null || ifixJars.length == 0) {
+            handleError("No iFix JAR files found in '" + libertyifixDir.getAbsolutePath()
+                    + "'. Set applyLibertyiFix=false if no iFix files are to be applied.");
+            return;
+        }
+
+        // Determine the installed Liberty version
+        String installedVersion = getInstalledLibertyVersion();
+        if (installedVersion == null) {
+            handleError("Unable to determine the installed WebSphere Liberty version from '"
+                    + installDirectory.getAbsolutePath() + "'.");
+            return;
+        }
+
+        getLog().info("Applying iFix files to WebSphere Liberty " + installedVersion
+                + " at: " + installDirectory.getAbsolutePath());
+
+        // Apply each iFix JAR
+        for (File ifixJar : ifixJars) {
+            applyIfix(ifixJar, installedVersion);
+        }
+
+        getLog().info("iFix application complete.");
+    }
+
+    /**
+     * Read the installed Liberty product version from the lib/versions/*.properties
+     * file under the install directory.
+     * Returns the version for the WebSphere Liberty product entry (productId = {@code com.ibm.websphere.appserver}).
+     */
+    private String getInstalledLibertyVersion() throws MojoExecutionException {
+        try {
+            List<ProductProperties> propertiesList = InstallFeatureUtil.loadProperties(installDirectory);
+            for (ProductProperties props : propertiesList) {
+                if (WAS_PRODUCT_ID.equals(props.getId())) {
+                    return props.getVersion();
+                }
+            }
+        } catch (PluginExecutionException e) {
+            throw new MojoExecutionException(
+                    "Error reading Liberty product properties from '" + installDirectory.getAbsolutePath() + "': "
+                            + e.getMessage(), e);
+        }
+        return null;
+    }
+
+    /**
+     * Read the Applies-To productVersion from the iFix JAR manifest and apply
+     * the iFix if the version matches the installed Liberty version.
+     */
+    private void applyIfix(File ifixJar, String installedVersion) throws MojoExecutionException {
+        getLog().info("Processing iFix: " + ifixJar.getName());
+
+        // Read Applies-To from MANIFEST.MF
+        String ifixVersion = readAppliestoVersion(ifixJar);
+        if (ifixVersion == null) {
+            handleError("Unable to read 'Applies-To' attribute from iFix JAR manifest: "
+                    + ifixJar.getName() + ". Skipping this iFix.");
+            return;
+        }
+
+        // Version check
+        if (!installedVersion.equals(ifixVersion)) {
+            handleError("iFix '" + ifixJar.getName() + "' targets Liberty version '" + ifixVersion
+                    + "' but the installed version is '" + installedVersion + "'. "
+                    + "This iFix cannot be applied.");
+            return;
+        }
+
+        // Execute: java -jar <ifixJar> --installLocation <installDirectory>
+        try {
+            getLog().info("Applying iFix '" + ifixJar.getName() + "' to Liberty at '"
+                    + installDirectory.getCanonicalPath() + "'...");
+
+            Java applyIfixTask = (Java) ant.createTask("java");
+            applyIfixTask.setJar(ifixJar);
+            Argument args = applyIfixTask.createArg();
+            args.setLine("--installLocation " + installDirectory.getCanonicalPath());
+            applyIfixTask.setTimeout(300000L);
+            applyIfixTask.setFork(true);
+            int rc = applyIfixTask.executeJava();
+
+            if (rc != 0) {
+                handleError("iFix '" + ifixJar.getName() + "' failed with return code " + rc + ".");
+            } else {
+                getLog().info("Successfully applied iFix: " + ifixJar.getName());
+            }
+        } catch (IOException e) {
+            handleError("Error applying iFix '" + ifixJar.getName() + "': " + e.getMessage());
+        }
+    }
+
+    /**
+     * Extract the productVersion from the iFix JAR's {@code Applies-To} manifest attribute.
+     * Example: {@code Applies-To: io.openliberty; productVersion=25.0.0.12; productInstallType=Archive}
+     *
+     * @param ifixJar the iFix JAR file
+     * @return the productVersion string, or {@code null} if not found
+     */
+    private String readAppliestoVersion(File ifixJar) {
+        try (JarFile jarFile = new JarFile(ifixJar)) {
+            Manifest manifest = jarFile.getManifest();
+            if (manifest == null) {
+                return null;
+            }
+            Attributes mainAttrs = manifest.getMainAttributes();
+            String appliesTo = mainAttrs.getValue(APPLIES_TO_ATTRIBUTE);
+            if (appliesTo == null || appliesTo.isEmpty()) {
+                return null;
+            }
+            getLog().debug("Applies-To: " + appliesTo);
+            Matcher m = PRODUCT_VERSION_PATTERN.matcher(appliesTo);
+            if (m.find()) {
+                return m.group(1).trim();
+            }
+        } catch (IOException e) {
+            getLog().debug("Error reading manifest from iFix JAR '" + ifixJar.getName() + "': " + e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Handle an error according to the {@code stopOniFixApplyError} setting.
+     * If {@code true}, throws {@link MojoExecutionException}.
+     * If {@code false}, logs a warning and returns normally.
+     */
+    private void handleError(String message) throws MojoExecutionException {
+        if (stopOniFixApplyError) {
+            throw new MojoExecutionException(message);
+        } else {
+            getLog().warn(message);
+        }
+    }
+}

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/ApplyIfixMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/ApplyIfixMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2025.
+ * (C) Copyright IBM Corporation 2026.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -1198,6 +1198,7 @@ public class DevMojo extends LooseAppSupport {
                     }
                     if (installFeature) {
                         runLibertyMojoInstallFeature(null, null, super.getContainerName());
+                        runLibertyMojoApplyIfix();
                     }
                 }
                 if (!(reinstallLiberty || restartServer || createServer || redeployApp || installFeature || runBoostPackage)) {
@@ -1584,6 +1585,7 @@ public class DevMojo extends LooseAppSupport {
             // Need to also check if this is a new Liberty installation or not. The isNewInstallation flag is set by runLibertyMojoCreate.
             if (!container && (!skipInstallFeature || isNewInstallation)) {
                 runLibertyMojoInstallFeature(null, null, null);
+                runLibertyMojoApplyIfix();
             } else if (skipInstallFeature) {
                 getLog().info("Skipping installation of features due to skipInstallFeature configuration.");
             }

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -242,6 +242,13 @@ public abstract class StartDebugMojoSupport extends ServerFeatureSupport {
         runLibertyMojo("install-feature", config);
     }
 
+
+    protected void runLibertyMojoApplyIfix() throws MojoExecutionException {
+        Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(getLibertyPlugin(), "apply-ifix", getLog());
+        runLibertyMojo("apply-ifix", config);
+    }
+
+
     protected void runLibertyMojoGenerateFeatures(Element classFiles, boolean optimize, boolean generateToSrc, boolean useTmpDirOut, boolean useTmpDirIn) throws MojoExecutionException {
         Xpp3Dom config = ExecuteMojoUtil.getPluginGoalConfig(getLibertyPlugin(), "generate-features", getLog());
         if (classFiles != null) {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2019, 2023.
+ * (C) Copyright IBM Corporation 2019, 2026.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/utils/ExecuteMojoUtil.java
@@ -242,6 +242,13 @@ public class ExecuteMojoUtil {
         INSTALL_FEATURE_PARAMS.addAll(LIBERTY_COMMON_PARAMS);
     }
 
+    private static final ArrayList<String> APPLY_IFIX_PARAMS;
+    static {
+        APPLY_IFIX_PARAMS = new ArrayList<>(Arrays.asList(
+                "applyLibertyiFix", "libertyifixDir", "stopOniFixApplyError"));
+        APPLY_IFIX_PARAMS.addAll(LIBERTY_COMMON_PARAMS);
+    }
+
     private static final ArrayList<String> GENERATE_FEATURES_PARAMS;
     static {
         GENERATE_FEATURES_PARAMS = LIBERTY_COMMON_PARAMS;
@@ -321,6 +328,10 @@ public class ExecuteMojoUtil {
         case "liberty-maven-plugin:install-feature":
             config = convertLibertyAlias(config);
             goalConfig = stripConfigElements(config, INSTALL_FEATURE_PARAMS);
+            break;
+        case "liberty-maven-plugin:apply-ifix":
+            config = convertLibertyAlias(config);
+            goalConfig = stripConfigElements(config, APPLY_IFIX_PARAMS);
             break;
         case "liberty-maven-plugin:generate-features":
             config = convertLibertyAlias(config);

--- a/liberty-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/liberty-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -40,9 +40,9 @@
                             </test>
                             <prepare-package>
                                 io.openliberty.tools:liberty-maven-plugin:install-server,
-                                io.openliberty.tools:liberty-maven-plugin:create,
-				io.openliberty.tools:liberty-maven-plugin:prepare-feature,
-                                io.openliberty.tools:liberty-maven-plugin:install-feature
+                                io.openliberty.tools:liberty-maven-plugin:create,				io.openliberty.tools:liberty-maven-plugin:prepare-feature,
+                                io.openliberty.tools:liberty-maven-plugin:install-feature,
+                                io.openliberty.tools:liberty-maven-plugin:apply-ifix
                             </prepare-package>
                             <package>
                                 io.openliberty.tools:liberty-maven-plugin:deploy,


### PR DESCRIPTION
## Summary

This pull request adds a new Maven goal `apply-ifix` to the Liberty Maven Plugin that
automates the application of IBM WebSphere Liberty iFix JAR files to the Liberty runtime
installation during the build lifecycle.

## Motivation

WebSphere Liberty iFix JARs (e.g. `250012-wlp-archive-IFPH69485.jar`) are security and
bug-fix patches distributed by IBM. Previously, users had to apply them manually by running
`java -jar <ifix>.jar --installLocation <wlp-dir>` outside the Maven build. This change
integrates that step into the standard Liberty Maven Plugin lifecycle so that iFix application
becomes a reproducible, automated part of the build.

## Changes

### New file: `liberty-maven-plugin/.../server/ApplyIfixMojo.java`

Implements the `apply-ifix` goal as a subclass of `PluginConfigSupport`.

Key behaviour:
- **Disabled by default** (`applyLibertyiFix=false`). No work is done unless the user explicitly opts in.
- **WebSphere Liberty only.** The `runtimeArtifact` `groupId` must be `com.ibm.websphere.appserver.runtime`. Open Liberty and pre-installed (`installDirectory`) configurations are not supported; both cases are handled according to `stopOniFixApplyError`.
- **Version validation.** Before applying each JAR, the `productVersion` field from the `Applies-To` attribute in `META-INF/MANIFEST.MF` is compared against the installed Liberty version read from `lib/versions/*.properties` (`com.ibm.websphere.productVersion`). A mismatch is treated as an error.
- **Applies iFix JARs** found in `libertyifixDir` (default: `${project.basedir}/src/main/liberty/ifixes`) by invoking `java -jar <ifix>.jar --installLocation <installDirectory>` via the Ant `Java` task, consistent with the existing `installLicense()` pattern in `BasicSupport`.
- **Error handling** is centralised through `stopOniFixApplyError` (default `true`): `true` → `MojoExecutionException` (build fails); `false` → WARNING (build continues).

New `@Parameter` annotations:

| Parameter | Default | Description |
|-----------|---------|-------------|
| `applyLibertyiFix` | `false` | Enable iFix application |
| `libertyifixDir` | `${project.basedir}/src/main/liberty/ifixes` | Directory containing iFix JARs |
| `stopOniFixApplyError` | `true` | Fail build on any iFix error |

### Modified: `StartDebugMojoSupport.java`

Added `runLibertyMojoApplyIfix()` helper method following the same pattern as the existing `runLibertyMojoInstallFeature()` and `runLibertyMojoDeploy()` helpers.

### Modified: `DevMojo.java`

`runLibertyMojoApplyIfix()` is called immediately after `runLibertyMojoInstallFeature()` in two places:

1. **Server startup path** — when features are installed before the server first starts
2. **pom.xml change-detection path** — when the `installFeature` flag is raised during a live reload cycle

The call is unconditional; `ApplyIfixMojo.execute()` exits immediately when `applyLibertyiFix=false` (the default), so there is no overhead for users who do not enable the feature.

### Modified: `ExecuteMojoUtil.java`

Added `APPLY_IFIX_PARAMS` list and a `liberty-maven-plugin:apply-ifix` case in `validateConfiguration()`. Without this, the mojo-executor path used by `dev` mode passed the raw `<runtimeArtifact>` alias element through to `ApplyIfixMojo`, causing Maven to fail with "Cannot find 'runtimeArtifact' in class ApplyIfixMojo" (the field is named `assemblyArtifact`; `runtimeArtifact` is only a `@Parameter` alias). The new case calls `convertLibertyAlias()` and `stripConfigElements()` consistently with the other Liberty goals.

### Modified: `META-INF/plexus/components.xml`

Added `liberty:apply-ifix` to the `prepare-package` phase of the `liberty-assembly` lifecycle, after `liberty:install-feature`.

### New file: `docs/apply-ifix.md`

User-facing reference documentation in the same format as existing goal docs. Covers all parameters, the iFix JAR naming convention, version validation behaviour, and three usage examples.

### Modified: `README.md`

- Added `apply-ifix` to the goals table (alphabetical order).
- Updated the `liberty-assembly` lifecycle phase table to include `liberty:apply-ifix` in the `prepare-package` row.

## Testing

Verified with a `liberty-assembly` project using `com.ibm.websphere.appserver.runtime:wlp-kernel:25.0.0.12` and two test iFix JARs (`250012-wlp-archive-IFPH69485.jar`, `250012-wlp-archive-IFPH70327.jar`):

- `./mvnw clean install` passes with both iFix JARs applied successfully during `prepare-package`.
- The Liberty server starts cleanly after iFix application.
- Unit tests in `ci.maven` (`./mvnw install`) pass with 0 failures.

## Example Configuration

```xml
<plugin>
    <groupId>io.openliberty.tools</groupId>
    <artifactId>liberty-maven-plugin</artifactId>
    <configuration>
        <runtimeArtifact>
            <groupId>com.ibm.websphere.appserver.runtime</groupId>
            <artifactId>wlp-webProfile10</artifactId>
            <version>25.0.0.12</version>
            <type>zip</type>
        </runtimeArtifact>
        <applyLibertyiFix>true</applyLibertyiFix>
        <!-- libertyifixDir defaults to src/main/liberty/ifixes -->
    </configuration>
</plugin>
```

Place iFix JAR files under `src/main/liberty/ifixes/`. They will be applied automatically during `prepare-package` after features are installed.