### PR TITLE
Fixed misleading expansion variable log message in ci.common- #532

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         RUNTIME: [ol, wlp]
-        RUNTIME_VERSION: [25.0.0.12]
+        RUNTIME_VERSION: [26.0.0.6]
         java: [25, 21, 17, 11, 8]
         exclude:
           - java: 8
@@ -135,7 +135,7 @@ jobs:
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         RUNTIME: [ol, wlp]
-        RUNTIME_VERSION: [ 25.0.0.12 ]
+        RUNTIME_VERSION: [ 26.0.0.6 ]
         java: [ 25, 21, 17, 11, 8 ]
         exclude:
           - java: 8

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -98,7 +98,8 @@ jobs:
       - name: Checkout ci.common
         uses: actions/checkout@v3
         with:
-          repository: OpenLiberty/ci.common
+          repository: sajeerzeji/ci.common
+          ref: fix/GHMVN2076-Message_update
           path: ci.common
       - name: Checkout ci.ant
         uses: actions/checkout@v3
@@ -206,7 +207,7 @@ jobs:
       - name: Clone ci.ant and ci.common repos to github.workspace
         run: |
           echo ${{github.workspace}}
-          git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common
+          git clone https://github.com/sajeerzeji/ci.common.git --branch fix/GHMVN2076-Message_update --single-branch ${{github.workspace}}/ci.common
           git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -98,8 +98,7 @@ jobs:
       - name: Checkout ci.common
         uses: actions/checkout@v3
         with:
-          repository: sajeerzeji/ci.common
-          ref: fix/GHMVN2076-Message_update
+          repository: OpenLiberty/ci.common
           path: ci.common
       - name: Checkout ci.ant
         uses: actions/checkout@v3
@@ -207,7 +206,7 @@ jobs:
       - name: Clone ci.ant and ci.common repos to github.workspace
         run: |
           echo ${{github.workspace}}
-          git clone https://github.com/sajeerzeji/ci.common.git --branch fix/GHMVN2076-Message_update --single-branch ${{github.workspace}}/ci.common
+          git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common
           git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>io.openliberty.tools</groupId>
             <artifactId>ci.common</artifactId>
-            <version>1.8.42</version>
+            <version>1.8.43-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>io.openliberty.tools</groupId>
             <artifactId>ci.common</artifactId>
-            <version>1.8.43-SNAPSHOT</version>
+            <version>1.8.43</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/liberty-maven-plugin/src/it/toolchain-java-warning-server-env-custom-file-it/src/test/java/net/wasdev/wlp/maven/test/app/ToolchainTest.java
+++ b/liberty-maven-plugin/src/it/toolchain-java-warning-server-env-custom-file-it/src/test/java/net/wasdev/wlp/maven/test/app/ToolchainTest.java
@@ -54,11 +54,11 @@ public class ToolchainTest {
         Assert.assertTrue(buildLog.exists());
         String os = System.getProperty("os.name");
         if (os != null && os.toLowerCase().startsWith("windows")) {
-            Assert.assertTrue("Did not find variable expansion message in build.log", logContainsMessage(buildLog, "Resolved environment variable \"EXP_VAR\" in path \"!EXP_VAR!_!EXP_VAR3!\" to \"TEST_WINDOWS\""));
-            Assert.assertTrue("Did not find second variable expansion message in build.log", logContainsMessage(buildLog, "Resolved environment variable \"EXP_VAR3\" in path \"!EXP_VAR!_!EXP_VAR3!\" to \"TEST_WINDOWS\""));
+            Assert.assertTrue("Did not find variable expansion message in build.log", logContainsMessage(buildLog, "Resolved environment variable \"EXP_VAR\" in path \"!EXP_VAR!_!EXP_VAR3!\" to \"TEST\""));
+            Assert.assertTrue("Did not find second variable expansion message in build.log", logContainsMessage(buildLog, "Resolved environment variable \"EXP_VAR3\" in path \"!EXP_VAR!_!EXP_VAR3!\" to \"WINDOWS\""));
         } else {
-            Assert.assertTrue("Did not find variable expansion message in build.log", logContainsMessage(buildLog, "Resolved environment variable \"EXP_VAR\" in path \"${EXP_VAR}_${EXP_VAR2}\" to \"TEST_UNIX\""));
-            Assert.assertTrue("Did not find second variable expansion message in build.log", logContainsMessage(buildLog, "Resolved environment variable \"EXP_VAR2\" in path \"${EXP_VAR}_${EXP_VAR2}\" to \"TEST_UNIX\""));
+            Assert.assertTrue("Did not find variable expansion message in build.log", logContainsMessage(buildLog, "Resolved environment variable \"EXP_VAR\" in path \"${EXP_VAR}_${EXP_VAR2}\" to \"TEST\""));
+            Assert.assertTrue("Did not find second variable expansion message in build.log", logContainsMessage(buildLog, "Resolved environment variable \"EXP_VAR2\" in path \"${EXP_VAR}_${EXP_VAR2}\" to \"UNIX\""));
         }
 
     }

