### PR TITLE
Fix Liberty Maven Plugin ignoring toolchain selected via auto-discovery

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -333,6 +333,7 @@
                                 <pomExcludes>
                                     <pomExclude>dev-it/pom.xml</pomExclude>
                                     <pomExclude>toolchain-run-it/pom.xml</pomExclude>
+                                    <pomExclude>toolchain-autodiscovery-it/pom.xml</pomExclude>
                                     <pomExclude>dev-container-it/pom.xml</pomExclude>
                                     <pomExclude>generate-features-it/pom.xml</pomExclude>
                                     <pomExclude>feature-generator-it/pom.xml</pomExclude>
@@ -378,6 +379,7 @@
                                 <pomExcludes>
                                     <pomExclude>dev-it/pom.xml</pomExclude>
                                     <pomExclude>toolchain-run-it/pom.xml</pomExclude>
+                                    <pomExclude>toolchain-autodiscovery-it/pom.xml</pomExclude>
                                     <pomExclude>dev-container-it/pom.xml</pomExclude>
                                     <pomExclude>basic-it/pom.xml</pomExclude>
                                     <pomExclude>assembly-it/pom.xml</pomExclude>

--- a/liberty-maven-plugin/src/it/toolchain-autodiscovery-it/pom.xml
+++ b/liberty-maven-plugin/src/it/toolchain-autodiscovery-it/pom.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!--
+    Integration test for GitHub issue: Liberty Maven Plugin ignores toolchain selected via
+    maven-toolchains-plugin auto-discovery (select-jdk-toolchain goal, no toolchains.xml required).
+
+    The maven-toolchains-plugin 3.2+ select-jdk-toolchain goal discovers JDKs from well-known
+    installation paths and registers the selected one in the Maven build context.
+    Before the fix, Liberty's initToolchain() only called getToolchains() which reads toolchains.xml
+    directly, bypassing the build context, causing CWWKM4100W to be emitted and the host JDK to
+    be used instead of the toolchain JDK.
+  -->
+
+  <parent>
+    <groupId>io.openliberty.tools.it</groupId>
+    <artifactId>tests</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>toolchain-autodiscovery-it</artifactId>
+  <packaging>war</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-servlet_3.0_spec</artifactId>
+      <version>1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.0.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>3.4.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>3.1.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.1.2</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <!--
+        Use maven-toolchains-plugin 3.3.0 select-jdk-toolchain goal, which performs
+        automatic JDK discovery from well-known OS locations without requiring a
+        toolchains.xml file.  It registers the selected JDK in the Maven build context
+        so that any plugin calling getToolchainFromBuildContext() can pick it up.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-toolchains-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>select-jdk-toolchain</goal>
+            </goals>
+            <configuration>
+              <version>11</version>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.openliberty.tools</groupId>
+        <artifactId>liberty-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <extensions>true</extensions>
+        <configuration>
+          <jdkToolchain>
+            <version>11</version>
+          </jdkToolchain>
+          <stripVersion>true</stripVersion>
+          <assemblyArtifact>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>assembly-server</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+          </assemblyArtifact>
+          <serverName>test</serverName>
+          <serverXmlFile>src/test/resources/server.xml</serverXmlFile>
+          <deployPackages>project</deployPackages>
+          <looseApplication>false</looseApplication>
+        </configuration>
+        <executions>
+          <execution>
+            <id>install-liberty</id>
+            <phase>package</phase>
+            <goals>
+              <goal>install-server</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>create-liberty-server</id>
+            <phase>package</phase>
+            <goals>
+              <goal>create</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>install-artifact</id>
+            <phase>package</phase>
+            <goals>
+              <goal>deploy</goal>
+            </goals>
+            <configuration>
+              <appsDirectory>apps</appsDirectory>
+              <stripVersion>true</stripVersion>
+            </configuration>
+          </execution>
+          <execution>
+            <id>start-liberty-server</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>start</goal>
+            </goals>
+            <configuration>
+              <background>true</background>
+              <verifyTimeout>60</verifyTimeout>
+            </configuration>
+          </execution>
+          <execution>
+            <id>stop-liberty-server</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>clean-server</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+            <configuration>
+              <cleanDropins>true</cleanDropins>
+              <cleanApps>true</cleanApps>
+              <cleanLogs>false</cleanLogs>
+              <cleanWorkarea>false</cleanWorkarea>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          <forkMode>once</forkMode>
+          <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
+          <argLine>-enableassertions</argLine>
+          <workingDirectory>${project.build.directory}</workingDirectory>
+          <includes>
+            <include>**/*Test.java</include>
+          </includes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>verify</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/liberty-maven-plugin/src/it/toolchain-autodiscovery-it/src/main/webapp/index.jsp
+++ b/liberty-maven-plugin/src/it/toolchain-autodiscovery-it/src/main/webapp/index.jsp
@@ -1,0 +1,7 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+  <head><title>Toolchain autodiscovery IT</title></head>
+  <body>
+    <h2>Liberty Toolchain Autodiscovery IT</h2>
+  </body>
+</html>

--- a/liberty-maven-plugin/src/it/toolchain-autodiscovery-it/src/test/java/net/wasdev/wlp/maven/test/app/ToolchainAutodiscoveryTest.java
+++ b/liberty-maven-plugin/src/it/toolchain-autodiscovery-it/src/test/java/net/wasdev/wlp/maven/test/app/ToolchainAutodiscoveryTest.java
@@ -1,0 +1,95 @@
+package net.wasdev.wlp.maven.test.app;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.Scanner;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Verifies that the Liberty Maven Plugin honours a toolchain selected via
+ * maven-toolchains-plugin auto-discovery (select-jdk-toolchain goal) when no
+ * toolchains.xml is present.
+ *
+ * Before the fix, initToolchain() only called getToolchains() which reads
+ * toolchains.xml directly, bypassing the build context.  When auto-discovery
+ * was used, no toolchains.xml existed, getToolchains() returned an empty list,
+ * and the plugin emitted CWWKM4100W instead of honouring the toolchain.
+ *
+ * After the fix, initToolchain() first calls getToolchainFromBuildContext() so
+ * that the JDK registered by select-jdk-toolchain is picked up.
+ */
+public class ToolchainAutodiscoveryTest {
+
+    // CWWKM4100I: toolchain initialised via maven-toolchains-plugin auto-discovery (build context)
+    static final String TOOLCHAIN_INITIALIZED_CONTEXT =
+            "CWWKM4100I: Using toolchain JDK from build context (auto-discovery)";
+
+    // CWWKM4101I: liberty goal applied the toolchain JDK (success path)
+    static final String TOOLCHAIN_CONFIGURED_FOR_GOAL =
+            "CWWKM4101I: The %s goal is using the configured toolchain JDK located at";
+
+    // CWWKM4100W: toolchain not found — must NOT appear when auto-discovery is used
+    static final String TOOLCHAIN_NOT_FOUND =
+            "CWWKM4100W: Toolchain configured for liberty server but no matching JDK was found via build context or toolchains.xml.";
+
+    @Test
+    public void testToolchainInitializedFromBuildContext() throws Exception {
+        File buildLog = new File("../build.log");
+        Assert.assertTrue("build.log does not exist", buildLog.exists());
+
+        Assert.assertTrue(
+                "Expected CWWKM4100I (toolchain from build context / auto-discovery) in build.log — " +
+                "indicates select-jdk-toolchain auto-discovery result was NOT honoured",
+                logContainsMessage(buildLog, TOOLCHAIN_INITIALIZED_CONTEXT));
+
+        Assert.assertFalse(
+                "Expected CWWKM4100W to be absent — it means the toolchain was not found, " +
+                "which indicates the auto-discovery build context was still being ignored",
+                logContainsMessage(buildLog, TOOLCHAIN_NOT_FOUND));
+    }
+
+    @Test
+    public void testToolchainAppliedToCreateGoal() throws Exception {
+        File buildLog = new File("../build.log");
+        Assert.assertTrue("build.log does not exist", buildLog.exists());
+
+        Assert.assertTrue(
+                "Expected CWWKM4101I for the 'create' goal in build.log",
+                logContainsMessage(buildLog, String.format(TOOLCHAIN_CONFIGURED_FOR_GOAL, "create")));
+    }
+
+    @Test
+    public void testToolchainAppliedToStartGoal() throws Exception {
+        File buildLog = new File("../build.log");
+        Assert.assertTrue("build.log does not exist", buildLog.exists());
+
+        Assert.assertTrue(
+                "Expected CWWKM4101I for the 'start' goal in build.log",
+                logContainsMessage(buildLog, String.format(TOOLCHAIN_CONFIGURED_FOR_GOAL, "start")));
+    }
+
+    @Test
+    public void testServerStarted() throws Exception {
+        File messagesLog = new File("liberty/usr/servers/test/logs/messages.log");
+        Assert.assertTrue(
+                "messages.log does not exist — Liberty server did not start",
+                messagesLog.exists());
+        Assert.assertTrue(
+                "Liberty server ready message not found in messages.log",
+                logContainsMessage(messagesLog, "CWWKF0011I"));
+    }
+
+    private boolean logContainsMessage(File logFile, String message) throws FileNotFoundException {
+        Assert.assertTrue("Log file not found: " + logFile.getAbsolutePath(), logFile.exists());
+        try (Scanner scanner = new Scanner(logFile)) {
+            while (scanner.hasNextLine()) {
+                if (scanner.nextLine().contains(message)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/liberty-maven-plugin/src/it/toolchain-autodiscovery-it/src/test/resources/server.xml
+++ b/liberty-maven-plugin/src/it/toolchain-autodiscovery-it/src/test/resources/server.xml
@@ -1,0 +1,7 @@
+<server description="default server">
+    <featureManager>
+        <feature>jsp-2.3</feature>
+    </featureManager>
+
+    <webApplication id="toolchain-autodiscovery-it" location="toolchain-autodiscovery-it.war" name="toolchain-autodiscovery-it"/>
+</server>

--- a/liberty-maven-plugin/src/it/toolchain-invalid-jdk-it/src/test/java/net/wasdev/wlp/maven/test/app/ToolchainTest.java
+++ b/liberty-maven-plugin/src/it/toolchain-invalid-jdk-it/src/test/java/net/wasdev/wlp/maven/test/app/ToolchainTest.java
@@ -30,7 +30,7 @@ public class ToolchainTest {
     public final String CONFIG_XML = "liberty-plugin-config.xml";
     public final String LOG_LOCATION = "liberty/usr/servers/test/logs/messages.log";
     static final String TOOLCHAIN_CONFIGURED_FOR_GOAL = "CWWKM4101I: The %s goal is using the configured toolchain JDK located at";
-    static final String INVALID_TOOLCHAIN_CONFIGURED = "CWWKM4100W: Toolchain configured for liberty server but jdkHome is not configured in .m2/toolchain.xml.";
+    static final String INVALID_TOOLCHAIN_CONFIGURED = "CWWKM4100W: Toolchain configured for liberty server but no matching JDK was found via build context or toolchains.xml.";
 
     @Test
     public void testConfigPropFileExist() throws Exception {

--- a/liberty-maven-plugin/src/it/toolchain-run-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseToolchainTest.java
+++ b/liberty-maven-plugin/src/it/toolchain-run-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseToolchainTest.java
@@ -53,7 +53,10 @@ public class BaseToolchainTest {
     static File pom;
     static BufferedWriter writer;
     static Process process;
-    static final String TOOLCHAIN_INITIALIZED = "CWWKM4100I: Using toolchain from build context";
+    static final String TOOLCHAIN_INITIALIZED_XML     = "CWWKM4100I: Using toolchain JDK from toolchains.xml";
+    static final String TOOLCHAIN_INITIALIZED_CONTEXT = "CWWKM4100I: Using toolchain JDK from build context (auto-discovery)";
+    // Backwards-compat alias used by tests that accept either resolution path
+    static final String TOOLCHAIN_INITIALIZED = TOOLCHAIN_INITIALIZED_XML;
     static final String TOOLCHAIN_CONFIGURED_FOR_GOAL = "CWWKM4101I: The %s goal is using the configured toolchain JDK located at";
     static final String JAVA_11_SE_REQUIRED_FOR_FEATURE = "CWWKF0032E: The %s feature requires a minimum Java runtime environment version of JavaSE 11";
     static final String JAVA_HOME_CONFIGURED="CWWKM4101W: The toolchain JDK configuration for goal %s is not honored because the JAVA_HOME property is specified in the server.env or jvm.options file.";

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/ServerFeatureSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/ServerFeatureSupport.java
@@ -48,6 +48,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
+import org.apache.maven.toolchain.ToolchainPrivate;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 import io.openliberty.tools.common.plugins.util.ServerFeatureUtil;
@@ -440,6 +441,16 @@ public abstract class ServerFeatureSupport extends BasicSupport {
     /**
      * Initialize the toolchain by calling the toolchain goal.
      * If useToolchainJdk is set to true, this method will also set the toolchain variable.
+     * <p>
+     * Resolution order:
+     * <ol>
+     *   <li>Toolchain selected by {@code maven-toolchains-plugin} and stored in the build context
+     *       (supports both explicit {@code toolchains.xml} entries and auto-discovered JDKs).
+     *       The build-context toolchain is accepted only when it matches the {@code jdkToolchain}
+     *       requirements.</li>
+     *   <li>Direct lookup via {@link ToolchainManager#getToolchains} against {@code toolchains.xml}
+     *       (legacy path, kept for backwards compatibility).</li>
+     * </ol>
      *
      * @throws MojoExecutionException If an exception occurred while running toolchain goal
      */
@@ -452,10 +463,29 @@ public abstract class ServerFeatureSupport extends BasicSupport {
             getLog().warn("ToolchainManager is null. Falling back to system default JDK.");
             return;
         }
+
+        // 1. Prefer the toolchain already selected by maven-toolchains-plugin (build context).
+        //    This is the path used by auto-discovery and by explicit toolchains.xml when the
+        //    toolchains goal has already run earlier in the lifecycle.
+        Toolchain buildContextTc = toolchainManager.getToolchainFromBuildContext("jdk", session);
+        if (buildContextTc != null) {
+            // Validate that the build-context toolchain satisfies the configured requirements.
+            boolean matches = true;
+            if (buildContextTc instanceof ToolchainPrivate) {
+                matches = ((ToolchainPrivate) buildContextTc).matchesRequirements(jdkToolchain);
+            }
+            if (matches) {
+                this.toolchain = buildContextTc;
+                getLog().info(MessageFormat.format(messages.getString("info.toolchain.initialized.context"), this.toolchain));
+                return;
+            }
+        }
+
+        // 2. Fall back to a direct scan of toolchains.xml entries (no maven-toolchains-plugin needed).
         List<Toolchain> tcs = toolchainManager.getToolchains(session, "jdk", jdkToolchain);
         if (tcs != null && !tcs.isEmpty()) {
             this.toolchain = tcs.get(0);
-            getLog().info(MessageFormat.format(messages.getString("info.toolchain.initialized"), this.toolchain));
+            getLog().info(MessageFormat.format(messages.getString("info.toolchain.initialized.xml"), this.toolchain));
         } else {
             getLog().warn(MessageFormat.format(messages.getString("warn.toolchain.not.available"), jdkToolchain));
         }

--- a/liberty-maven-plugin/src/main/resources/io/openliberty/tools/maven/MvnMessages.properties
+++ b/liberty-maven-plugin/src/main/resources/io/openliberty/tools/maven/MvnMessages.properties
@@ -359,15 +359,17 @@ error.uninstall.feature.fail.explanation=An error was returned when uninstalling
 error.uninstall.feature.fail.useraction=Check the return code and execution failure log to investigate the cause of the failure.
 
 
-#need to define new message string
-info.toolchain.initialized=CWWKM4100I: Using toolchain from build context: {0}.
-info.toolchain.initialized.explanation=Toolchain is configured for Liberty server tasks from <jdkToolchain> and user's .m2/toolchain.xml.
-info.toolchain.initialized.useraction=No action required.
+info.toolchain.initialized.context=CWWKM4100I: Using toolchain JDK from build context (auto-discovery): {0}.
+info.toolchain.initialized.context.explanation=Toolchain JDK was selected by maven-toolchains-plugin auto-discovery and registered in the build context. No toolchains.xml is required.
+info.toolchain.initialized.context.useraction=No action required.
 
-#need to define new message string
-warn.toolchain.not.available=CWWKM4100W: Toolchain configured for liberty server but jdkHome is not configured in .m2/toolchain.xml.
-warn.toolchain.not.available.explanation=Toolchain is configured for Liberty server tasks in <jdkToolchain> but jdkHome is not configured in user's .m2/toolchain.xml.
-warn.toolchain.not.available.useraction=Check .m2/toolchain.xml and configure toolchain version properly.
+info.toolchain.initialized.xml=CWWKM4100I: Using toolchain JDK from toolchains.xml: {0}.
+info.toolchain.initialized.xml.explanation=Toolchain JDK was resolved directly from the user's ~/.m2/toolchains.xml file.
+info.toolchain.initialized.xml.useraction=No action required.
+
+warn.toolchain.not.available=CWWKM4100W: Toolchain configured for liberty server but no matching JDK was found via build context or toolchains.xml.
+warn.toolchain.not.available.explanation=Toolchain is configured for Liberty server tasks in <jdkToolchain> but no matching JDK was found. Either run maven-toolchains-plugin to register a JDK via auto-discovery, or configure the required JDK version in ~/.m2/toolchains.xml.
+warn.toolchain.not.available.useraction=Run the maven-toolchains-plugin select-jdk-toolchain goal, or add the required JDK to ~/.m2/toolchains.xml.
 
 #need to define new message string
 info.toolchain.configured=CWWKM4101I: The {0} goal is using the configured toolchain JDK located at {1}.


### PR DESCRIPTION
Fixes #2074 

- call getToolchainFromBuildContext() first in initToolchain(), validating the result against jdkToolchain requirements. Fall back to getToolchains()(toolchains.xml) only when the build context has no matching toolchain.

- Also split the single info.toolchain.initialized message into two distinct messages so the log clearly indicates whether the toolchain came from auto-discovery (build context) or an explicit toolchains.xml entry.

- Add toolchain-autodiscovery-it integration test using the reproduction project from the issue report. The test runs maven-toolchains-plugin select-jdk-toolchain (no toolchains.xml) and asserts CWWKM4100I from the build-context path is logged and CWWKM4100W is absent.