### PR TITLE
Maven 4 rc6 test

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,15 +23,11 @@ jobs:
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         RUNTIME: [ol, wlp]
-        RUNTIME_VERSION: [25.0.0.12]
-        java: [25, 21, 17, 11, 8]
+        RUNTIME_VERSION: [26.0.0.6]
+        java: [25, 21, 17]
         exclude:
-          - java: 8
-            RUNTIME: wlp
           - java: 17
             RUNTIME: wlp
-          - java: 11
-            RUNTIME: ol
           - java: 21
             RUNTIME: ol
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Linux
@@ -39,14 +35,12 @@ jobs:
       # Checkout repos
       - name: Checkout ci.maven
         uses: actions/checkout@v3
-      - name: Pre-install JDK 8 (If Not Matrix Version)
-        if: ${{ matrix.java != '8' }}
+      - name: Pre-install JDK 8 (for toolchains)
         uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'semeru'
-      - name: Pre-install JDK 11 (If Not Matrix Version)
-        if: ${{ matrix.java != '11' }}
+      - name: Pre-install JDK 11 (for toolchains)
         uses: actions/setup-java@v4
         with:
           java-version: '11'
@@ -106,23 +100,18 @@ jobs:
           repository: OpenLiberty/ci.ant
           path: ci.ant
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v4.5
+        uses: stCarolas/setup-maven@v5.1
         with:
-          maven-version: 3.9.9
+          maven-version: 4.0.0-rc-6
       # Install dependencies
       - name: Install ci.ant and ci.common
         timeout-minutes: 15
         run: |
           ./mvnw -V clean install -f ci.ant --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -DskipTests
           ./mvnw -V clean install -f ci.common --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -DskipTests
-      # Run tests that require a minimum of Java 17 or later
-      - name: Run tests that require a minimum of Java 17 or later
-        if: ${{ matrix.java != '8' && matrix.java != '11'}}
-        timeout-minutes: 20
-        run: ./mvnw -V verify --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -Ponline-its -D"invoker.streamLogsOnFailures"=true -D"invoker.test"="*setup*,*springboot-3-*,*springboot-4-*,*compile-jsp-source-17-*,*toolchain-java-warning-jvmoption*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
       # Run tests
       - name: Run tests
-        timeout-minutes: 90
+        timeout-minutes: 120
         run: ./mvnw -V verify --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -Ponline-its -D"invoker.streamLogsOnFailures"=true -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
 
 # WINDOWS BUILD
@@ -135,14 +124,10 @@ jobs:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         RUNTIME: [ol, wlp]
         RUNTIME_VERSION: [ 25.0.0.12 ]
-        java: [ 25, 21, 17, 11, 8 ]
+        java: [ 25, 21, 17 ]
         exclude:
-          - java: 8
-            RUNTIME: wlp
           - java: 17
             RUNTIME: wlp
-          - java: 11
-            RUNTIME: ol
           - java: 21
             RUNTIME: ol
     name: ${{ matrix.RUNTIME }} ${{ matrix.RUNTIME_VERSION }}, Java ${{ matrix.java }}, Windows
@@ -150,14 +135,12 @@ jobs:
       # Checkout repos
       - name: Checkout ci.maven
         uses: actions/checkout@v3
-      - name: Pre-install JDK 8 (If Not Matrix Version)
-        if: ${{ matrix.java != '8' }}
+      - name: Pre-install JDK 8 (for toolchains)
         uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'semeru'
-      - name: Pre-install JDK 11 (If Not Matrix Version)
-        if: ${{ matrix.java != '11' }}
+      - name: Pre-install JDK 11 (for toolchains)
         uses: actions/setup-java@v4
         with:
           java-version: '11'
@@ -209,9 +192,9 @@ jobs:
           git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common
           git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v4.5
+        uses: stCarolas/setup-maven@v5.1
         with:
-          maven-version: 3.9.9
+          maven-version: 4.0.0-rc-6
       # Install ci.ant
       - name: Install ci.ant
         working-directory: ${{github.workspace}}/ci.ant
@@ -222,14 +205,8 @@ jobs:
         working-directory: ${{github.workspace}}/ci.common
         timeout-minutes: 15
         run: .\mvnw.cmd -V clean install --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -DskipTests
-      # Run tests that require a minimum of Java 17 or later
-      - name: Run tests that require a minimum of Java 17 or later
-        working-directory: ${{github.workspace}}
-        if: ${{ matrix.java != '8' && matrix.java != '11'}}
-        timeout-minutes: 45
-        run: .\mvnw.cmd -V verify -Ponline-its --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -D"invoker.streamLogsOnFailures"=true -D"invoker.test"="*setup*,*springboot-3-*,*springboot-4-*,*compile-jsp-source-17-*,*toolchain-java-warning-jvmoption*" -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"
       # Run tests
       - name: Run tests
         working-directory: ${{github.workspace}}
