### PR TITLE
Fixed IT subprocess Maven resolution to use the active build's Maven binary

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [ main ]
+    branches: [ main, maven_4_rc_6 ]
 
 env:
   # server-config-props-it fix

--- a/liberty-maven-plugin/src/it/dev-container-it/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-container-it/pom.xml
@@ -80,6 +80,8 @@
                     <systemPropertyVariables>
                         <mavenPluginVersion>@pom.version@</mavenPluginVersion>
                         <runtimeVersion>${runtimeVersion}</runtimeVersion>
+                        <maven.home>${maven.home}</maven.home>
+
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>

--- a/liberty-maven-plugin/src/it/dev-container-it/src/test/java/net/wasdev/wlp/test/it/BaseDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-container-it/src/test/java/net/wasdev/wlp/test/it/BaseDevTest.java
@@ -92,7 +92,7 @@ public class BaseDevTest {
    }
 
    protected static void startProcess(String params, boolean isDevMode) throws IOException, InterruptedException, FileNotFoundException {
-      startProcess(params, isDevMode, "mvn liberty:");
+      startProcess(params, isDevMode, getMvnBin() + " liberty:");
    }
 
    protected static void startProcess(String params, boolean isDevMode, String mavenPluginCommand) throws IOException, InterruptedException, FileNotFoundException {
@@ -230,6 +230,23 @@ public class BaseDevTest {
             assertTrue(getLogTail(), verifyLogMessageExists("CWWKE0036I", 20000, ++serverStoppedOccurrences));
          }
       }
