### PR TITLE
Fix liberty:dev dependency resolution failure for rar-packaged upstream modules

### DIFF
--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multiModuleTestCases.md
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/multiModuleTestCases.md
@@ -14,6 +14,17 @@ multipleLibertyModules-skip-conflicts)  pom, ear1+war+jar, ear2+war+jar, jar2
 sample.ejb) pom, ear+war+ejb
 - Based on https://github.com/WASdev/sample.ejb
 
+sample.rar) pom, rar-ear+rar-war+rar-ra
+- Reproduces the bug where liberty:dev failed on a multi-module project with a
+  rar-packaged upstream module: dev mode only ran compile on rar-ra, leaving the
+  artifact unresolvable by the downstream EAR (CWWKM/dependency resolution failure).
+- Fix: DevMojo adds a rar branch that calls getOrCreateRarArtifact(), mirroring
+  the existing EAR handling, pointing the in-memory artifact reference at target/
+  so downstream resolution succeeds without a prior mvn install.
+- Server info in rar-ear module
+- Main pom: ./pom.xml
+- Tests: MultiModuleRarUpstreamTest (cold start), MultiModuleRarPreInstalledTest (pre-installed)
+
 a)  pom, ear+war+jar
 - Server info in ear module
 - Main pom: ./pom.xml

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.rar/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.rar/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>sample</groupId>
+    <artifactId>rar</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <name>Sample RAR Multi-Module Project</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <modules>
+        <module>rar-ra</module>
+        <module>rar-war</module>
+        <module>rar-ear</module>
+    </modules>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.rar/rar-ear/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.rar/rar-ear/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>sample</groupId>
+        <artifactId>rar</artifactId>
+        <version>1.0</version>
+    </parent>
+
+    <artifactId>rar-ear</artifactId>
+    <packaging>ear</packaging>
+
+    <name>EAR Module</name>
+
+    <dependencies>
+        <!-- The rar dependency must be resolved from the local Maven repository.
+             This is the dependency that triggers the bug: without the fix in
+             DevMojo.java, dev mode only compiles the rar-ra module and never
+             installs it, so this dependency resolution fails. -->
+        <dependency>
+            <groupId>sample</groupId>
+            <artifactId>rar-ra</artifactId>
+            <version>1.0</version>
+            <type>rar</type>
+        </dependency>
+        <dependency>
+            <groupId>sample</groupId>
+            <artifactId>rar-war</artifactId>
+            <version>1.0</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <version>7</version>
+                    <generateApplicationXml>true</generateApplicationXml>
+                    <modules>
+                        <webModule>
+                            <groupId>sample</groupId>
+                            <artifactId>rar-war</artifactId>
+                            <bundleFileName>rar-war.war</bundleFileName>
+                            <contextRoot>/rar-war</contextRoot>
+                        </webModule>
+                        <rarModule>
+                            <groupId>sample</groupId>
+                            <artifactId>rar-ra</artifactId>
+                            <bundleFileName>rar-ra.rar</bundleFileName>
+                        </rarModule>
+                    </modules>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>SUB_VERSION</version>
+                <configuration>
+                    <serverName>rarServer</serverName>
+                    <configFile>src/main/liberty/config/server.xml</configFile>
+                    <appsDirectory>apps</appsDirectory>
+                    <looseApplication>true</looseApplication>
+                    <installAppPackages>project</installAppPackages>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.rar/rar-ear/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.rar/rar-ear/src/main/liberty/config/server.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="rar server">
+
+    <!-- Enable features -->
+    <featureManager>
+        <feature>javaee-7.0</feature>
+    </featureManager>
+
+    <keyStore password="change1me"/>
+
+    <httpEndpoint id="defaultHttpEndpoint"
+                  httpPort="9080"
+                  httpsPort="9443" />
+
+    <enterpriseApplication id="rar-ear" location="rar-ear.ear" name="rar-ear"/>
+</server>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.rar/rar-ear/src/test/java/sample/rar/it/RarEarIT.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.rar/rar-ear/src/test/java/sample/rar/it/RarEarIT.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2026.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package sample.rar.it;
+
+import static org.junit.Assert.*;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+
+public class RarEarIT {
+    private static String URL;
+
+    @BeforeClass
+    public static void init() {
+        URL = "http://localhost:9080/rar-war";
+    }
+
+    @Test
+    public void testServlet() throws Exception {
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet method = new HttpGet(URL);
+
+            try (CloseableHttpResponse response = client.execute(method)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+
+                assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
+
+                String responseBody = EntityUtils.toString(response.getEntity());
+
+                assertTrue("Unexpected response body", responseBody.contains("Hello RAR World."));
+            }
+        }
+    }
+}

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.rar/rar-ra/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.rar/rar-ra/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>sample</groupId>
+        <artifactId>rar</artifactId>
+        <version>1.0</version>
+    </parent>
+
+    <artifactId>rar-ra</artifactId>
+    <packaging>rar</packaging>
+
+    <name>RAR Module</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-rar-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.rar/rar-ra/src/main/rar/META-INF/ra.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.rar/rar-ra/src/main/rar/META-INF/ra.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<connector xmlns="http://java.sun.com/xml/ns/j2ee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee
+        http://java.sun.com/xml/ns/j2ee/connector_1_5.xsd"
+    version="1.5">
+    <display-name>Sample RAR</display-name>
+    <vendor-name>Sample</vendor-name>
+    <eis-type>Sample EIS</eis-type>
+    <resourceadapter-version>1.0</resourceadapter-version>
+    <resourceadapter/>
+</connector>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.rar/rar-war/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.rar/rar-war/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>sample</groupId>
+        <artifactId>rar</artifactId>
+        <version>1.0</version>
+    </parent>
+
+    <artifactId>rar-war</artifactId>
+    <packaging>war</packaging>
+
+    <name>WAR Module</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>7.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.4.0</version>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.rar/rar-war/src/main/java/sample/rar/web/HelloServlet.java
+++ b/liberty-maven-plugin/src/it/dev-it/resources/multi-module-projects/sample.rar/rar-war/src/main/java/sample/rar/web/HelloServlet.java
@@ -1,0 +1,20 @@
+package sample.rar.web;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/")
+public class HelloServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter writer = response.getWriter();
+        writer.println("Hello RAR World.");
+    }
+}

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/BaseMultiModuleTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright IBM Corporation 2021.
+ * (c) Copyright IBM Corporation 2021, 2026.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,9 @@ public class BaseMultiModuleTest extends BaseDevTest {
       optionalReplaceVersion(new File(tempProj, "ear2"));
       optionalReplaceVersion(new File(tempProj, "war"));
       optionalReplaceVersion(new File(tempProj, "war2"));
+      optionalReplaceVersion(new File(tempProj, "rar-ra"));
+      optionalReplaceVersion(new File(tempProj, "rar-war"));
+      optionalReplaceVersion(new File(tempProj, "rar-ear"));
    }
 
    protected static void run(String params) throws Exception {

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRarPreInstalledTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRarPreInstalledTest.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2026.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Verifies that {@code liberty:dev} starts correctly when the
+ * {@code rar}-packaged upstream module has already been installed to the local
+ * Maven repository by a prior {@code mvn install}.
+ *
+ * <p>This exercises the "artifact already exists" branch of
+ * {@code getOrCreateRarArtifact()} — the happy path where the artifact is found
+ * in {@code ~/.m2} and no in-memory redirect is needed.  It complements
+ * {@link MultiModuleRarUpstreamTest} which tests the cold-start (no prior
+ * install) path.
+ */
+public class MultiModuleRarPreInstalledTest extends BaseMultiModuleTest {
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        setUpMultiModule("sample.rar", "rar-ear", null);
+        // Pre-install the rar-ra module to ~/.m2 to simulate the "already installed"
+        // scenario described in the bug report workaround. getOrCreateRarArtifact()
+        // should detect the existing artifact and skip the in-memory redirect.
+        runCommand("mvn install -pl rar-ra -am");
+        run();
+    }
+
+    /**
+     * Verifies startup and endpoint when the RAR artifact is pre-installed.
+     * Exercises the "artifact already exists in ~/.m2" branch of
+     * {@code getOrCreateRarArtifact()}.
+     */
+    @Test
+    public void runTest() throws Exception {
+        assertTrue("Liberty server did not start when rar-ra was pre-installed. " + getLogTail(),
+                verifyLogMessageExists("CWWKF0011I:", 120000));
+
+        assertEndpointContent("http://localhost:9080/rar-war", "Hello RAR World.");
+    }
+
+    @AfterClass
+    public static void cleanUpAfterClass() throws Exception {
+        BaseDevTest.cleanUpAfterClass();
+    }
+}

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRarUpstreamTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRarUpstreamTest.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.test.dev.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Verifies that {@code liberty:dev} correctly handles a {@code rar}-packaged
+ * upstream module in a multi-module project so that the downstream EAR can
+ * resolve the artifact during its dependency resolution phase.
+ *
+ * <p>Without the fix in {@code DevMojo.java}, dev mode falls into the generic
+ * {@code else} branch for upstream modules and only runs {@code resources} +
+ * {@code compile}.  The RAR artifact is never made resolvable, so the downstream
+ * EAR's Maven dependency resolution fails with "Could not find artifact" before
+ * Liberty even starts.
+ *
+ * <p>The fix adds a dedicated {@code rar} branch in {@code doDevMode()} that
+ * calls {@code getOrCreateRarArtifact()} — mirroring the existing EAR treatment
+ * — which points the in-memory artifact reference at the module's {@code target/}
+ * directory so that downstream resolution succeeds without requiring a prior
+ * {@code mvn install}.
+ */
+public class MultiModuleRarUpstreamTest extends BaseMultiModuleTest {
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        setUpMultiModule("sample.rar", "rar-ear", null);
+        run();
+    }
+
+    /**
+     * Single sequential test that:
+     * <ol>
+     *   <li>Verifies the server started (dependency resolution on the {@code rar-ra}
+     *       artifact succeeded — the core bug fix assertion).</li>
+     *   <li>Confirms no dependency resolution error was logged.</li>
+     *   <li>Confirms the WAR inside the EAR is reachable.</li>
+     *   <li>Modifies the WAR servlet and confirms dev mode hot-reloads it —
+     *       verifying the dev mode watcher loop still functions in a project
+     *       with a {@code rar}-packaged upstream module.</li>
+     * </ol>
+     */
+    @Test
+    public void runTest() throws Exception {
+        // 1. Server must have started — proves rar-ra artifact was resolvable
+        assertTrue("Liberty server did not start. " + getLogTail(),
+                verifyLogMessageExists("CWWKF0011I:", 120000));
+
+        // 2. No dependency resolution error
+        assertFalse("Found 'Could not find artifact' in log. " + getLogTail(),
+                verifyLogMessageExists("Could not find artifact", 2000));
+        assertFalse("Found 'Could not resolve dependencies' in log. " + getLogTail(),
+                verifyLogMessageExists("Could not resolve dependencies", 2000));
+
+        // 3. WAR endpoint is live
+        assertEndpointContent("http://localhost:9080/rar-war", "Hello RAR World.");
+
+        // 4. Hot-reload: modify the WAR servlet and verify the app updates
+        modifyWarServlet();
+
+        assertEndpointContent("http://localhost:9080/rar-war", "Hello RAR World Updated.");
+    }
+
+    private static void modifyWarServlet() throws Exception {
+        int appUpdatedCount = countOccurrences("CWWKZ0003I:", logFile);
+
+        File srcFile = new File(tempProj, "rar-war/src/main/java/sample/rar/web/HelloServlet.java");
+        File targetClass = new File(tempProj, "rar-war/target/classes/sample/rar/web/HelloServlet.class");
+        assertTrue(srcFile.exists());
+        assertTrue(targetClass.exists());
+
+        long lastModified = targetClass.lastModified();
+        waitLongEnough();
+        replaceString("Hello RAR World.", "Hello RAR World Updated.", srcFile);
+
+        assertTrue(getLogTail(), verifyLogMessageExists("CWWKZ0003I:", 10000, logFile, ++appUpdatedCount));
+        assertTrue(waitForCompilation(targetClass, lastModified, 6000));
+    }
+
+    @AfterClass
+    public static void cleanUpAfterClass() throws Exception {
+        BaseDevTest.cleanUpAfterClass();
+    }
+}