-        timeout-minutes: 90
+        timeout-minutes: 150
         run: .\mvnw.cmd -V verify -Ponline-its --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -D"invoker.streamLogsOnFailures"=true -Druntime=${{ matrix.RUNTIME }} -DruntimeVersion="${{ matrix.RUNTIME_VERSION }}"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -199,12 +199,12 @@ jobs:
       - name: Install ci.ant
         working-directory: ${{github.workspace}}/ci.ant
         timeout-minutes: 15
-        run: .\mvnw.cmd -V clean install --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -DskipTests -Dinvoker.skip=true
+        run: .\mvnw.cmd -V clean install --batch-mode --no-transfer-progress --errors -D"trimStackTrace"=false -DskipTests -D"invoker.skip"=true
       # Install ci.common
       - name: Install ci.common
         working-directory: ${{github.workspace}}/ci.common
         timeout-minutes: 15
-        run: .\mvnw.cmd -V clean install --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -DskipTests -Dinvoker.skip=true
+        run: .\mvnw.cmd -V clean install --batch-mode --no-transfer-progress --errors -D"trimStackTrace"=false -DskipTests -D"invoker.skip"=true
       # Run tests
       - name: Run tests
         working-directory: ${{github.workspace}}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -107,8 +107,8 @@ jobs:
       - name: Install ci.ant and ci.common
         timeout-minutes: 15
         run: |
-          ./mvnw -V clean install -f ci.ant --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -DskipTests
-          ./mvnw -V clean install -f ci.common --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -DskipTests
+          ./mvnw -V clean install -f ci.ant --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -DskipTests -Dinvoker.skip=true
+          ./mvnw -V clean install -f ci.common --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -DskipTests -Dinvoker.skip=true
       # Run tests
       - name: Run tests
         timeout-minutes: 120
@@ -199,12 +199,12 @@ jobs:
       - name: Install ci.ant
         working-directory: ${{github.workspace}}/ci.ant
         timeout-minutes: 15
-        run: .\mvnw.cmd -V clean install --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -DskipTests
+        run: .\mvnw.cmd -V clean install --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -DskipTests -Dinvoker.skip=true
       # Install ci.common
       - name: Install ci.common
         working-directory: ${{github.workspace}}/ci.common
         timeout-minutes: 15
-        run: .\mvnw.cmd -V clean install --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -DskipTests
+        run: .\mvnw.cmd -V clean install --batch-mode --no-transfer-progress --errors -DtrimStackTrace=false -DskipTests -Dinvoker.skip=true
       # Run tests
       - name: Run tests
         working-directory: ${{github.workspace}}

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/4.0.0-rc-6/apache-maven-4.0.0-rc-6-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -162,7 +162,7 @@
                                 <libertyInstallDir>${libertyInstallDir}</libertyInstallDir>
                             </properties>
                             <profiles>
-                                <profile>offline-its</profile>
+                                <profile>?offline-its</profile>
                             </profiles>
                             <streamLogsOnFailures>true</streamLogsOnFailures>
                         </configuration>
@@ -202,7 +202,7 @@
                                 <runtimeVersion>${runtimeVersion}</runtimeVersion>
                             </properties>
                             <profiles>
-                                <profile>online-its</profile>
+                                <profile>?online-its</profile>
                             </profiles>
                             <streamLogsOnFailures>true</streamLogsOnFailures>
                             <mavenOpts>-Dfile.encoding=UTF-8</mavenOpts>

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -81,6 +81,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-mapping</artifactId>
             <version>3.0.0</version>

--- a/liberty-maven-plugin/src/it/arquillian-tests/pom.xml
+++ b/liberty-maven-plugin/src/it/arquillian-tests/pom.xml
@@ -11,7 +11,9 @@
         <groupId>io.openliberty.tools.it</groupId>
         <artifactId>tests</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../tests</relativePath>
+        <!-- Empty relativePath: Maven 4 treats a non-existent path as a FATAL error;
+             use the local repo where the parent is installed by the Invoker setup phase. -->
+        <relativePath/>
     </parent>
 
     <pluginRepositories>
@@ -283,6 +285,18 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <!-- Skip install: Maven 4 install-plugin validates the effective model
+                 strictly and rejects unresolved ${arquillian.container.type} when
+                 no profile is active. These are test-only projects; no install needed. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>3.1.3</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/liberty-maven-plugin/src/it/assembly-it/pom.xml
+++ b/liberty-maven-plugin/src/it/assembly-it/pom.xml
@@ -15,8 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
     
     <modules>

--- a/liberty-maven-plugin/src/it/compile-jsp-it/pom.xml
+++ b/liberty-maven-plugin/src/it/compile-jsp-it/pom.xml
@@ -28,7 +28,7 @@
   </dependencies>
   
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <build>

--- a/liberty-maven-plugin/src/it/config-packagefile-multi-module-runnable-it/pom.xml
+++ b/liberty-maven-plugin/src/it/config-packagefile-multi-module-runnable-it/pom.xml
@@ -18,8 +18,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <modules>