--- a/liberty-maven-plugin/src/it/toolchain-java-warning-server-env-custom-file-it/src/test/java/net/wasdev/wlp/maven/test/app/ToolchainTest.java
+++ b/liberty-maven-plugin/src/it/toolchain-java-warning-server-env-custom-file-it/src/test/java/net/wasdev/wlp/maven/test/app/ToolchainTest.java
@@ -54,11 +54,11 @@ public class ToolchainTest {
         Assert.assertTrue(buildLog.exists());
         String os = System.getProperty("os.name");
         if (os != null && os.toLowerCase().startsWith("windows")) {
-            Assert.assertTrue("Did not find variable expansion message in build.log", logContainsMessage(buildLog, "Resolving Property EXP_VAR for expression !EXP_VAR!_!EXP_VAR3!. Resolved expression value is TEST"));
-            Assert.assertTrue("Did not find second variable expansion message in build.log", logContainsMessage(buildLog, "Resolving Property EXP_VAR3 for expression !EXP_VAR!_!EXP_VAR3!. Resolved expression value is TEST_WINDOWS"));
-        }else {
-            Assert.assertTrue("Did not find variable expansion message in build.log", logContainsMessage(buildLog, "Resolving Property EXP_VAR for expression ${EXP_VAR}_${EXP_VAR2}. Resolved expression value is TEST"));
-            Assert.assertTrue("Did not find second variable expansion message in build.log", logContainsMessage(buildLog, "Resolving Property EXP_VAR2 for expression ${EXP_VAR}_${EXP_VAR2}. Resolved expression value is TEST_UNIX"));
+            Assert.assertTrue("Did not find variable expansion message in build.log", logContainsMessage(buildLog, "Resolved environment variable \"EXP_VAR\" in path \"!EXP_VAR!_!EXP_VAR3!\" to \"TEST_WINDOWS\""));
+            Assert.assertTrue("Did not find second variable expansion message in build.log", logContainsMessage(buildLog, "Resolved environment variable \"EXP_VAR3\" in path \"!EXP_VAR!_!EXP_VAR3!\" to \"TEST_WINDOWS\""));
+        } else {
+            Assert.assertTrue("Did not find variable expansion message in build.log", logContainsMessage(buildLog, "Resolved environment variable \"EXP_VAR\" in path \"${EXP_VAR}_${EXP_VAR2}\" to \"TEST_UNIX\""));
+            Assert.assertTrue("Did not find second variable expansion message in build.log", logContainsMessage(buildLog, "Resolved environment variable \"EXP_VAR2\" in path \"${EXP_VAR}_${EXP_VAR2}\" to \"TEST_UNIX\""));
         }
 
     }

--- a/liberty-maven-plugin/src/it/toolchain-java-warning-server-env-custom-file-it/src/test/java/net/wasdev/wlp/maven/test/app/ToolchainTest.java
+++ b/liberty-maven-plugin/src/it/toolchain-java-warning-server-env-custom-file-it/src/test/java/net/wasdev/wlp/maven/test/app/ToolchainTest.java
@@ -56,9 +56,11 @@ public class ToolchainTest {
         if (os != null && os.toLowerCase().startsWith("windows")) {
             Assert.assertTrue("Did not find variable expansion message in build.log", logContainsMessage(buildLog, "Resolved environment variable \"EXP_VAR\" in path \"!EXP_VAR!_!EXP_VAR3!\" to \"TEST\""));
             Assert.assertTrue("Did not find second variable expansion message in build.log", logContainsMessage(buildLog, "Resolved environment variable \"EXP_VAR3\" in path \"!EXP_VAR!_!EXP_VAR3!\" to \"WINDOWS\""));
+            Assert.assertTrue("Did not find complete resolved value log message in build.log", logContainsMessage(buildLog, "Resolved path \"!EXP_VAR!_!EXP_VAR3!\" to \"TEST_WINDOWS\""));
         } else {
             Assert.assertTrue("Did not find variable expansion message in build.log", logContainsMessage(buildLog, "Resolved environment variable \"EXP_VAR\" in path \"${EXP_VAR}_${EXP_VAR2}\" to \"TEST\""));
             Assert.assertTrue("Did not find second variable expansion message in build.log", logContainsMessage(buildLog, "Resolved environment variable \"EXP_VAR2\" in path \"${EXP_VAR}_${EXP_VAR2}\" to \"UNIX\""));
+            Assert.assertTrue("Did not find complete resolved value log message in build.log", logContainsMessage(buildLog, "Resolved path \"${EXP_VAR}_${EXP_VAR2}\" to \"TEST_UNIX\""));
         }
 
     }


### PR DESCRIPTION
Fixes #2076 

Reference: https://github.com/OpenLiberty/ci.maven/issues/2076#issuecomment-5191485848

In ci.common, moved the log call to after the full string is assembled, so the complete resolved path is shown, and updates the message format to clearly state which variable was expanded, the original expression it appeared in, and the fully resolved result. The corresponding IT assertions in ci.maven and ci.gradle are updated to match the new message format.