--- a/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRarUpstreamTest.java
+++ b/liberty-maven-plugin/src/it/dev-it/src/test/java/net/wasdev/wlp/test/dev/it/MultiModuleRarUpstreamTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright IBM Corporation 2024.
+ * (c) Copyright IBM Corporation 2026.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/DevMojo.java
@@ -1412,6 +1412,17 @@ public class DevMojo extends LooseAppSupport {
                     getOrCreateEarArtifact(project);
                 } else if (project.getPackaging().equals("pom")) {
                     getLog().debug("Skipping compile/resources on module with pom packaging type");
+                } else if (project.getPackaging().equals("rar")) {
+                    // A rar-packaged upstream module must have its artifact available for
+                    // downstream EAR dependency resolution. Mirroring the EAR handling above,
+                    // we compile and then ensure the artifact is resolvable via getOrCreateRarArtifact.
+                    runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
+                    try {
+                        runCompileMojoLogWarningWithException("compile");
+                    } catch (MojoExecutionException e) {
+                        compileMojoError.put(project.getName(), Boolean.TRUE);
+                    }
+                    getOrCreateRarArtifact(project);
                 } else {
                     runMojo("org.apache.maven.plugins", "maven-resources-plugin", "resources");
                     try {

--- a/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/io/openliberty/tools/maven/server/StartDebugMojoSupport.java
@@ -894,6 +894,28 @@ public abstract class StartDebugMojoSupport extends ServerFeatureSupport {
         }
     }
 
+    /**
+     * Ensure the rar artifact for the given upstream module is resolvable by downstream
+     * EAR modules during dev mode.  Because the EAR is assembled as a loose application,
+     * the actual {@code .rar} file never needs to exist on disk; we only need Maven's
+     * artifact resolution to succeed.  If the artifact is not already in the local
+     * repository we point its in-memory file reference at the module's build output
+     * directory ({@code target/}) so that resolution does not fall back to
+     * {@code ~/.m2} and fail with "Could not find artifact".
+     *
+     * @param rarProject the upstream project with {@code rar} packaging
+     */
+    protected void getOrCreateRarArtifact(MavenProject rarProject) {
+        org.apache.maven.model.Dependency existingRarItem = createArtifactItem(rarProject.getGroupId(), rarProject.getArtifactId(), rarProject.getPackaging(), rarProject.getVersion());
+        try {
+            Artifact existingRarArtifact = getArtifact(existingRarItem);
+            getLog().debug("RAR artifact already exists at " + existingRarArtifact.getFile());
+        } catch (MojoExecutionException e) {
+            getLog().debug("RAR artifact not in local repository; pointing artifact file to build output directory.");
+            updateArtifactPathToOutputDirectory(rarProject);
+        }
+    }
+
     private void installEmptyEAR(MavenProject earProject) throws MojoExecutionException {
         String goal = "install-file";
         Plugin plugin = getPlugin("org.apache.maven.plugins", "maven-install-plugin");
@@ -967,8 +989,10 @@ public abstract class StartDebugMojoSupport extends ServerFeatureSupport {
      * @param artifactToUpdate
      */
     protected void updateArtifactPathToOutputDirectory(MavenProject mavenProject, Artifact artifactToUpdate) {
-        Path outputDir = null; 
-        if (artifactToUpdate.getType().equals("ear")) {
+        Path outputDir = null;
+        String type = artifactToUpdate.getType();
+        if (type.equals("ear") || type.equals("rar")) {
+            // Binary artifact types that are resolved from the build directory, not target/classes
             outputDir = Paths.get(mavenProject.getBuild().getDirectory());
         } else {
             outputDir = Paths.get(mavenProject.getBuild().getOutputDirectory());


### PR DESCRIPTION
Fixes #2096 
The fix mirrors the existing getOrCreateEarArtifact() pattern

Adds multi-module integration test sample.rar (rar-ra + rar-war + rar-ear) and MultiModuleRarUpstreamTest and MultiModuleRarPreInstalledTest to verify that liberty:dev starts successfully from a clean workspace with a rar-packaged upstream module.