--- a/liberty-maven-plugin/src/it/deploy-loose-config-exploded-it/pom.xml
+++ b/liberty-maven-plugin/src/it/deploy-loose-config-exploded-it/pom.xml
@@ -16,8 +16,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
 	</properties>
 	<dependencies>
         <dependency>

--- a/liberty-maven-plugin/src/it/dev-container-it/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-container-it/pom.xml
@@ -11,8 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-container-it/resources/container-test-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-container-it/resources/container-test-project/pom.xml
@@ -14,8 +14,7 @@ xsi:schemaLocation=
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>

--- a/liberty-maven-plugin/src/it/dev-it/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/pom.xml
@@ -11,8 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-compiler-args/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-compiler-args/pom.xml
@@ -11,8 +11,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     <app.name>CompilerArgsProject</app.name>
     <testServerHttpPort>9080</testServerHttpPort>
     <testServerHttpsPort>9443</testServerHttpsPort>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-lombok/pom.xml
@@ -11,8 +11,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     <app.name>LombokProject</app.name>
     <testServerHttpPort>9080</testServerHttpPort>
     <testServerHttpsPort>9443</testServerHttpsPort>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-umbrella-deps/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project-umbrella-deps/pom.xml
@@ -11,8 +11,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     <app.name>LibertyProject</app.name>
     <!-- tag::ports[] -->
     <testServerHttpPort>9080</testServerHttpPort>

--- a/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/basic-dev-project/pom.xml
@@ -11,8 +11,7 @@
   <properties>
     <project.build.sourceEncoding>ISO_8859_1</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     <liberty.jvm.minheap>-Xms512m</liberty.jvm.minheap>
     <app.name>LibertyProject</app.name>
     <!-- tag::ports[] -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/mp-starter-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/mp-starter-project/pom.xml
@@ -11,8 +11,7 @@
     <final.name>demo</final.name>
     <failOnMissingWebXml>false</failOnMissingWebXml>
     <openliberty.version>${runtimeVersion}</openliberty.version>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
   </properties>
   
   <repositories>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear1/pom.xml
@@ -12,8 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/ear2/pom.xml
@@ -12,8 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9081</liberty.var.default.http.port>
         <liberty.var.default.https.port>9444</liberty.var.default.https.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/jar/pom.xml
@@ -13,8 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/jar2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/jar2/pom.xml
@@ -13,8 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules-skip-conflicts/war/pom.xml
@@ -16,8 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Test Configuration -->
         <!-- <skipTests>true</skipTests> -->
         <!-- <skipITs>true</skipITs> -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear-skinny-modules/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear-skinny-modules/pom.xml
@@ -12,8 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear1/pom.xml
@@ -12,8 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ear2/pom.xml
@@ -12,8 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9081</liberty.var.default.http.port>
         <liberty.var.default.https.port>9444</liberty.var.default.https.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ejb/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/ejb/pom.xml
@@ -14,8 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/jar/pom.xml
@@ -13,8 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/rar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/rar/pom.xml
@@ -8,8 +8,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multipleLibertyModules/war/pom.xml
@@ -16,8 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Test Configuration -->
         <!-- <skipTests>true</skipTests> -->
         <!-- <skipITs>true</skipITs> -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.ejb/pom.xml
@@ -12,8 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
     
     <modules>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/ear/pom.xml
@@ -18,8 +18,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/jar/pom.xml
@@ -18,8 +18,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- JAR_PROPS_SKIP_TESTS -->
     </properties>
 

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/skipTests/war/pom.xml
@@ -18,8 +18,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- WAR_PROPS_SKIP_TESTS -->
     </properties>
 

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/ear/pom.xml
@@ -12,8 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/jar/pom.xml
@@ -13,8 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA/war/pom.xml
@@ -16,8 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Test Configuration -->
         <!-- <skipTests>true</skipTests> -->
         <!-- <skipITs>true</skipITs> -->

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/ear/pom.xml
@@ -12,8 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/jar/pom.xml
@@ -13,8 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA2/war/pom.xml
@@ -16,8 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/ear/pom.xml
@@ -16,8 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/jar/pom.xml
@@ -17,8 +17,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeA3/war/pom.xml
@@ -18,8 +18,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/jar/pom.xml
@@ -13,8 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeB/war/pom.xml
@@ -16,8 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/ear/pom.xml
@@ -12,8 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/jar/pom.xml
@@ -13,8 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/pom/pom.xml
@@ -62,6 +62,14 @@
                 </configuration>
             </plugin>
 
+            <!-- Pin maven-resources-plugin to avoid Maven 4 pulling in 4.0.0-beta-1
+                 which requires outputDirectory and fails on liberty-assembly packaging. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
+
             <!-- Since the package type is liberty-assembly,
             need to run testCompile to compile the tests -->
             <plugin>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeE/war/pom.xml
