### PR TITLE
Add devc non-default port and empty loose-app integration tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -98,7 +98,8 @@ jobs:
       - name: Checkout ci.common
         uses: actions/checkout@v3
         with:
-          repository: OpenLiberty/ci.common
+          repository: venmanyarun/ci.common
+          ref: devc-port-resolution
           path: ci.common
       - name: Checkout ci.ant
         uses: actions/checkout@v3
@@ -206,7 +207,7 @@ jobs:
       - name: Clone ci.ant and ci.common repos to github.workspace
         run: |
           echo ${{github.workspace}}
-          git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common
+          git clone --branch devc-port-resolution --single-branch https://github.com/venmanyarun/ci.common.git ${{github.workspace}}/ci.common
           git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5

--- a/liberty-maven-plugin/src/it/dev-container-it/resources/container-empty-looseapp-project/Containerfile
+++ b/liberty-maven-plugin/src/it/dev-container-it/resources/container-empty-looseapp-project/Containerfile
@@ -1,0 +1,12 @@
+# Start with OL runtime.
+FROM icr.io/appcafe/open-liberty:full-java11-openj9-ubi
+
+ARG VERSION=1.0
+ARG REVISION=SNAPSHOT
+
+USER root
+
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config/
+COPY --chown=1001:0 target/*.war /config/apps/
+
+USER 1001

--- a/liberty-maven-plugin/src/it/dev-container-it/resources/container-empty-looseapp-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-container-it/resources/container-empty-looseapp-project/pom.xml
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.tools.it</groupId>
+    <artifactId>container-empty-looseapp-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+
+    <!--
+        Test resource for: ci.common Issue - libertyDevc throws NullPointerException when
+        loose app XML file is empty or malformed.
+
+        The integration test (DevcEmptyLooseAppTest) pre-creates an empty placeholder file
+        at target/.libertyDevc/apps/rest.war.xml before starting liberty:dev with container flag,
+        then verifies that dev mode reaches "Liberty is running in dev mode." without printing
+        NullPointerException in the log.
+    -->
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>9.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>rest</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.2</version>
+            </plugin>
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>SUB_VERSION</version>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/liberty-maven-plugin/src/it/dev-container-it/resources/container-empty-looseapp-project/src/main/java/io/openliberty/guides/rest/SystemApplication.java
+++ b/liberty-maven-plugin/src/it/dev-container-it/resources/container-empty-looseapp-project/src/main/java/io/openliberty/guides/rest/SystemApplication.java
@@ -1,0 +1,8 @@
+package io.openliberty.guides.rest;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/api")
+public class SystemApplication extends Application {
+}

--- a/liberty-maven-plugin/src/it/dev-container-it/resources/container-empty-looseapp-project/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-container-it/resources/container-empty-looseapp-project/src/main/liberty/config/server.xml
@@ -1,0 +1,14 @@
+<server description="Empty loose-app XML test server">
+
+  <featureManager>
+      <feature>restfulWS-3.0</feature>
+  </featureManager>
+
+  <variable name="default.http.port" defaultValue="9080"/>
+  <variable name="default.https.port" defaultValue="9443"/>
+
+  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+      id="defaultHttpEndpoint" host="*" />
+
+  <webApplication location="rest.war" contextRoot="/"/>
+</server>

--- a/liberty-maven-plugin/src/it/dev-container-it/resources/container-nondefault-port-project/Containerfile
+++ b/liberty-maven-plugin/src/it/dev-container-it/resources/container-nondefault-port-project/Containerfile
@@ -1,0 +1,12 @@
+# Start with OL runtime.
+FROM icr.io/appcafe/open-liberty:full-java11-openj9-ubi
+
+ARG VERSION=1.0
+ARG REVISION=SNAPSHOT
+
+USER root
+
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config/
+COPY --chown=1001:0 target/*.war /config/apps/
+
+USER 1001

--- a/liberty-maven-plugin/src/it/dev-container-it/resources/container-nondefault-port-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-container-it/resources/container-nondefault-port-project/pom.xml
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.tools.it</groupId>
+    <artifactId>container-nondefault-port-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+
+    <!--
+        Test resource for: ci.common Issue — libertyDevc reports "Unable to retrieve locally
+        mapped port" when Liberty HTTP port is set to a non-default value via server variables.
+
+        Overrides the HTTP port to 9090 and HTTPS port to 9453 via liberty.var.* properties so
+        that they are written to configDropins/overrides/liberty-plugin-variable-config.xml.
+        The integration test (DevcNonDefaultPortTest) verifies that the container run command
+        logged by the plugin contains "-p <hostPort>:9090" (not "-p <hostPort>:9080").
+    -->
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Non-default ports — written to configDropins/overrides/liberty-plugin-variable-config.xml -->
+        <liberty.var.default.http.port>9090</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9453</liberty.var.default.https.port>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>9.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>rest</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.2</version>
+            </plugin>
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>SUB_VERSION</version>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/liberty-maven-plugin/src/it/dev-container-it/resources/container-nondefault-port-project/src/main/java/io/openliberty/guides/rest/SystemApplication.java
+++ b/liberty-maven-plugin/src/it/dev-container-it/resources/container-nondefault-port-project/src/main/java/io/openliberty/guides/rest/SystemApplication.java
@@ -1,0 +1,8 @@
+package io.openliberty.guides.rest;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/api")
+public class SystemApplication extends Application {
+}

--- a/liberty-maven-plugin/src/it/dev-container-it/resources/container-nondefault-port-project/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-container-it/resources/container-nondefault-port-project/src/main/liberty/config/server.xml
@@ -1,0 +1,21 @@
+<server description="Non-default port test server">
+
+  <featureManager>
+      <feature>restfulWS-3.0</feature>
+  </featureManager>
+
+  <!--
+    Ports are intentionally left as variable references.
+    The actual values (9090 / 9453) are injected via liberty.var.* in pom.xml,
+    which writes them to configDropins/overrides/liberty-plugin-variable-config.xml.
+    The plugin must read that file before building the container run command so
+    that it publishes -p <host>:9090 instead of the default -p <host>:9080.
+  -->
+  <variable name="default.http.port" defaultValue="9080"/>
+  <variable name="default.https.port" defaultValue="9443"/>
+
+  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+      id="defaultHttpEndpoint" host="*" />
+
+  <webApplication location="rest.war" contextRoot="/"/>
+</server>

--- a/liberty-maven-plugin/src/it/dev-container-it/src/test/java/net/wasdev/wlp/test/it/DevcEmptyLooseAppTest.java
+++ b/liberty-maven-plugin/src/it/dev-container-it/src/test/java/net/wasdev/wlp/test/it/DevcEmptyLooseAppTest.java
@@ -1,0 +1,80 @@
+package net.wasdev.wlp.test.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Integration test for ci.common fix: {@code libertyDevc} must not throw
+ * {@code NullPointerException} when the loose application XML file is empty
+ * or malformed (e.g. written as an empty placeholder before the EAR build
+ * completes).
+ *
+ * <p>Before starting container dev mode the test pre-creates an empty
+ * {@code target/.libertyDevc/apps/rest.war.xml} file to simulate the race
+ * condition described in the issue. Dev mode must reach "Liberty is running
+ * in dev mode." and the log must contain no {@code NullPointerException}.
+ */
+public class DevcEmptyLooseAppTest extends BaseDevTest {
+
+    private static final String PROJECT_ROOT = "../resources/container-empty-looseapp-project";
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        setUpBeforeClass(null, PROJECT_ROOT, true, false, null, null);
+
+        // Pre-create an empty loose-app XML placeholder to simulate the race
+        // condition where the file exists but has not been written yet.
+        File looseAppDir = new File(PROJECT_ROOT + "/target/.libertyDevc/apps");
+        looseAppDir.mkdirs();
+        File emptyLooseApp = new File(looseAppDir, "rest.war.xml");
+        try (FileWriter fw = new FileWriter(emptyLooseApp)) {
+            // intentionally empty — zero bytes
+        }
+        assertTrue("Empty loose-app placeholder must exist before starting dev mode",
+                emptyLooseApp.exists());
+        assertTrue("Empty loose-app placeholder must be zero bytes",
+                emptyLooseApp.length() == 0);
+
+        startProcess("-Dcontainer -Dliberty.dev.podman=true -DcontainerBuildTimeout=599", true);
+    }
+
+    @AfterClass
+    public static void cleanUpAfterClass() throws Exception {
+        BaseDevTest.cleanUpAfterClass();
+    }
+
+    /**
+     * Verifies that dev mode starts successfully despite the empty loose-app XML.
+     * Before the fix, a {@code NullPointerException} terminated startup immediately.
+     */
+    @Test
+    public void devcStartsWithoutNpe() throws Exception {
+        assertTrue("Dev mode must start successfully (container image built): " + getLogTail(),
+                verifyLogMessageExists("Completed building container image.", 120000));
+        assertTrue("Liberty must start in dev mode despite the empty loose-app XML: " + getLogTail(),
+                verifyLogMessageExists("Liberty is running in dev mode.", 120000));
+    }
+
+    /**
+     * Verifies that no {@code NullPointerException} was emitted during startup.
+     * This is the primary regression guard for the NPE fix.
+     */
+    @Test
+    public void noNullPointerExceptionInLog() throws Exception {
+        // Give dev mode a moment to complete startup before inspecting logs.
+        assertTrue("Dev mode must have started before checking for NPE: " + getLogTail(),
+                verifyLogMessageExists("Liberty is running in dev mode.", 120000));
+
+        assertFalse("NullPointerException must not appear in the dev mode log: " + getLogTail(),
+                readFile("NullPointerException", logFile));
+    }
+
+}

