### PR TITLE
Fixed the race condition: removed premature runHotkeyReaderThread() call before watchFiles()

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -98,7 +98,8 @@ jobs:
       - name: Checkout ci.common
         uses: actions/checkout@v3
         with:
-          repository: OpenLiberty/ci.common
+          repository: sajeerzeji/ci.common
+          ref: GHLMP2070-Fix_race_condition_in_DevMojo_doDevMode
           path: ci.common
       - name: Checkout ci.ant
         uses: actions/checkout@v3
@@ -206,7 +207,7 @@ jobs:
       - name: Clone ci.ant and ci.common repos to github.workspace
         run: |
           echo ${{github.workspace}}
-          git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common
+          git clone https://github.com/sajeerzeji/ci.common.git --branch GHLMP2070-Fix_race_condition_in_DevMojo_doDevMode --single-branch ${{github.workspace}}/ci.common
           git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -1696,9 +1696,6 @@ public class DevMojo extends LooseAppSupport {
             throw new MojoExecutionException("Error starting the server in dev mode.", e);
         }
 
-        // start watching for keypresses immediately
-        util.runHotkeyReaderThread(executor);
-
         // Note that serverXmlFile can be null. DevUtil will automatically watch
         // all files in the configDirectory,
         // which is where the server.xml is located if a specific serverXmlFile


### PR DESCRIPTION
Fixes #2070 

PR Ci.Common: https://github.com/OpenLiberty/ci.common/pull/526
PR Ci.Gradle: https://github.com/OpenLiberty/ci.gradle/pull/1095

As a part of this PR https://github.com/OpenLiberty/ci.common/pull/526 we mad ci.common print the "Liberty is running in dev mode." startup banner from inside watchFiles() after all directories are registered with the WatchService, the explicit util.runHotkeyReaderThread(executor) call that DevMojo.doDevMode() made between startServer() and watchFiles() is no longer needed and has been removed. That call was the source of the race condition described in the issue, it caused the ready message to fire before the WatchService had registered any source directories, making it an unreliable signal for tests and users. The early hotkey reader thread is still started via startEarlyHotkeyReader() before server startup to allow quitting during startup, and the post-test-run re-print from the finally block inside the watch loop remains unchanged.