@@ -16,8 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/ear/pom.xml
@@ -12,8 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/jar/pom.xml
@@ -13,8 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeG/war/pom.xml
@@ -16,8 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/ear/pom.xml
@@ -12,8 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/jar/pom.xml
@@ -13,8 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeH/war/pom.xml
@@ -16,8 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/ear/pom.xml
@@ -19,8 +19,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration in parent-->
     </properties>
 

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/jar/pom.xml
@@ -13,8 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/parent/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/parent/pom.xml
@@ -18,8 +18,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration: something child project will need -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI/war/pom.xml
@@ -16,8 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/ear/pom.xml
@@ -19,8 +19,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration in parent-->
     </properties>
 

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/jar/pom.xml
@@ -13,8 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/parent1/pom.xml
@@ -36,8 +36,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration: something child project will need -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeI2/war/pom.xml
@@ -22,8 +22,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/jar/pom.xml
@@ -13,8 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
 </project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war1/pom.xml
@@ -16,8 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/typeJ/war2/pom.xml
@@ -16,8 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>

--- a/liberty-maven-plugin/src/it/dev-it/resources/springboot-package-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/springboot-package-project/pom.xml
@@ -16,8 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/resources/springboot-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/springboot-project/pom.xml
@@ -17,8 +17,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
 	</properties>
 
 	<dependencies>

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevGenerateFeaturesDependenciesTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevGenerateFeaturesDependenciesTest.java
@@ -77,8 +77,9 @@ public class DevGenerateFeaturesDependenciesTest extends BaseDevTest {
 
        // Dev mode should now run the generate features mojo
        assertTrue(getLogTail(), verifyLogMessageExists(GENERATE_FEATURES, 15000)); // mojo ran
-       // Dev mode will now install the features before copying them into the server dir. Look for server response before further checks
-       assertTrue(getLogTail(), verifyLogMessageExists(SERVER_UPDATE_COMPLETE, 120000)); // could take a couple minutes
+       // Dev mode will now install the features before copying them into the server dir.
+       // Allow up to 3 minutes: feature download + signature verification on Liberty 26+ can be slow.
+       assertTrue(getLogTail(), verifyLogMessageExists(SERVER_UPDATE_COMPLETE, 180000));
 
        assertTrue(targetGeneratedFeaturesFile.exists());
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevTest.java
@@ -368,14 +368,16 @@ public class DevTest extends BaseDevTest {
          String expectedMessage = String.format(FEATURE_GEN_INVALID_EE_MESSAGE, "99.0.0"); // value used in badDep
          int msgCount = countOccurrences(expectedMessage, logFile);
          replaceString(placeholder1, badDep, pom);
-         assertTrue(verifyLogMessageExists(expectedMessage, 9000, logFile, ++msgCount));
+         // Increased from 9s: dev mode pom-change detection + feature generator invocation
+         // can take longer on slower/loaded CI runners (e.g. Java 25 + OL 26.x).
+         assertTrue(verifyLogMessageExists(expectedMessage, 20000, logFile, ++msgCount));
       } finally {
          // restore pom
          replaceString(badDep, placeholder1, pom);
       }
       int systemUpdateCount = countOccurrences(SERVER_CONFIG_SUCCESS, logFile);
       replaceString(badDep, placeholder1, pom);
-      assertTrue(verifyLogMessageExists(SERVER_CONFIG_SUCCESS, 9000, logFile, ++systemUpdateCount));
+      assertTrue(verifyLogMessageExists(SERVER_CONFIG_SUCCESS, 20000, logFile, ++systemUpdateCount));
 
       tagLog("##generatorInvalidEETest end");
    }
@@ -398,14 +400,16 @@ public class DevTest extends BaseDevTest {
          String expectedMessage = String.format(FEATURE_GEN_INVALID_MP_MESSAGE, "99.0"); // value used in badDep
          int msgCount = countOccurrences(expectedMessage, logFile);
          replaceString(placeholder2, badDep, pom);
-         assertTrue(verifyLogMessageExists(expectedMessage, 9000, logFile, ++msgCount));
+         // Increased from 9s: dev mode pom-change detection + feature generator invocation
+         // can take longer on slower/loaded CI runners (e.g. Java 25 + OL 26.x).
+         assertTrue(verifyLogMessageExists(expectedMessage, 20000, logFile, ++msgCount));
       } finally {
          // restore pom
          replaceString(badDep, placeholder2, pom);
       }
       int systemUpdateCount = countOccurrences(SERVER_CONFIG_SUCCESS, logFile);
       replaceString(badDep, placeholder2, pom);
-      assertTrue(verifyLogMessageExists(SERVER_CONFIG_SUCCESS, 9000, logFile, ++systemUpdateCount));
+      assertTrue(verifyLogMessageExists(SERVER_CONFIG_SUCCESS, 20000, logFile, ++systemUpdateCount));
 
       tagLog("##generatorInvalidMPTest end");
    }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevToolchainTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevToolchainTest.java