+   }
+
+   /**
+    * Returns the absolute path to the mvn executable that is running this build,
+    * derived from the {@code maven.home} system property injected by the Maven
+    * Invoker Plugin. Falls back to the plain {@code mvn} command (relies on PATH)
+    * if the property is not set, which preserves behaviour when tests are run
+    * directly outside of the invoker.
+    */
+   protected static String getMvnBin() {
+      String mavenHome = System.getProperty("maven.home");
+      if (mavenHome != null && !mavenHome.isEmpty()) {
+         String os = System.getProperty("os.name");
+         String cmd = (os != null && os.toLowerCase().startsWith("windows")) ? "mvn.cmd" : "mvn";
+         return new File(mavenHome, "bin/" + cmd).getAbsolutePath();
+      }
+      return "mvn";
    }
 
    protected static ProcessBuilder buildProcess(String processCommand) {

--- a/liberty-maven-plugin/src/it/dev-it/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/pom.xml
@@ -68,6 +68,7 @@
                     <systemPropertyVariables>
                         <mavenPluginVersion>@pom.version@</mavenPluginVersion>
                         <runtimeVersion>${runtimeVersion}</runtimeVersion>
+                        <maven.home>${maven.home}</maven.home>
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseDevTest.java
@@ -155,7 +155,7 @@ public class BaseDevTest {
    }
 
    protected static void startProcess(String params, boolean isDevMode) throws IOException, InterruptedException, FileNotFoundException {
-      startProcess(params, isDevMode, "mvn liberty:");
+      startProcess(params, isDevMode, getMvnBin() + " liberty:");
    }
 
    protected static void startProcess(String params, boolean isDevMode, String mavenPluginCommand) throws IOException, InterruptedException, FileNotFoundException {
@@ -402,6 +402,23 @@ public class BaseDevTest {
          br.close();
       }
       return occurrences;
+   }
+
+   /**
+    * Returns the absolute path to the mvn executable that is running this build,
+    * derived from the {@code maven.home} system property injected by the Maven
+    * Invoker Plugin. Falls back to the plain {@code mvn} command (relies on PATH)
+    * if the property is not set, which preserves behaviour when tests are run
+    * directly outside of the invoker.
+    */
+   protected static String getMvnBin() {
+      String mavenHome = System.getProperty("maven.home");
+      if (mavenHome != null && !mavenHome.isEmpty()) {
+         String os = System.getProperty("os.name");
+         String cmd = (os != null && os.toLowerCase().startsWith("windows")) ? "mvn.cmd" : "mvn";
+         return new File(mavenHome, "bin/" + cmd).getAbsolutePath();
+      }
+      return "mvn";
    }
 
    protected static ProcessBuilder buildProcess(String processCommand) {

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
@@ -65,7 +65,7 @@ public class BaseMultiModuleTest extends BaseDevTest {
    }
 
    protected static void run(String params, boolean devMode) throws Exception {
-      startProcess(params, devMode, "mvn io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":");
+      startProcess(params, devMode, getMvnBin() + " io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":");
    }
 
    private static void replaceVersion(File dir) throws IOException {

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevToolchainTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/DevToolchainTest.java
@@ -20,7 +20,7 @@ public class DevToolchainTest extends BaseDevTest {
                                                     "<!-- ADDITIONAL_CONFIGURATION -->";
             replaceString(additionalConfigMarker, additionalConfigReplacement, pom);
 
-            startProcess(null, true, "mvn liberty:");
+            startProcess(null, true, getMvnBin() + " liberty:");
 
             assertTrue(verifyLogMessageExists("Maven compiler plugin is not configured with a jdkToolchain. Using Liberty Maven Plugin jdkToolchain configuration for Java compiler options.", 120000));
             // basic-dev-project uses <maven.compiler.release>, so DevMojo takes the release branch
@@ -51,7 +51,7 @@ public class DevToolchainTest extends BaseDevTest {
     public void noToolchainConfigurationDoesNotEmitToolchainMessages() throws Exception {
         setUpBeforeClass(null, "../resources/basic-dev-project", true, false, null, null);
         try {
-            startProcess(null, true, "mvn liberty:");
+            startProcess(null, true, getMvnBin() + " liberty:");
 
             assertTrue(verifyLogMessageDoesNotExist(
                     "Maven compiler plugin is not configured with a jdkToolchain. Using Liberty Maven Plugin jdkToolchain configuration for Java compiler options.",
@@ -95,7 +95,7 @@ public class DevToolchainTest extends BaseDevTest {
                                                 "</plugins>";
             replaceString(pluginsEndMarker, compilerPluginReplacement, pom);
 
-            startProcess(null, true, "mvn liberty:");
+            startProcess(null, true, getMvnBin() + " liberty:");
 
             assertTrue(verifyLogMessageExists("Liberty Maven Plugin jdkToolchain configuration matches the Maven Compiler Plugin jdkToolchain configuration: version 11.", 120000));
         } finally {
@@ -131,7 +131,7 @@ public class DevToolchainTest extends BaseDevTest {
                                                 "   </plugins>";
             replaceString(pluginsEndMarker, compilerPluginReplacement, pom);
 
-            startProcess(null, true, "mvn liberty:");
+            startProcess(null, true, getMvnBin() + " liberty:");
 
             assertTrue(verifyLogMessageExists("Liberty Maven Plugin jdkToolchain configuration (version 11) does not match the Maven Compiler Plugin jdkToolchain configuration (version 8). The Liberty Maven Plugin jdkToolchain configuration will be used for compilation.", 120000));
         } finally {
@@ -150,7 +150,7 @@ public class DevToolchainTest extends BaseDevTest {
                                                 "<!-- ADDITIONAL_CONFIGURATION -->";
             replaceString(additionalConfigMarker, additionalConfigReplacement, pom);
 
-            startProcess(null, true, "mvn -X liberty:");
+            startProcess(null, true, getMvnBin() + " -X liberty:");
 
             assertTrue(verifyLogMessageExists("maven-surefire-plugin is not configured with a jdkToolchain. Using Liberty Maven Plugin jdkToolchain configuration for test execution.", 120000));
         } finally {
@@ -183,7 +183,7 @@ public class DevToolchainTest extends BaseDevTest {
                                                "        </configuration>";
             replaceString(surefirePluginMarker, surefirePluginReplacement, pom);
 
-            startProcess(null, true, "mvn -X liberty:");
+            startProcess(null, true, getMvnBin() + " -X liberty:");
 
             assertTrue(verifyLogMessageExists("Liberty Maven Plugin jdkToolchain configuration matches the maven-surefire-plugin jdkToolchain configuration: version 11.", 120000));
         } finally {
@@ -216,7 +216,7 @@ public class DevToolchainTest extends BaseDevTest {
                                                "        </configuration>";
             replaceString(surefirePluginMarker, surefirePluginReplacement, pom);
 
-            startProcess(null, true, "mvn -X liberty:");
+            startProcess(null, true, getMvnBin() + " -X liberty:");
 
             assertTrue(verifyLogMessageExists("Liberty Maven Plugin jdkToolchain configuration (version 11) does not match the maven-surefire-plugin jdkToolchain configuration (version 8). The Liberty Maven Plugin jdkToolchain configuration will be used for test execution.", 120000));
         } finally {

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleM2InstalledTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleM2InstalledTest.java
@@ -40,7 +40,7 @@ public class MultiModuleM2InstalledTest extends BaseMultiModuleTest {
    public void purgeUpstreamSourcePart_DevMode_Test() throws Exception {
 
       // install everything to m2
-      runCommand("mvn install");
+      runCommand(getMvnBin() + " install");
 
       // ensure class was compiled
       File targetClass = new File(tempProj, "jar/target/classes/io/openliberty/guides/multimodules/lib/Converter.class");
@@ -51,11 +51,11 @@ public class MultiModuleM2InstalledTest extends BaseMultiModuleTest {
       assertTrue(srcClass.delete());
 
       // clean targets
-      runCommand("mvn clean");
+      runCommand(getMvnBin() + " clean");
 
       // dev mode should purge the jar module from m2, so that the war module will show a failure due to the missing dependency.
       // i.e. it should not find the jar dependency from m2
-      startProcess(null, true, "mvn io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":", false);
+      startProcess(null, true, getMvnBin() + " io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":", false);
       
       assertTrue(getLogTail(logFile), verifyLogMessageExists("package io.openliberty.guides.multimodules.lib does not exist", 25000));
       

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunInstallEarTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunInstallEarTest.java
@@ -84,7 +84,7 @@ public class MultiModuleRunInstallEarTest extends BaseMultiModuleTest {
    }
 
    private static void runMvnInstallEar() throws Exception {
-      StringBuilder command = new StringBuilder("mvn install -pl ../ear -am");
+      StringBuilder command = new StringBuilder(getMvnBin() + " install -pl ../ear -am");
       ProcessBuilder builder = buildProcess(command.toString());
 
       builder.redirectOutput(logFile);

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunM2InstalledTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRunM2InstalledTest.java
@@ -40,7 +40,7 @@ public class MultiModuleRunM2InstalledTest extends BaseMultiModuleTest {
    public void purgeUpstreamSourcePart_LibertyRun_Test() throws Exception {
 
       // install everything to m2
-      runCommand("mvn install");
+      runCommand(getMvnBin() + " install");
 
       // ensure class was compiled
       File targetClass = new File(tempProj, "jar/target/classes/io/openliberty/guides/multimodules/lib/Converter.class");
@@ -51,11 +51,11 @@ public class MultiModuleRunM2InstalledTest extends BaseMultiModuleTest {
       assertTrue(srcClass.delete());
 
       // clean targets
-      runCommand("mvn clean");
+      runCommand(getMvnBin() + " clean");
 
       // run goal should purge the jar module from m2, so that the war module will show a failure due to the missing dependency.
       // i.e. it should not find the jar dependency from m2
-      startProcess(null, false, "mvn io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":", false);
+      startProcess(null, false, getMvnBin() + " io.openliberty.tools:liberty-maven-plugin:"+System.getProperty("mavenPluginVersion")+":", false);
       
       assertTrue(getLogTail(logFile), verifyLogMessageExists("package io.openliberty.guides.multimodules.lib does not exist", 25000));
       

--- a/liberty-maven-plugin/src/it/dev-skip-install-feature-it/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-skip-install-feature-it/pom.xml
@@ -89,6 +89,8 @@
                     <systemPropertyVariables>
                         <mavenPluginVersion>@pom.version@</mavenPluginVersion>
                         <runtimeVersion>${runtimeVersion}</runtimeVersion>
+                        <maven.home>${maven.home}</maven.home>
+
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>

--- a/liberty-maven-plugin/src/it/dev-skip-install-feature-it/src/test/java/net/wasdev/wlp/test/it/BaseDevTest.java
+++ b/liberty-maven-plugin/src/it/dev-skip-install-feature-it/src/test/java/net/wasdev/wlp/test/it/BaseDevTest.java
@@ -92,7 +92,7 @@ public class BaseDevTest {
    }
 
    protected static void startProcess(String params, boolean isDevMode) throws IOException, InterruptedException, FileNotFoundException {
-      startProcess(params, isDevMode, "mvn liberty:");
+      startProcess(params, isDevMode, getMvnBin() + " liberty:");
    }
 
    protected static void startProcess(String params, boolean isDevMode, String mavenPluginCommand) throws IOException, InterruptedException, FileNotFoundException {
@@ -230,6 +230,23 @@ public class BaseDevTest {
             assertTrue(getLogTail(), verifyLogMessageExists("CWWKE0036I", 20000, ++serverStoppedOccurrences));
          }
       }
+   }
+
+   /**
+    * Returns the absolute path to the mvn executable that is running this build,
+    * derived from the {@code maven.home} system property injected by the Maven
+    * Invoker Plugin. Falls back to the plain {@code mvn} command (relies on PATH)
+    * if the property is not set, which preserves behaviour when tests are run
+    * directly outside of the invoker.
+    */
+   protected static String getMvnBin() {
+      String mavenHome = System.getProperty("maven.home");
+      if (mavenHome != null && !mavenHome.isEmpty()) {
+         String os = System.getProperty("os.name");
+         String cmd = (os != null && os.toLowerCase().startsWith("windows")) ? "mvn.cmd" : "mvn";
+         return new File(mavenHome, "bin/" + cmd).getAbsolutePath();
+      }
+      return "mvn";
    }
 
    protected static ProcessBuilder buildProcess(String processCommand) {

--- a/liberty-maven-plugin/src/it/feature-generator-it/pom.xml
+++ b/liberty-maven-plugin/src/it/feature-generator-it/pom.xml
@@ -69,6 +69,8 @@
                         <mavenPluginVersion>@pom.version@</mavenPluginVersion>
                         <runtimeVersion>${runtimeVersion}</runtimeVersion>
                         <generatorVersion>${featureGenJar.version}</generatorVersion>
+                        <maven.home>${maven.home}</maven.home>
+
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>

--- a/liberty-maven-plugin/src/it/feature-generator-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseGeneratorTest.java
+++ b/liberty-maven-plugin/src/it/feature-generator-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseGeneratorTest.java
@@ -185,7 +185,7 @@ public class BaseGeneratorTest {
      * @param command - command to run
      */
     protected static void runProcess(String processCommand) throws IOException, InterruptedException {
-        StringBuilder command = new StringBuilder("mvn ").append(processCommand);
+        StringBuilder command = new StringBuilder(getMvnBin()).append(" ").append(processCommand);
         ProcessBuilder builder = buildProcess(command.toString());
         builder.redirectOutput(logFile);
         builder.redirectError(logFile);
@@ -202,6 +202,23 @@ public class BaseGeneratorTest {
         Path path = logFile.toPath();
         Charset charset = StandardCharsets.UTF_8;
         processOutput = new String(Files.readAllBytes(path), charset);
+    }
+
+    /**
+     * Returns the absolute path to the mvn executable that is running this build,
+     * derived from the {@code maven.home} system property injected by the Maven
+     * Invoker Plugin. Falls back to the plain {@code mvn} command (relies on PATH)
+     * if the property is not set, which preserves behaviour when tests are run
+     * directly outside of the invoker.
+     */
+    protected static String getMvnBin() {
+        String mavenHome = System.getProperty("maven.home");
+        if (mavenHome != null && !mavenHome.isEmpty()) {
+            String os = System.getProperty("os.name");
+            String cmd = (os != null && os.toLowerCase().startsWith("windows")) ? "mvn.cmd" : "mvn";
+            return new File(mavenHome, "bin/" + cmd).getAbsolutePath();
+        }
+        return "mvn";
     }
 
     protected static ProcessBuilder buildProcess(String processCommand) {

--- a/liberty-maven-plugin/src/it/generate-features-it/pom.xml
+++ b/liberty-maven-plugin/src/it/generate-features-it/pom.xml
@@ -71,6 +71,7 @@
                     <systemPropertyVariables>
                         <mavenPluginVersion>@pom.version@</mavenPluginVersion>
                         <runtimeVersion>${runtimeVersion}</runtimeVersion>
+                        <maven.home>${maven.home}</maven.home>
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>

--- a/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseGenerateFeaturesTest.java
+++ b/liberty-maven-plugin/src/it/generate-features-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseGenerateFeaturesTest.java
@@ -109,7 +109,7 @@ public class BaseGenerateFeaturesTest {
      * @param command - command to run
      */
     protected static void runProcess(String processCommand) throws IOException, InterruptedException {
-        StringBuilder command = new StringBuilder("mvn " + processCommand);
+        StringBuilder command = new StringBuilder(getMvnBin() + " " + processCommand);
         ProcessBuilder builder = buildProcess(command.toString());
         builder.redirectOutput(logFile);
         builder.redirectError(logFile);
@@ -129,6 +129,23 @@ public class BaseGenerateFeaturesTest {
         Path path = logFile.toPath();
         Charset charset = StandardCharsets.UTF_8;
         processOutput = new String(Files.readAllBytes(path), charset);
+    }
+
+    /**
+     * Returns the absolute path to the mvn executable that is running this build,
+     * derived from the {@code maven.home} system property injected by the Maven
+     * Invoker Plugin. Falls back to the plain {@code mvn} command (relies on PATH)
+     * if the property is not set, which preserves behaviour when tests are run
+     * directly outside of the invoker.
+     */
+    protected static String getMvnBin() {
+        String mavenHome = System.getProperty("maven.home");
+        if (mavenHome != null && !mavenHome.isEmpty()) {
+            String os = System.getProperty("os.name");
+            String cmd = (os != null && os.toLowerCase().startsWith("windows")) ? "mvn.cmd" : "mvn";
+            return new File(mavenHome, "bin/" + cmd).getAbsolutePath();
+        }
+        return "mvn";
     }
 
     protected static ProcessBuilder buildProcess(String processCommand) {

--- a/liberty-maven-plugin/src/it/server-config-props-it/src/test/java/net/wasdev/wlp/test/servlet/it/ServerConfigPropertiesTest.java
+++ b/liberty-maven-plugin/src/it/server-config-props-it/src/test/java/net/wasdev/wlp/test/servlet/it/ServerConfigPropertiesTest.java
@@ -92,7 +92,7 @@ public class ServerConfigPropertiesTest {
             Assert.assertTrue("Server not created successfully.", createResult.getExitCode() == 0);
 
             //Start server in dev mode with generate-features disabled
-            ProcessBuilder builder = buildProcess(logFile, "mvn liberty:dev");
+            ProcessBuilder builder = buildProcess(logFile, getMvnBin() + " liberty:dev");
             Process process = builder.start();
             OutputStream stdin = process.getOutputStream();
       
@@ -138,12 +138,29 @@ public class ServerConfigPropertiesTest {
         Assert.assertTrue("server-config-props-it.war.xml was not installed correctly", appMessage.endsWith("server-config-props-it.war.xml."));
     }
 
+    /**
+     * Returns the absolute path to the mvn executable that is running this build,
+     * derived from the {@code maven.home} system property injected by the Maven
+     * Invoker Plugin. Falls back to the plain {@code mvn} command (relies on PATH)
+     * if the property is not set, which preserves behaviour when tests are run
+     * directly outside of the invoker.
+     */
+    private static String getMvnBin() {
+        String mavenHome = System.getProperty("maven.home");
+        if (mavenHome != null && !mavenHome.isEmpty()) {
+            String os = System.getProperty("os.name");
+            String cmd = (os != null && os.toLowerCase().startsWith("windows")) ? "mvn.cmd" : "mvn";
+            return new File(mavenHome, "bin/" + cmd).getAbsolutePath();
+        }
+        return "mvn";
+    }
+
     private ProcessBuilder buildProcess(File logFile, String processCommand) throws Exception {
         ProcessBuilder builder = new ProcessBuilder();
         builder.redirectOutput(logFile);
         builder.redirectError(logFile);
         builder.directory(new File(".."));
-  
+
         String os = System.getProperty("os.name");
         if (os != null && os.toLowerCase().startsWith("windows")) {
            builder.command("CMD", "/C", processCommand);

--- a/liberty-maven-plugin/src/it/toolchain-run-it/pom.xml
+++ b/liberty-maven-plugin/src/it/toolchain-run-it/pom.xml
@@ -72,6 +72,7 @@
                     <systemPropertyVariables>
                         <mavenPluginVersion>@pom.version@</mavenPluginVersion>
                         <runtimeVersion>${runtimeVersion}</runtimeVersion>
+                        <maven.home>${maven.home}</maven.home>
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>

--- a/liberty-maven-plugin/src/it/toolchain-run-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseToolchainTest.java
+++ b/liberty-maven-plugin/src/it/toolchain-run-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseToolchainTest.java
@@ -98,7 +98,7 @@ public class BaseToolchainTest {
         replaceVersion();
         // if you want some custom action to be executed
         customActionBeforeProcessStart.run();
-        startProcess(params, "mvn liberty:", goal, logFile, logErrorFile);
+        startProcess(params, getMvnBin() + " liberty:", goal, logFile, logErrorFile);
     }
 
     protected static void startProcess(String params, String mavenPluginCommand, String goal, File logFile, File logErrorFile) throws IOException {
@@ -209,7 +209,7 @@ public class BaseToolchainTest {
 
         stopProcess(isDevMode, checkForShutdownMessage);
         //calling stop liberty for making sure run/dev is stopped
-        startProcess(null, "mvn liberty:", "stop", new File(basicDevProj, "logFileStop.txt"),  new File(basicDevProj, "logFileStopError.txt"));
+        startProcess(null, getMvnBin() + " liberty:", "stop", new File(basicDevProj, "logFileStop.txt"),  new File(basicDevProj, "logFileStopError.txt"));
         process.waitFor(10,TimeUnit.SECONDS);
         destroyProcess();
         if (tempProj != null && tempProj.exists()) {
@@ -255,6 +255,23 @@ public class BaseToolchainTest {
             br.close();
         }
         return false;
+    }
+
+    /**
+     * Returns the absolute path to the mvn executable that is running this build,
+     * derived from the {@code maven.home} system property injected by the Maven
+     * Invoker Plugin. Falls back to the plain {@code mvn} command (relies on PATH)
+     * if the property is not set, which preserves behaviour when tests are run
+     * directly outside of the invoker.
+     */
+    protected static String getMvnBin() {
+        String mavenHome = System.getProperty("maven.home");
+        if (mavenHome != null && !mavenHome.isEmpty()) {
+            String os = System.getProperty("os.name");
+            String cmd = (os != null && os.toLowerCase().startsWith("windows")) ? "mvn.cmd" : "mvn";
+            return new File(mavenHome, "bin/" + cmd).getAbsolutePath();
+        }
+        return "mvn";
     }
 
     protected static ProcessBuilder buildProcess(String processCommand) {


### PR DESCRIPTION
Integration tests that hardcoded mvn as a subprocess command relied on path resolution, which is not guaranteed to match the Maven binary that launched the build. This could cause tests to invoke a different Maven version, for example when using the Maven wrapper or when Maven is installed via the CI setup-maven step outside of path. This fixes the issue by forwarding maven.home from the Invoker Plugin into each IT's JVM and resolving the absolute path to the correct mvn/mvn.cmd executable at runtime. A path based fallback is retained so tests can still be run standalone outside of the invoker. Changes are limited entirely to IT test code and IT POM configurations.

Behaviour will be:

CI resolves to the Maven installed by setup-maven
Local with mvn resolves to the locally installed Maven
Local with ./mvnw resolves to the Maven wrapper distribution