### PR TITLE
Add DevcEmptyLooseAppTest IT for empty/malformed loose-app XML fix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -98,7 +98,8 @@ jobs:
       - name: Checkout ci.common
         uses: actions/checkout@v3
         with:
-          repository: OpenLiberty/ci.common
+          repository: venmanyarun/ci.common
+          ref: fix/devc-empty-looseapp-540
           path: ci.common
       - name: Checkout ci.ant
         uses: actions/checkout@v3
@@ -206,7 +207,7 @@ jobs:
       - name: Clone ci.ant and ci.common repos to github.workspace
         run: |
           echo ${{github.workspace}}
-          git clone https://github.com/OpenLiberty/ci.common.git ${{github.workspace}}/ci.common
+          git clone --branch fix/devc-empty-looseapp-540 --single-branch https://github.com/venmanyarun/ci.common.git ${{github.workspace}}/ci.common
           git clone https://github.com/OpenLiberty/ci.ant.git ${{github.workspace}}/ci.ant
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5

--- a/liberty-maven-plugin/src/it/dev-container-it/resources/container-empty-looseapp-project/Containerfile
+++ b/liberty-maven-plugin/src/it/dev-container-it/resources/container-empty-looseapp-project/Containerfile
@@ -1,0 +1,12 @@
+# Start with OL runtime.
+FROM icr.io/appcafe/open-liberty:full-java11-openj9-ubi
+
+ARG VERSION=1.0
+ARG REVISION=SNAPSHOT
+
+USER root
+
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config/
+COPY --chown=1001:0 target/*.war /config/apps/
+
+USER 1001

--- a/liberty-maven-plugin/src/it/dev-container-it/resources/container-empty-looseapp-project/pom.xml
+++ b/liberty-maven-plugin/src/it/dev-container-it/resources/container-empty-looseapp-project/pom.xml
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.tools.it</groupId>
+    <artifactId>container-empty-looseapp-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+
+    <!--
+        Test resource for: ci.common Issue - libertyDevc throws NullPointerException when
+        loose app XML file is empty or malformed.
+
+        The integration test (DevcEmptyLooseAppTest) pre-creates an empty placeholder file
+        at target/.libertyDevc/apps/rest.war.xml before starting liberty:dev with container flag,
+        then verifies that dev mode reaches "Liberty is running in dev mode." without printing
+        NullPointerException in the log.
+    -->
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>9.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>rest</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.2</version>
+            </plugin>
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>SUB_VERSION</version>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/liberty-maven-plugin/src/it/dev-container-it/resources/container-empty-looseapp-project/src/main/java/io/openliberty/guides/rest/SystemApplication.java
+++ b/liberty-maven-plugin/src/it/dev-container-it/resources/container-empty-looseapp-project/src/main/java/io/openliberty/guides/rest/SystemApplication.java
@@ -1,0 +1,8 @@
+package io.openliberty.guides.rest;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/api")
+public class SystemApplication extends Application {
+}

--- a/liberty-maven-plugin/src/it/dev-container-it/resources/container-empty-looseapp-project/src/main/liberty/config/server.xml
+++ b/liberty-maven-plugin/src/it/dev-container-it/resources/container-empty-looseapp-project/src/main/liberty/config/server.xml
@@ -1,0 +1,14 @@
+<server description="Empty loose-app XML test server">
+
+  <featureManager>
+      <feature>restfulWS-3.0</feature>
+  </featureManager>
+
+  <variable name="default.http.port" defaultValue="9080"/>
+  <variable name="default.https.port" defaultValue="9443"/>
+
+  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+      id="defaultHttpEndpoint" host="*" />
+
+  <webApplication location="rest.war" contextRoot="/"/>
+</server>

--- a/liberty-maven-plugin/src/it/dev-container-it/src/test/java/net/wasdev/wlp/test/it/DevcEmptyLooseAppTest.java
+++ b/liberty-maven-plugin/src/it/dev-container-it/src/test/java/net/wasdev/wlp/test/it/DevcEmptyLooseAppTest.java
@@ -1,0 +1,80 @@
+package net.wasdev.wlp.test.it;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Integration test for ci.common fix: {@code libertyDevc} must not throw
+ * {@code NullPointerException} when the loose application XML file is empty
+ * or malformed (e.g. written as an empty placeholder before the EAR build
+ * completes).
+ *
+ * <p>Before starting container dev mode the test pre-creates an empty
+ * {@code target/.libertyDevc/apps/rest.war.xml} file to simulate the race
+ * condition described in the issue. Dev mode must reach "Liberty is running
+ * in dev mode." and the log must contain no {@code NullPointerException}.
+ */
+public class DevcEmptyLooseAppTest extends BaseDevTest {
+
+    private static final String PROJECT_ROOT = "../resources/container-empty-looseapp-project";
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        setUpBeforeClass(null, PROJECT_ROOT, true, false, null, null);
+
+        // Pre-create an empty loose-app XML placeholder to simulate the race
+        // condition where the file exists but has not been written yet.
+        File looseAppDir = new File(PROJECT_ROOT + "/target/.libertyDevc/apps");
+        looseAppDir.mkdirs();
+        File emptyLooseApp = new File(looseAppDir, "rest.war.xml");
+        try (FileWriter fw = new FileWriter(emptyLooseApp)) {
+            // intentionally empty — zero bytes
+        }
+        assertTrue("Empty loose-app placeholder must exist before starting dev mode",
+                emptyLooseApp.exists());
+        assertTrue("Empty loose-app placeholder must be zero bytes",
+                emptyLooseApp.length() == 0);
+
+        startProcess("-Dcontainer -Dliberty.dev.podman=true -DcontainerBuildTimeout=599", true);
+    }
+
+    @AfterClass
+    public static void cleanUpAfterClass() throws Exception {
+        BaseDevTest.cleanUpAfterClass();
+    }
+
+    /**
+     * Verifies that dev mode starts successfully despite the empty loose-app XML.
+     * Before the fix, a {@code NullPointerException} terminated startup immediately.
+     */
+    @Test
+    public void devcStartsWithoutNpe() throws Exception {
+        assertTrue("Dev mode must start successfully (container image built): " + getLogTail(),
+                verifyLogMessageExists("Completed building container image.", 120000));
+        assertTrue("Liberty must start in dev mode despite the empty loose-app XML: " + getLogTail(),
+                verifyLogMessageExists("Liberty is running in dev mode.", 120000));
+    }
+
+    /**
+     * Verifies that no {@code NullPointerException} was emitted during startup.
+     * This is the primary regression guard for the NPE fix.
+     */
+    @Test
+    public void noNullPointerExceptionInLog() throws Exception {
+        // Give dev mode a moment to complete startup before inspecting logs.
+        assertTrue("Dev mode must have started before checking for NPE: " + getLogTail(),
+                verifyLogMessageExists("Liberty is running in dev mode.", 120000));
+
+        assertFalse("NullPointerException must not appear in the dev mode log: " + getLogTail(),
+                readFile("NullPointerException", logFile));
+    }
+
+}


### PR DESCRIPTION
Integration test that verifies libertyDevc does not throw NullPointerException when the loose-app XML placeholder is empty at startup (simulating the race condition in multi-module container dev mode where the file exists but has not been written yet).

ci.common fix: venmanyarun/ci.common#fix/devc-empty-looseapp-540
Fixes: https://github.com/OpenLiberty/ci.common/issues/540

container mode tests success in local
<img width="799" height="322" alt="image" src="https://github.com/user-attachments/assets/222c5e60-6635-4aa7-9b22-bfc39c3aab85" />