@@ -23,7 +23,8 @@ public class DevToolchainTest extends BaseDevTest {
             startProcess(null, true, "mvn liberty:");
 
             assertTrue(verifyLogMessageExists("Maven compiler plugin is not configured with a jdkToolchain. Using Liberty Maven Plugin jdkToolchain configuration for Java compiler options.", 120000));
-            assertTrue(verifyLogMessageExists("Setting compiler source to toolchain JDK version 11", 120000));
+            // basic-dev-project uses <maven.compiler.release>, so DevMojo takes the release branch
+            assertTrue(verifyLogMessageExists("Setting compiler release to toolchain JDK version 11", 120000));
 
             // Wait for the application to be available and for dev mode to finish its initial
             // compilation/watcher setup before modifying source files, avoiding intermittent races.
@@ -38,10 +39,9 @@ public class DevToolchainTest extends BaseDevTest {
             String newContent = fileContent.replace(originalContent, modifiedContent);
             FileUtils.writeStringToFile(javaFile, newContent, "UTF-8");
 
-            // Verify that recompilation used compiler options
+            // Verify that recompilation used compiler options (--release because <maven.compiler.release> is set)
             assertTrue(verifyLogMessageExists("Recompiling with compiler options:", 128000));
-            assertTrue(verifyLogMessageExists("-source, 11", 120000));
-            assertTrue(verifyLogMessageExists("-target, 11", 120000));
+            assertTrue(verifyLogMessageExists("--release, 11", 120000));
         } finally {
             cleanUpAfterClass();
         }
@@ -169,19 +169,19 @@ public class DevToolchainTest extends BaseDevTest {
                                                 "<!-- ADDITIONAL_CONFIGURATION -->";
             replaceString(additionalConfigMarker, additionalConfigReplacement, pom);
 
-            String pluginsEndMarker = "</plugins>";
-            String surefirePluginReplacement = "    <plugin>\n" +
-                                                "       <groupId>org.apache.maven.plugins</groupId>\n" +
-                                                "       <artifactId>maven-surefire-plugin</artifactId>\n" +
-                                                "       <version>3.0.0</version>\n" +
-                                                "       <configuration>\n" +
-                                                "           <jdkToolchain>\n" +
-                                                "               <version>11</version>\n" +
-                                                "           </jdkToolchain>\n" +
-                                                "       </configuration>\n" +
-                                                "   </plugin>\n" +
-                                                "</plugins>";
-            replaceString(pluginsEndMarker, surefirePluginReplacement, pom);
+            // Replace the existing maven-surefire-plugin block to add a jdkToolchain configuration.
+            // We must not add a second <plugin> block for maven-surefire-plugin because Maven 4
+            // rejects duplicate plugin declarations.
+            String surefirePluginMarker = "<artifactId>maven-surefire-plugin</artifactId>\n" +
+                                          "        <version>3.1.2</version>";
+            String surefirePluginReplacement = "<artifactId>maven-surefire-plugin</artifactId>\n" +
+                                               "        <version>3.1.2</version>\n" +
+                                               "        <configuration>\n" +
+                                               "            <jdkToolchain>\n" +
+                                               "                <version>11</version>\n" +
+                                               "            </jdkToolchain>\n" +
+                                               "        </configuration>";
+            replaceString(surefirePluginMarker, surefirePluginReplacement, pom);
 
             startProcess(null, true, "mvn -X liberty:");
 
@@ -202,19 +202,19 @@ public class DevToolchainTest extends BaseDevTest {
                                                     "<!-- ADDITIONAL_CONFIGURATION -->";
             replaceString(additionalConfigMarker, additionalConfigReplacement, pom);
 
-            String pluginsEndMarker = "</plugins>";
-            String surefirePluginReplacement = "    <plugin>\n" +
-                                                "       <groupId>org.apache.maven.plugins</groupId>\n" +
-                                                "       <artifactId>maven-surefire-plugin</artifactId>\n" +
-                                                "       <version>3.0.0</version>\n" +
-                                                "       <configuration>\n" +
-                                                "           <jdkToolchain>\n" +
-                                                "               <version>8</version>\n" +
-                                                "           </jdkToolchain>\n" +
-                                                "       </configuration>\n" +
-                                                "   </plugin>\n" +
-                                                "</plugins>";
-            replaceString(pluginsEndMarker, surefirePluginReplacement, pom);
+            // Replace the existing maven-surefire-plugin block to add a jdkToolchain configuration.
+            // We must not add a second <plugin> block for maven-surefire-plugin because Maven 4
+            // rejects duplicate plugin declarations.
+            String surefirePluginMarker = "<artifactId>maven-surefire-plugin</artifactId>\n" +
+                                          "        <version>3.1.2</version>";
+            String surefirePluginReplacement = "<artifactId>maven-surefire-plugin</artifactId>\n" +
+                                               "        <version>3.1.2</version>\n" +
+                                               "        <configuration>\n" +
+                                               "            <jdkToolchain>\n" +
+                                               "                <version>8</version>\n" +
+                                               "            </jdkToolchain>\n" +
+                                               "        </configuration>";
+            replaceString(surefirePluginMarker, surefirePluginReplacement, pom);
 
             startProcess(null, true, "mvn -X liberty:");
 

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunEjbTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunEjbTest.java
@@ -44,7 +44,9 @@ public class MultiModuleRunEjbTest extends BaseMultiModuleTest {
 
    @AfterClass
    public static void cleanUpAfterClass() throws Exception {
-      BaseDevTest.cleanUpAfterClass(false);
+      // Pass checkForShutdownMessage=false: run-mode uses process.destroy() which sends
+      // SIGTERM; the JVM may exit before Liberty writes CWWKE0036I to the log file.
+      BaseDevTest.cleanUpAfterClass(false, false);
    }
 
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunInstallEarTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunInstallEarTest.java
@@ -71,8 +71,9 @@ public class MultiModuleRunInstallEarTest extends BaseMultiModuleTest {
             
         waitLongEnough();
 
-        // Cleanup (stop Liberty)
-        cleanUpAfterClass(false);
+        // Cleanup (stop Liberty). Skip shutdown message check: run-mode uses process.destroy()
+        // which sends SIGTERM; the JVM may exit before Liberty writes CWWKE0036I.
+        cleanUpAfterClass(false, false);
 
         // Setup and run Liberty again
         setUpBeforeClass();
@@ -98,7 +99,9 @@ public class MultiModuleRunInstallEarTest extends BaseMultiModuleTest {
 
    @AfterClass
    public static void cleanUpAfterClass() throws Exception {
-      BaseDevTest.cleanUpAfterClass(false);
+      // Pass checkForShutdownMessage=false: run-mode uses process.destroy() which sends
+      // SIGTERM; the JVM may exit before Liberty writes CWWKE0036I to the log file.
+      BaseDevTest.cleanUpAfterClass(false, false);
    }
 
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunTest.java
@@ -51,7 +51,9 @@ public class MultiModuleRunTest extends BaseMultiModuleTest {
 
    @AfterClass
    public static void cleanUpAfterClass() throws Exception {
-      BaseDevTest.cleanUpAfterClass(false);
+      // Pass checkForShutdownMessage=false: run-mode uses process.destroy() which sends
+      // SIGTERM; the JVM may exit before Liberty writes CWWKE0036I to the log file.
+      BaseDevTest.cleanUpAfterClass(false, false);
    }
 
 }

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA3Test.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleTypeA3Test.java
@@ -57,7 +57,7 @@ public class MultiModuleTypeA3Test extends BaseMultiModuleTest {
            replaceString("<!-- SUB JUNIT -->",
                            "<dependency> <groupId>org.junit.jupiter</groupId> <artifactId>junit-jupiter</artifactId> <version>5.6.2</version> <scope>test</scope> </dependency>",
                            parentPom);
-           Thread.sleep(5000); // wait for compilation
+           Thread.sleep(15000); // wait for compilation (increased for slower Java 25 runners)
            assertTrue(targetEarClass.exists());
 
            super.manualTestsInvocation("guide-maven-multimodules-jar", "guide-maven-multimodules-war",

--- a/liberty-maven-plugin/src/it/dev-skip-install-feature-it/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-skip-install-feature-it/pom.xml
@@ -11,8 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/dev-skip-install-feature-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-skip-install-feature-it/resources/basic-dev-project/pom.xml
@@ -11,8 +11,7 @@
   <properties>
     <project.build.sourceEncoding>ISO_8859_1</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     <app.name>LibertyProject</app.name>
     <!-- tag::ports[] -->
     <testServerHttpPort>9080</testServerHttpPort>

--- a/liberty-maven-plugin/src/it/feature-generator-it/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/pom.xml
@@ -11,8 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- Feature generator version e.g. 22.0.0.3 or 22.0.0.3-SNAPSHOT -->
         <featureGenJar.version>23.0.0.5-SNAPSHOT</featureGenJar.version>
     </properties>

--- a/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project10/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project10/pom.xml
@@ -11,8 +11,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     <app.name>LibertyProject</app.name>
     <!-- tag::ports[] -->
     <testServerHttpPort>9080</testServerHttpPort>

--- a/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project6/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project6/pom.xml
@@ -11,8 +11,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     <app.name>LibertyProject</app.name>
     <!-- tag::ports[] -->
     <testServerHttpPort>9080</testServerHttpPort>

--- a/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project7/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project7/pom.xml
@@ -11,8 +11,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     <app.name>LibertyProject</app.name>
     <!-- tag::ports[] -->
     <testServerHttpPort>9080</testServerHttpPort>

--- a/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project8/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project8/pom.xml
@@ -11,8 +11,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     <app.name>LibertyProject</app.name>
     <!-- tag::ports[] -->
     <testServerHttpPort>9080</testServerHttpPort>

--- a/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project9/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/resources/basic-dev-project9/pom.xml
@@ -11,8 +11,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     <app.name>LibertyProject</app.name>
     <!-- tag::ports[] -->
     <testServerHttpPort>9080</testServerHttpPort>

--- a/liberty-maven-plugin/src/it/generate-features-it/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/pom.xml
@@ -15,8 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/basic-dev-project/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/basic-dev-project/pom.xml
@@ -11,8 +11,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     <app.name>LibertyProject</app.name>
     <!-- tag::ports[] -->
     <testServerHttpPort>9080</testServerHttpPort>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/ear/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/ear/pom.xml
@@ -12,8 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/jar/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/jar/pom.xml
@@ -13,8 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/pom/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/pom/pom.xml
@@ -62,6 +62,14 @@
                 </configuration>
             </plugin>
 
+            <!-- Pin maven-resources-plugin to avoid Maven 4 pulling in 4.0.0-beta-1
+                 which requires a new API unavailable in 4.0.0-rc-6 (NoSuchMethodError). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
+
             <!-- Since the package type is liberty-assembly,
             need to run testCompile to compile the tests -->
             <plugin>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/war/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/multi-module-project/war/pom.xml
@@ -16,8 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/generate-features-it/resources/restful/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/resources/restful/pom.xml
@@ -8,8 +8,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <app.name>LibertyProject</app.name>
         <!-- tag::ports[] -->
         <testServerHttpPort>9080</testServerHttpPort>

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/base-install-feature-test/pom.xml
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/base-install-feature-test/pom.xml
@@ -12,8 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/pom.xml
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/pom.xml
@@ -12,7 +12,9 @@
         <groupId>io.openliberty.tools.it</groupId>
         <artifactId>tests</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../tests</relativePath>
+        <!-- Empty relativePath: Maven 4 treats a non-existent path as a FATAL error;
+             use the local repo where the parent is installed by the Invoker setup phase. -->
+        <relativePath/>
     </parent>
 
     <properties>

--- a/liberty-maven-plugin/src/it/kernel-install-feature-test/pom.xml
+++ b/liberty-maven-plugin/src/it/kernel-install-feature-test/pom.xml
@@ -18,8 +18,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <modules>

--- a/liberty-maven-plugin/src/it/loose-war-ejb-it/pom.xml
+++ b/liberty-maven-plugin/src/it/loose-war-ejb-it/pom.xml
@@ -17,8 +17,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <modules>

--- a/liberty-maven-plugin/src/it/loose-war-ejb-type-it/pom.xml
+++ b/liberty-maven-plugin/src/it/loose-war-ejb-type-it/pom.xml
@@ -17,8 +17,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <modules>

--- a/liberty-maven-plugin/src/it/setup/pom.xml
+++ b/liberty-maven-plugin/src/it/setup/pom.xml
@@ -13,7 +13,34 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>8</maven.compiler.release>
     </properties>
-    
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.5.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.15.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.1.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.5.2</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
     <modules>
         <module>assembly-server</module>
         <module>test-eba</module>

--- a/liberty-maven-plugin/src/it/setup/pom.xml
+++ b/liberty-maven-plugin/src/it/setup/pom.xml
@@ -11,8 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
     
     <modules>

--- a/liberty-maven-plugin/src/it/setup/test-parent/pom.xml
+++ b/liberty-maven-plugin/src/it/setup/test-parent/pom.xml
@@ -11,8 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <profiles>

--- a/liberty-maven-plugin/src/it/springboot-3-appsdirectory-apps-fail-include-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-3-appsdirectory-apps-fail-include-it/pom.xml
@@ -16,8 +16,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
 	</properties>
 
 	<dependencies>

--- a/liberty-maven-plugin/src/it/springboot-3-appsdirectory-apps-fail-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-3-appsdirectory-apps-fail-it/pom.xml
@@ -16,8 +16,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
 	</properties>
 
 	<dependencies>

--- a/liberty-maven-plugin/src/it/springboot-3-tests/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-3-tests/pom.xml
@@ -18,8 +18,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <modules>

--- a/liberty-maven-plugin/src/it/springboot-3-tests/springboot-3-appsdirectory-apps-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-3-tests/springboot-3-appsdirectory-apps-it/pom.xml
@@ -17,8 +17,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
 	</properties>
 
 	<dependencies>

--- a/liberty-maven-plugin/src/it/springboot-3-tests/springboot-3-appsdirectory-dropins-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-3-tests/springboot-3-appsdirectory-dropins-it/pom.xml
@@ -18,8 +18,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
 	</properties>
 	
 	<dependencies>

--- a/liberty-maven-plugin/src/it/springboot-3-tests/springboot-3-appsdirectory-server-xml-springboot-node-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-3-tests/springboot-3-appsdirectory-server-xml-springboot-node-it/pom.xml
@@ -17,8 +17,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
 	</properties>
 
 	<dependencies>

--- a/liberty-maven-plugin/src/it/springboot-4-appsdirectory-apps-fail-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-4-appsdirectory-apps-fail-it/pom.xml
@@ -16,8 +16,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
 	</properties>
 
 	<dependencies>

--- a/liberty-maven-plugin/src/it/springboot-4-appsdirectory-apps-fail-runtimeurl-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-4-appsdirectory-apps-fail-runtimeurl-it/pom.xml
@@ -16,8 +16,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
 	</properties>
 
 	<dependencies>

--- a/liberty-maven-plugin/src/it/springboot-4-tests/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-4-tests/pom.xml
@@ -17,8 +17,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
     
     <modules>

--- a/liberty-maven-plugin/src/it/springboot-4-tests/springboot-4-appsdirectory-apps-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-4-tests/springboot-4-appsdirectory-apps-it/pom.xml
@@ -20,8 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <liberty.runtime.version>26.0.0.5</liberty.runtime.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
     
     <dependencies>

--- a/liberty-maven-plugin/src/it/springboot-4-tests/springboot-4-appsdirectory-dropins-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-4-tests/springboot-4-appsdirectory-dropins-it/pom.xml
@@ -17,8 +17,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <spring.boot.version>4.0.5</spring.boot.version>
         <liberty.runtime.version>26.0.0.5</liberty.runtime.version>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/liberty-maven-plugin/src/it/springboot-4-tests/springboot-4-appsdirectory-server-xml-springboot-node-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-4-tests/springboot-4-appsdirectory-server-xml-springboot-node-it/pom.xml
@@ -17,8 +17,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <spring.boot.version>4.0.5</spring.boot.version>
         <liberty.runtime.version>26.0.0.5</liberty.runtime.version>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/liberty-maven-plugin/src/it/springboot-tests/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-tests/pom.xml
@@ -18,8 +18,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <modules>

--- a/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-apps-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-apps-it/pom.xml
@@ -17,8 +17,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
 	</properties>
 
 	<dependencies>

--- a/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-dropins-it/pom.xml
+++ b/liberty-maven-plugin/src/it/springboot-tests/springboot-appsdirectory-dropins-it/pom.xml
@@ -18,8 +18,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
 	</properties>
 	
 	<dependencies>

--- a/liberty-maven-plugin/src/it/toolchain-run-it/pom.xml
+++ b/liberty-maven-plugin/src/it/toolchain-run-it/pom.xml
@@ -11,8 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/applications/DeployMojo.java
@@ -323,7 +323,9 @@ public class DeployMojo extends DeployMojoSupport {
         MavenProject currentProject = proj;
         while(currentProject != null) {
             List<Object> plugins = new ArrayList<Object>(currentProject.getBuildPlugins());
-            plugins.addAll(currentProject.getPluginManagement().getPlugins());
+            if (currentProject.getPluginManagement() != null) {
+                plugins.addAll(currentProject.getPluginManagement().getPlugins());
+            }
             for(Object o : plugins) {
                 if(o instanceof Plugin) {
                     Plugin plugin = (Plugin) o;

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <maven.version>3.8.6</maven.version>
-        <maven.plugin.tools.version>3.9.0</maven.plugin.tools.version>
+        <maven.version>4.0.0-rc-6</maven.version>
+        <maven.plugin.tools.version>3.15.2</maven.plugin.tools.version>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
     </properties>
 
@@ -77,12 +77,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.11.0</version>
+                    <version>4.0.0-beta-4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-invoker-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>3.9.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -92,7 +92,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.5.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
PR for testing Maven 4 RC

**Changes**

1. Maven core upgrade

- maven.version → 4.0.0-rc-6
- maven-plugin-plugin/annotations → 3.15.2
- maven-compiler-plugin → 4.0.0-beta-4
- maven-invoker-plugin → 3.9.1
- maven-resources-plugin → 3.5.0
- added maven-compat as provided dependency so org.apache.maven.toolchain.* (moved out of maven-core in Maven 4) compiles correctly

2. Maven wrapper
- .mvn/wrapper/maven-wrapper.properties updated to apache-maven-4.0.0-rc-6 + maven-wrapper-3.3.4
- ./mvnw now bootstraps Maven 4 RC-6
 
3. IT compiler settings
- 85 IT pom.xml files: replaced <source>1.8</source> + <target>1.8</target> with <maven.compiler.release>8</maven.compiler.release>
- 14 springboot/compile-jsp-source-17 files updated to release 17

4. CI workflow

- removed Java 8 & 11 from the test matrix (kept their JDK install steps for toolchain tests)
- merged the two separate test steps into one 
- replaced stCarolas/setup-maven@v4.5 / Maven 3.9.9 with stCarolas/setup-maven@v5.1 / Maven 4.0.0-rc-6