--- a/liberty-maven-plugin/src/it/dev-container-it/src/test/java/net/wasdev/wlp/test/it/DevcNonDefaultPortTest.java
+++ b/liberty-maven-plugin/src/it/dev-container-it/src/test/java/net/wasdev/wlp/test/it/DevcNonDefaultPortTest.java
@@ -1,0 +1,102 @@
+package net.wasdev.wlp.test.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Integration test for ci.common fix: {@code libertyDevc} / {@code liberty:devc} must
+ * publish the correct container port when Liberty's HTTP/HTTPS port is overridden via
+ * {@code liberty.var.*} Maven properties (written to
+ * {@code configDropins/overrides/liberty-plugin-variable-config.xml}).
+ *
+ * <p>Before the fix, {@code getContainerCommand()} always mapped the hardcoded defaults
+ * (9080 / 9443) regardless of the configured port, causing
+ * "Unable to retrieve locally mapped port" at startup for any non-default port.
+ *
+ * <p>This test project sets {@code liberty.var.default.http.port=9090} and
+ * {@code liberty.var.default.https.port=9453}. The container run command logged
+ * by the plugin must contain {@code :9090} (not {@code :9080}) and must not contain
+ * the "Unable to retrieve locally mapped port" error message.
+ */
+public class DevcNonDefaultPortTest extends BaseDevTest {
+
+    private static final String PROJECT_ROOT = "../resources/container-nondefault-port-project";
+
+    /** The non-default HTTP port configured via {@code liberty.var.default.http.port}. */
+    private static final String EXPECTED_HTTP_PORT = "9090";
+
+    /** The non-default HTTPS port configured via {@code liberty.var.default.https.port}. */
+    private static final String EXPECTED_HTTPS_PORT = "9453";
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        setUpBeforeClass(null, PROJECT_ROOT, true, false, null, null);
+        startProcess("-Dcontainer -Dliberty.dev.podman=true -DcontainerBuildTimeout=599", true);
+    }
+
+    @AfterClass
+    public static void cleanUpAfterClass() throws Exception {
+        BaseDevTest.cleanUpAfterClass();
+    }
+
+    /**
+     * Verifies that the container run command logged by the plugin publishes the
+     * non-default HTTP port ({@code :9090}) and not the hardcoded default ({@code :9080}).
+     *
+     * <p>The log line looks like:
+     * {@code Container command: podman run --rm -p 54321:9090 -p 54322:9453 ...}
+     *
+     * <p>Before the fix the mapping was always {@code :9080} regardless of configuration.
+     */
+    @Test
+    public void containerRunCommandUsesConfiguredHttpPort() throws Exception {
+        assertTrue("Dev mode must have started before inspecting the container command: " + getLogTail(),
+                verifyLogMessageExists("Liberty is running in dev mode.", 120000));
+
+        assertTrue("Container run command must publish the configured HTTP port :"
+                        + EXPECTED_HTTP_PORT + " (not the hardcoded default :9080): " + getLogTail(),
+                verifyLogMessageExists(":" + EXPECTED_HTTP_PORT, 5000));
+
+        assertFalse("Container run command must NOT use the hardcoded default HTTP port :9080 "
+                        + "when a non-default port is configured: " + getLogTail(),
+                readFile("-p 9080:9080", logFile));
+    }
+
+    /**
+     * Verifies that the container run command publishes the non-default HTTPS port.
+     */
+    @Test
+    public void containerRunCommandUsesConfiguredHttpsPort() throws Exception {
+        assertTrue("Dev mode must have started before inspecting the container command: " + getLogTail(),
+                verifyLogMessageExists("Liberty is running in dev mode.", 120000));
+
+        assertTrue("Container run command must publish the configured HTTPS port :"
+                        + EXPECTED_HTTPS_PORT + " (not the hardcoded default :9443): " + getLogTail(),
+                verifyLogMessageExists(":" + EXPECTED_HTTPS_PORT, 5000));
+
+        assertFalse("Container run command must NOT use the hardcoded default HTTPS port :9443 "
+                        + "when a non-default port is configured: " + getLogTail(),
+                readFile("-p 9443:9443", logFile));
+    }
+
+    /**
+     * Verifies that the "Unable to retrieve locally mapped port" error no longer appears.
+     * This message was the user-visible symptom of the bug: the port was published on 9080
+     * but Liberty started on 9090, so the port query always failed.
+     */
+    @Test
+    public void noUnretrievablePortError() throws Exception {
+        assertTrue("Dev mode must have started before checking for port error: " + getLogTail(),
+                verifyLogMessageExists("Liberty is running in dev mode.", 120000));
+
+        assertFalse("'Unable to retrieve locally mapped port' must not appear when the "
+                        + "correct port is published: " + getLogTail(),
+                readFile("Unable to retrieve locally mapped port", logFile));
+    }
+}


### PR DESCRIPTION
- DevcNonDefaultPortTest: verifies that when liberty.var.* sets a non-default HTTP port (9090/9453), the container run command publishes those ports (-p 9090:9090) and 'Unable to retrieve locally mapped port' does not appear. The configDropins/overrides mount introduced in ci.common ensures Liberty inside the container reads liberty-plugin-variable-config.xml and starts on 9090.
- DevcEmptyLooseAppTest: verifies that libertyDevc does not throw NullPointerException when the loose-app XML placeholder is empty at startup. Dev mode must reach 'Liberty is running in dev mode.' with no NullPointerException in the log.

Tests for https://github.com/OpenLiberty/ci.common/pull/542


All dev container integration tests are successful in local

<img width="1041" height="544" alt="image" src="https://github.com/user-attachments/assets/0af1ae9c-dbaa-4c9b-a25b-ca1e9a438e6b" />
